### PR TITLE
Monthly report

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -60,5 +60,5 @@ config :re, ReWeb.Search.Cluster,
 
 config :re, Re.Stats.Scheduler,
   jobs: [
-    {"@monthly", {Re.Stats.Reports, :monthly_stats, []}}
+    {"@monthly", {Re.Stats.Reports, :monthly_stats, [Timex.now()]}}
   ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -60,5 +60,5 @@ config :re, ReWeb.Search.Cluster,
 
 config :re, Re.Stats.Scheduler,
   jobs: [
-    {"@monthly", {Re.Stats.Reports, :monthly_stats, [Timex.now()]}}
+    {"@monthly", {Re.Stats.Reports, :monthly_stats, []}}
   ]

--- a/lib/re/interests/interests.ex
+++ b/lib/re/interests/interests.ex
@@ -24,7 +24,7 @@ defmodule Re.Interests do
   def preload(interest), do: Repo.preload(interest, :interest_type)
 
   def get_types do
-    Repo.all(from it in InterestType, where: it.enabled == true)
+    Repo.all(from(it in InterestType, where: it.enabled == true))
   end
 
   def request_contact(params, user) do

--- a/lib/re/stats/reports.ex
+++ b/lib/re/stats/reports.ex
@@ -1,5 +1,92 @@
 defmodule Re.Stats.Reports do
-  def monthly_stats do
-    :ok
+
+  import Ecto.Query
+
+  alias Re.{
+    Listing,
+    Repo,
+    User
+  }
+
+  alias ReWeb.Notifications.Emails
+
+  def monthly_stats(time) do
+    users_to_be_notified()
+    |> Enum.map(&generate_report(&1, time))
+    |> Enum.each(fn {user, listing} -> Emails.monthly_report(user, listing) end)
+  end
+
+  def users_to_be_notified do
+    User
+    |> preload([listings: ^where(Listing, [l], l.is_active == true)])
+    |> where([u], u.confirmed == true and u.role == "user")
+    |> Repo.all
+    |> Enum.filter(fn
+      %{listings: []} -> false
+      %{listings: nil} -> false
+      %{listings: _listings} -> true
+    end)
+    |> Enum.filter(fn %{notification_preferences: %{email: email}} -> email end)
+  end
+
+  def generate_report(user, time) do
+    listings = user
+      |> Map.get(:listings)
+      |> Enum.map(&get_listings_stats(&1, time))
+
+    {user, listings}
+  end
+
+  def get_listings_stats(listing, time) do
+    month = Timex.shift(time, months: -1)
+
+    listing
+    |> Repo.preload([
+      listings_visualisations: (from lv in Re.Stats.ListingVisualization, where: lv.inserted_at > ^month),
+      tour_visualisations: (from tv in Re.Stats.TourVisualization, where: tv.inserted_at > ^month),
+      in_person_visits: (from ipv in Re.Stats.InPersonVisit, where: ipv.inserted_at > ^month),
+      listings_favorites: (from f in Re.Favorite, where: f.inserted_at > ^month),
+      interests: (from i in Re.Interest, where: i.inserted_at > ^month)
+    ])
+    |> replace_with_count()
+  end
+
+  defp replace_with_count(listing) do
+    listing
+    |> count_listings_visualisations()
+    |> count_tour_visualisations()
+    |> count_in_person_visits()
+    |> count_listings_favorites()
+    |> count_interests()
+  end
+
+  defp count_listings_visualisations(%{listings_visualisations: listings_visualisations} = listing) do
+    listing
+    |> Map.put(:listings_visualisations_count, Enum.count(listings_visualisations))
+    |> Map.delete(:listings_visualisations)
+  end
+
+  defp count_tour_visualisations(%{tour_visualisations: tour_visualisations} = listing) do
+    listing
+    |> Map.put(:tour_visualisations_count, Enum.count(tour_visualisations))
+    |> Map.delete(:tour_visualisations)
+  end
+
+  defp count_in_person_visits(%{in_person_visits: in_person_visits} = listing) do
+    listing
+    |> Map.put(:in_person_visits_count, Enum.count(in_person_visits))
+    |> Map.delete(:in_person_visits)
+  end
+
+  defp count_listings_favorites(%{listings_favorites: listings_favorites} = listing) do
+    listing
+    |> Map.put(:listings_favorites_count, Enum.count(listings_favorites))
+    |> Map.delete(:listings_favorites)
+  end
+
+  defp count_interests(%{interests: interests} = listing) do
+    listing
+    |> Map.put(:interests_count, Enum.count(interests))
+    |> Map.delete(:interests)
   end
 end

--- a/lib/re/stats/reports.ex
+++ b/lib/re/stats/reports.ex
@@ -1,4 +1,7 @@
 defmodule Re.Stats.Reports do
+  @moduledoc """
+  Module for reporting listing stats to users
+  """
   import Ecto.Query
 
   alias Re.{

--- a/lib/re/stats/reports.ex
+++ b/lib/re/stats/reports.ex
@@ -20,6 +20,7 @@ defmodule Re.Stats.Reports do
     User
     |> preload([listings: ^where(Listing, [l], l.is_active == true)])
     |> where([u], u.confirmed == true and u.role == "user")
+    |> order_by([u], u.id)
     |> Repo.all
     |> Enum.filter(fn
       %{listings: []} -> false

--- a/lib/re/stats/reports.ex
+++ b/lib/re/stats/reports.ex
@@ -12,7 +12,9 @@ defmodule Re.Stats.Reports do
 
   alias ReWeb.Notifications.Emails
 
-  def monthly_stats(time) do
+  def monthly_stats() do
+    time = Timex.now()
+
     users_to_be_notified()
     |> Enum.map(&generate_report(&1, time))
     |> Enum.each(fn {user, listing} -> Emails.monthly_report(user, listing) end)

--- a/lib/re/stats/scheduler.ex
+++ b/lib/re/stats/scheduler.ex
@@ -1,3 +1,4 @@
 defmodule Re.Stats.Scheduler do
+  @moduledoc false
   use Quantum.Scheduler, otp_app: :re
 end

--- a/lib/re_web/notifications/emails/emails.ex
+++ b/lib/re_web/notifications/emails/emails.ex
@@ -11,6 +11,7 @@ defmodule ReWeb.Notifications.Emails do
 
   alias ReWeb.Notifications.{
     Emails.Server,
+    ReportEmail,
     UserEmail
   }
 
@@ -40,6 +41,9 @@ defmodule ReWeb.Notifications.Emails do
 
   def price_updated(new_price, listing),
     do: GenServer.cast(Server, {UserEmail, :price_updated, new_price, listing})
+
+  def monthly_report(user, listings),
+    do: GenServer.cast(Server, {ReportEmail, :monthly_report, [user, listings]})
 
   def inspect, do: GenServer.call(Server, :inspect)
 end

--- a/lib/re_web/notifications/emails/report_email.ex
+++ b/lib/re_web/notifications/emails/report_email.ex
@@ -1,0 +1,79 @@
+defmodule ReWeb.Notifications.ReportEmail do
+  @moduledoc """
+  Module for building report e-mails
+  """
+  import Swoosh.Email
+
+  alias Re.{
+    Interest,
+    Listing,
+    User
+  }
+
+  @frontend_url Application.get_env(:re, :frontend_url)
+  @contato_email "contato@emcasa.com"
+  @listing_path "/imoveis/"
+
+  def build_url(path, param) do
+    @frontend_url
+    |> URI.merge(path)
+    |> URI.merge(param)
+    |> URI.to_string()
+  end
+
+  def monthly_report(%User{name: name, email: email}, listings) do
+    {html, text} =
+      listings
+      |> Enum.map(&report_listing/1)
+      |> Enum.reduce({"", ""}, fn {html_fragment, text_fragment}, {html_acc, text_acc} -> {html_acc <> html_fragment, text_acc <> text_fragment} end)
+
+    html_body = """
+    Olá, #{name}.<br>
+    Estamos enviando esse e-mail com as estatísticas de acesso do seu imóvel desse mês:<br>
+    #{html}<br>
+    Cheque a página do imóvel para as visualizações totais<br>
+    Equipe EmCasa
+    """
+
+    text_body = """
+    Olá, #{name}.
+    Estamos enviando esse e-mail com as estatísticas de acesso do seu imóvel desse mês:
+    #{text}
+    Cheque a página do imóvel para as visualizações totais
+    Equipe EmCasa
+    """
+
+    new()
+    |> to(email)
+    |> from(@contato_email)
+    |> subject("Relatório mensal de acesso dos seus imóveis")
+    |> html_body(html_body)
+    |> text_body(text_body)
+  end
+
+  defp report_listing(listing) do
+    listing_url = build_url(@listing_path, to_string(listing.id))
+
+    html_fragment = """
+      <a href=\"#{listing_url}\">Seu imóvel</a><br>
+      Visualizações do imóvel esse mês: #{listing.listings_visualisations_count}<br>
+      Visualizações de Tour 3D esse mês: #{listing.tour_visualisations_count}<br>
+      Visitas físicas esse mês: #{listing.in_person_visits_count}<br>
+      Favoritado esse mês: #{listing.listings_favorites_count}<br>
+      Interesses esse mês: #{listing.interests_count}<br>
+      <br>
+    """
+
+    text_fragment = """
+    <a href=\"#{listing_url}\">Seu imóvel</a><br>
+    Visualizações do imóvel esse mês: #{listing.listings_visualisations_count}
+    Visualizações de Tour 3D esse mês: #{listing.tour_visualisations_count}
+    Visitas físicas esse mês: #{listing.in_person_visits_count}
+    Favoritado esse mês: #{listing.listings_favorites_count}
+    Interesses esse mês: #{listing.interests_count}
+
+    """
+
+    {html_fragment, text_fragment}
+  end
+end

--- a/lib/re_web/notifications/emails/report_email.ex
+++ b/lib/re_web/notifications/emails/report_email.ex
@@ -25,7 +25,9 @@ defmodule ReWeb.Notifications.ReportEmail do
     {html, text} =
       listings
       |> Enum.map(&report_listing/1)
-      |> Enum.reduce({"", ""}, fn {html_fragment, text_fragment}, {html_acc, text_acc} -> {html_acc <> html_fragment, text_acc <> text_fragment} end)
+      |> Enum.reduce({"", ""}, fn {html_fragment, text_fragment}, {html_acc, text_acc} ->
+        {html_acc <> html_fragment, text_acc <> text_fragment}
+      end)
 
     html_body = """
     Olá, #{name}.<br>

--- a/lib/re_web/notifications/emails/report_email.ex
+++ b/lib/re_web/notifications/emails/report_email.ex
@@ -5,8 +5,6 @@ defmodule ReWeb.Notifications.ReportEmail do
   import Swoosh.Email
 
   alias Re.{
-    Interest,
-    Listing,
     User
   }
 

--- a/test/re/images/images_test.exs
+++ b/test/re/images/images_test.exs
@@ -32,10 +32,11 @@ defmodule Re.ImagesTest do
 
   describe "check_same_listing/1" do
     test "should return error when images are from distinct listings" do
-      assert {:error, :distinct_listings} == Images.check_same_listing([
-        {:ok, %{listing_id: 1}, %{position: 1}},
-        {:ok, %{listing_id: 2}, %{position: 2}}
-      ])
+      assert {:error, :distinct_listings} ==
+               Images.check_same_listing([
+                 {:ok, %{listing_id: 1}, %{position: 1}},
+                 {:ok, %{listing_id: 2}, %{position: 2}}
+               ])
     end
   end
 
@@ -43,11 +44,12 @@ defmodule Re.ImagesTest do
     test "should error when input is invalid" do
       [image1, image2, image3] = insert_list(3, :image)
 
-      assert {:ok, [_, %Ecto.Changeset{}, _]} = Images.update_images([
-        {:ok, image1, %{position: 1, description: "waow1"}},
-        {:ok, image2, %{position: false, description: "waow2"}},
-        {:ok, image3, %{position: 3, description: "waow3"}}
-      ])
+      assert {:ok, [_, %Ecto.Changeset{}, _]} =
+               Images.update_images([
+                 {:ok, image1, %{position: 1, description: "waow1"}},
+                 {:ok, image2, %{position: false, description: "waow2"}},
+                 {:ok, image3, %{position: 3, description: "waow3"}}
+               ])
     end
   end
 end

--- a/test/re/stats/reports_test.exs
+++ b/test/re/stats/reports_test.exs
@@ -64,25 +64,45 @@ defmodule Re.Stats.ReportsTest do
     test "get only last month's stats" do
       now = Timex.now()
 
-      listing =
-        insert(
-          :listing,
-          listings_visualisations:
-            [build_list(5, :listing_visualisation)] ++
-              [build_list(5, :listing_visualisation, inserted_at: Timex.shift(now, months: -2))],
-          tour_visualisations:
-            [build_list(5, :tour_visualisation)] ++
-              [build_list(5, :tour_visualisation, inserted_at: Timex.shift(now, months: -2))],
-          in_person_visits:
-            [build_list(5, :in_person_visit)] ++
-              [build_list(5, :in_person_visit, inserted_at: Timex.shift(now, months: -2))],
-          listings_favorites:
-            [build_list(5, :listings_favorites)] ++
-              [build_list(5, :listings_favorites, inserted_at: Timex.shift(now, months: -2))],
-          interests:
-            [build_list(5, :interest)] ++
-              [build_list(5, :interest, inserted_at: Timex.shift(now, months: -2))]
-        )
+      listing = insert(:listing)
+      insert_list(5, :listing_visualisation, listing: listing)
+
+      insert_list(
+        5,
+        :listing_visualisation,
+        listing: listing,
+        inserted_at: Timex.shift(now, months: -2)
+      )
+
+      insert_list(5, :tour_visualisation, listing: listing)
+
+      insert_list(
+        5,
+        :tour_visualisation,
+        listing: listing,
+        inserted_at: Timex.shift(now, months: -2)
+      )
+
+      insert_list(5, :in_person_visit, listing: listing)
+
+      insert_list(
+        5,
+        :in_person_visit,
+        listing: listing,
+        inserted_at: Timex.shift(now, months: -2)
+      )
+
+      insert_list(5, :listings_favorites, listing: listing)
+
+      insert_list(
+        5,
+        :listings_favorites,
+        listing: listing,
+        inserted_at: Timex.shift(now, months: -2)
+      )
+
+      insert_list(5, :interest, listing: listing)
+      insert_list(5, :interest, listing: listing, inserted_at: Timex.shift(now, months: -2))
 
       assert %{
                listings_visualisations_count: 5,

--- a/test/re/stats/reports_test.exs
+++ b/test/re/stats/reports_test.exs
@@ -7,7 +7,7 @@ defmodule Re.Stats.ReportsTest do
 
   describe "users_to_be_notified/0" do
     test "get users with active listings only" do
-      %{id: id1}  = insert(:user, listings: [build(:listing)])
+      %{id: id1} = insert(:user, listings: [build(:listing)])
       insert(:user, listings: [build(:listing, is_active: false)])
       %{id: id3} = insert(:user, listings: [build(:listing, is_active: false), build(:listing)])
       insert(:user)
@@ -16,10 +16,31 @@ defmodule Re.Stats.ReportsTest do
     end
 
     test "get users with email notifications enabled only" do
-      %{id: id1} = insert(:user, notification_preferences: %{email: true, app: true}, listings: [build(:listing)])
-      insert(:user, notification_preferences: %{email: false, app: true}, listings: [build(:listing)])
-      %{id: id2} = insert(:user, notification_preferences: %{email: true, app: false}, listings: [build(:listing)])
-      insert(:user, notification_preferences: %{email: false, app: false}, listings: [build(:listing)])
+      %{id: id1} =
+        insert(
+          :user,
+          notification_preferences: %{email: true, app: true},
+          listings: [build(:listing)]
+        )
+
+      insert(
+        :user,
+        notification_preferences: %{email: false, app: true},
+        listings: [build(:listing)]
+      )
+
+      %{id: id2} =
+        insert(
+          :user,
+          notification_preferences: %{email: true, app: false},
+          listings: [build(:listing)]
+        )
+
+      insert(
+        :user,
+        notification_preferences: %{email: false, app: false},
+        listings: [build(:listing)]
+      )
 
       assert [%{id: ^id1}, %{id: ^id2}] = Reports.users_to_be_notified()
     end
@@ -43,21 +64,33 @@ defmodule Re.Stats.ReportsTest do
     test "get only last month's stats" do
       now = Timex.now()
 
-      listing = insert(:listing,
-        listings_visualisations: [build_list(5, :listing_visualisation)] ++ [build_list(5, :listing_visualisation, inserted_at: Timex.shift(now, months: -2))],
-        tour_visualisations: [build_list(5, :tour_visualisation)] ++ [build_list(5, :tour_visualisation, inserted_at: Timex.shift(now, months: -2))],
-        in_person_visits: [build_list(5, :in_person_visit)] ++ [build_list(5, :in_person_visit, inserted_at: Timex.shift(now, months: -2))],
-        listings_favorites: [build_list(5, :listings_favorites)] ++ [build_list(5, :listings_favorites, inserted_at: Timex.shift(now, months: -2))],
-        interests: [build_list(5, :interest)] ++ [build_list(5, :interest, inserted_at: Timex.shift(now, months: -2))]
-      )
+      listing =
+        insert(
+          :listing,
+          listings_visualisations:
+            [build_list(5, :listing_visualisation)] ++
+              [build_list(5, :listing_visualisation, inserted_at: Timex.shift(now, months: -2))],
+          tour_visualisations:
+            [build_list(5, :tour_visualisation)] ++
+              [build_list(5, :tour_visualisation, inserted_at: Timex.shift(now, months: -2))],
+          in_person_visits:
+            [build_list(5, :in_person_visit)] ++
+              [build_list(5, :in_person_visit, inserted_at: Timex.shift(now, months: -2))],
+          listings_favorites:
+            [build_list(5, :listings_favorites)] ++
+              [build_list(5, :listings_favorites, inserted_at: Timex.shift(now, months: -2))],
+          interests:
+            [build_list(5, :interest)] ++
+              [build_list(5, :interest, inserted_at: Timex.shift(now, months: -2))]
+        )
 
       assert %{
-        listings_visualisations_count: 5,
-        tour_visualisations_count: 5,
-        in_person_visits_count: 5,
-        listings_favorites_count: 5,
-        interests_count: 5
-      } = Reports.get_listings_stats(listing, now)
+               listings_visualisations_count: 5,
+               tour_visualisations_count: 5,
+               in_person_visits_count: 5,
+               listings_favorites_count: 5,
+               interests_count: 5
+             } = Reports.get_listings_stats(listing, now)
     end
   end
 end

--- a/test/re/stats/reports_test.exs
+++ b/test/re/stats/reports_test.exs
@@ -1,0 +1,63 @@
+defmodule Re.Stats.ReportsTest do
+  use Re.ModelCase
+
+  import Re.Factory
+
+  alias Re.Stats.Reports
+
+  describe "users_to_be_notified/0" do
+    test "get users with active listings only" do
+      %{id: id1}  = insert(:user, listings: [build(:listing)])
+      insert(:user, listings: [build(:listing, is_active: false)])
+      %{id: id3} = insert(:user, listings: [build(:listing, is_active: false), build(:listing)])
+      insert(:user)
+
+      assert [%{id: ^id1}, %{id: ^id3, listings: [_listing]}] = Reports.users_to_be_notified()
+    end
+
+    test "get users with email notifications enabled only" do
+      %{id: id1} = insert(:user, notification_preferences: %{email: true, app: true}, listings: [build(:listing)])
+      insert(:user, notification_preferences: %{email: false, app: true}, listings: [build(:listing)])
+      %{id: id2} = insert(:user, notification_preferences: %{email: true, app: false}, listings: [build(:listing)])
+      insert(:user, notification_preferences: %{email: false, app: false}, listings: [build(:listing)])
+
+      assert [%{id: ^id1}, %{id: ^id2}] = Reports.users_to_be_notified()
+    end
+
+    test "get users with confirmed email only" do
+      %{id: id} = insert(:user, listings: [build(:listing)])
+      insert(:user, listings: [build(:listing)], confirmed: false)
+
+      assert [%{id: ^id}] = Reports.users_to_be_notified()
+    end
+
+    test "do not get admins" do
+      %{id: id} = insert(:user, listings: [build(:listing)])
+      insert(:user, listings: [build(:listing)], role: "admin")
+
+      assert [%{id: ^id}] = Reports.users_to_be_notified()
+    end
+  end
+
+  describe "get_listings_stats/2" do
+    test "get only last month's stats" do
+      now = Timex.now()
+
+      listing = insert(:listing,
+        listings_visualisations: [build_list(5, :listing_visualisation)] ++ [build_list(5, :listing_visualisation, inserted_at: Timex.shift(now, months: -2))],
+        tour_visualisations: [build_list(5, :tour_visualisation)] ++ [build_list(5, :tour_visualisation, inserted_at: Timex.shift(now, months: -2))],
+        in_person_visits: [build_list(5, :in_person_visit)] ++ [build_list(5, :in_person_visit, inserted_at: Timex.shift(now, months: -2))],
+        listings_favorites: [build_list(5, :listings_favorites)] ++ [build_list(5, :listings_favorites, inserted_at: Timex.shift(now, months: -2))],
+        interests: [build_list(5, :interest)] ++ [build_list(5, :interest, inserted_at: Timex.shift(now, months: -2))]
+      )
+
+      assert %{
+        listings_visualisations_count: 5,
+        tour_visualisations_count: 5,
+        in_person_visits_count: 5,
+        listings_favorites_count: 5,
+        interests_count: 5
+      } = Reports.get_listings_stats(listing, now)
+    end
+  end
+end

--- a/test/re_web/notifications/emails/server_test.exs
+++ b/test/re_web/notifications/emails/server_test.exs
@@ -11,6 +11,7 @@ defmodule ReWeb.Notifications.Emails.ServerTest do
 
   alias ReWeb.Notifications.{
     Emails.Server,
+    ReportEmail,
     UserEmail
   }
 
@@ -108,6 +109,30 @@ defmodule ReWeb.Notifications.Emails.ServerTest do
       assert_email_sent(UserEmail.price_updated(user2, 1_000_000, listing))
       assert_email_not_sent(UserEmail.price_updated(user3, 1_000_000, listing))
       assert_email_not_sent(UserEmail.price_updated(user4, 1_000_000, listing))
+    end
+
+    test "monthly_report/2" do
+      user = insert(:user)
+      listing1 =
+        :listing
+        |> build(user: user)
+        |> Map.put(:listings_visualisations_count, 3)
+        |> Map.put(:tour_visualisations_count, 2)
+        |> Map.put(:in_person_visits_count, 4)
+        |> Map.put(:listings_favorites_count, 5)
+        |> Map.put(:interests_count, 8)
+
+      listing2 =
+        :listing
+        |> build(user: user)
+        |> Map.put(:listings_visualisations_count, 4)
+        |> Map.put(:tour_visualisations_count, 12)
+        |> Map.put(:in_person_visits_count, 4)
+        |> Map.put(:listings_favorites_count, 3)
+        |> Map.put(:interests_count, 0)
+
+      Server.handle_cast({ReportEmail, :monthly_report, [user, [listing1, listing2]]}, [])
+      assert_email_sent(ReportEmail.monthly_report(user, [listing1, listing2]))
     end
   end
 

--- a/test/re_web/notifications/emails/server_test.exs
+++ b/test/re_web/notifications/emails/server_test.exs
@@ -113,6 +113,7 @@ defmodule ReWeb.Notifications.Emails.ServerTest do
 
     test "monthly_report/2" do
       user = insert(:user)
+
       listing1 =
         :listing
         |> build(user: user)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,7 +16,11 @@ defmodule Re.Factory do
       password_hash: Bcrypt.hashpwsalt("password"),
       role: "user",
       confirmation_token: "97971cce-eb6e-418a-8529-e717ca1dcf62",
-      confirmed: true
+      confirmed: true,
+      notification_preferences: %{
+        email: true,
+        app: true
+      }
     }
   end
 


### PR DESCRIPTION
- Generate monthly report for users, only for users with:
  - confirmed e-mail
  - active listings
  - not admin
  - e-mail notifications enabled