### PR TITLE
Respond with 200 status code instead of 422

### DIFF
--- a/lib/re_web/integrations/pipedrive/plug.ex
+++ b/lib/re_web/integrations/pipedrive/plug.ex
@@ -30,7 +30,7 @@ defmodule ReWeb.Integrations.Pipedrive.Plug do
       {:error, :not_handled} ->
         conn
         |> put_resp_content_type("text/plain")
-        |> send_resp(422, "Webhook not handled")
+        |> send_resp(200, "Webhook not handled")
     end
   end
 

--- a/test/re_web/integrations/pipedrive/plug_test.exs
+++ b/test/re_web/integrations/pipedrive/plug_test.exs
@@ -31,7 +31,7 @@ defmodule ReWeb.Integrations.Pipedrive.PlugTest do
           previous: %{done: true}
         })
 
-      assert text_response(conn, 422) == "Webhook not handled"
+      assert text_response(conn, 200) == "Webhook not handled"
     end
 
     test "unauthenticated request", %{unauthenticated_conn: conn} do


### PR DESCRIPTION
Pipedrive is complaining about receiving frequent error responses which aren't exactly errors, so changing the code.