### PR TITLE
Add score schema

### DIFF
--- a/apps/re/lib/listings/history/status.ex
+++ b/apps/re/lib/listings/history/status.ex
@@ -2,8 +2,6 @@ defmodule Re.Listings.History.Status do
   @moduledoc """
   Context for handling listing's status history
   """
-  import Ecto.Query
-
   alias Re.{
     Listings.StatusHistory,
     Repo

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -69,6 +69,13 @@ defmodule ReWeb.Resolvers.Listings do
   def is_active(%{status: "active"}, _, _), do: {:ok, true}
   def is_active(_, _, _), do: {:ok, false}
 
+  def score(%{score: score}, _, %{context: %{current_user: current_user}}) do
+    case Bodyguard.permit(Listings, :show_score, current_user, %{}) do
+      :ok -> {:ok, score}
+      _ -> {:ok, nil}
+    end
+  end
+
   def activate(%{id: id}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Listings, :activate_listing, current_user, %{}),
          {:ok, listing} <- Listings.get_preloaded(id),

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -98,6 +98,7 @@ defmodule ReWeb.Types.Listing do
     field :matterport_code, :string
     field :is_exclusive, :boolean
     field :is_release, :boolean
+    field :score, :integer
 
     field :phone, :string
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -35,6 +35,7 @@ defmodule ReWeb.Types.Listing do
     field :is_exclusive, :boolean
     field :is_release, :boolean
     field :inserted_at, :naive_datetime
+    field :score, :integer, resolve: &Resolvers.Listings.score/3
 
     field :address, :address,
       resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_listing/3)

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -8,6 +8,8 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
     Listing.MutationHelpers
   }
 
+  alias Re.Listing
+
   setup %{conn: conn} do
     conn = put_req_header(conn, "accept", "application/json")
     admin_user = insert(:user, email: "admin@email.com", role: "admin")
@@ -67,6 +69,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["matterportCode"] == listing.matterport_code
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
+      assert inserted_listing["score"] == listing.score
 
       refute inserted_listing["isActive"]
 
@@ -120,6 +123,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["matterportCode"] == nil
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
+      assert inserted_listing["score"] == nil
 
       refute inserted_listing["isActive"]
 
@@ -344,6 +348,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["matterportCode"] == new_listing.matterport_code
       assert updated_listing["isExclusive"] == new_listing.is_exclusive
       assert updated_listing["isRelease"] == new_listing.is_release
+      assert updated_listing["score"] == new_listing.score
 
       assert inserted_address["city"] == new_address.city
       assert inserted_address["state"] == new_address.state
@@ -392,6 +397,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["isExclusive"] == new_listing.is_exclusive
       assert updated_listing["isRelease"] == new_listing.is_release
 
+      refute updated_listing["score"]
       refute updated_listing["isActive"]
 
       assert inserted_address["city"] == new_address.city
@@ -402,6 +408,8 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_address["street"] == new_address.street
       assert inserted_address["streetNumber"] == new_address.street_number
       assert inserted_address["postalCode"] == new_address.postal_code
+
+      assert Repo.get(Listing, old_listing.id).score == old_listing.score
     end
 
     test "user should not update listing", %{user_conn: conn, address: address, listing: listing} do

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -31,7 +31,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           build(:image, filename: "test3.jpg", position: 1)
         ],
         user: user,
-        zap_highlight: true
+        zap_highlight: true,
+        score: 4
       )
 
       insert(:image, filename: "not_in_listing_image.jpg")
@@ -68,6 +69,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                 name
               }
               zapHighlight
+              score
             }
             remaining_count
           }
@@ -84,7 +86,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                    "twoImages" => [%{"filename" => "test3.jpg"}, %{"filename" => "test2.jpg"}],
                    "inactiveImages" => [%{"filename" => "test2.jpg"}],
                    "owner" => %{"name" => user.name},
-                   "zapHighlight" => true
+                   "zapHighlight" => true,
+                   "score" => 4
                  }
                ],
                "remaining_count" => 0
@@ -100,7 +103,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           build(:image, filename: "test2.jpg", is_active: false)
         ],
         user: user,
-        vivareal_highlight: true
+        vivareal_highlight: true,
+        score: 4
       )
 
       insert(:image, filename: "not_in_listing_image.jpg")
@@ -127,6 +131,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                 name
               }
               vivarealHighlight
+              score
             }
             remaining_count
           }
@@ -142,7 +147,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                    "activeImages" => [%{"filename" => "test.jpg"}],
                    "inactiveImages" => [%{"filename" => "test2.jpg"}],
                    "owner" => %{"name" => user.name},
-                   "vivarealHighlight" => nil
+                   "vivarealHighlight" => nil,
+                   "score" => nil
                  }
                ],
                "remaining_count" => 0
@@ -160,7 +166,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           build(:image, filename: "test2.jpg", is_active: false)
         ],
         user: user,
-        zap_super_highlight: true
+        zap_super_highlight: true,
+        score: 4
       )
 
       insert(:image, filename: "not_in_listing_image.jpg")
@@ -187,6 +194,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                 name
               }
               zapSuperHighlight
+              score
             }
             remaining_count
           }
@@ -202,7 +210,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                    "activeImages" => [%{"filename" => "test.jpg"}],
                    "inactiveImages" => [%{"filename" => "test.jpg"}],
                    "owner" => nil,
-                   "zapSuperHighlight" => nil
+                   "zapSuperHighlight" => nil,
+                   "score" => nil
                  }
                ],
                "remaining_count" => 0
@@ -220,7 +229,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           build(:image, filename: "test2.jpg", is_active: false)
         ],
         user: user,
-        zap_highlight: true
+        zap_highlight: true,
+        score: 4
       )
 
       insert(:image, filename: "not_in_listing_image.jpg")
@@ -247,6 +257,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                 name
               }
               zapHighlight
+              score
             }
             remaining_count
           }
@@ -262,7 +273,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                    "activeImages" => [%{"filename" => "test.jpg"}],
                    "inactiveImages" => [%{"filename" => "test.jpg"}],
                    "owner" => nil,
-                   "zapHighlight" => nil
+                   "zapHighlight" => nil,
+                   "score" => nil
                  }
                ],
                "remaining_count" => 0

--- a/apps/re_web/test/support/mutation_helpers.ex
+++ b/apps/re_web/test/support/mutation_helpers.ex
@@ -35,7 +35,8 @@ defmodule ReWeb.Listing.MutationHelpers do
         "hasElevator" => listing.has_elevator,
         "matterportCode" => listing.matterport_code,
         "isExclusive" => listing.is_exclusive,
-        "isRelease" => listing.is_release
+        "isRelease" => listing.is_release,
+        "score" => listing.score
       }
     }
   end
@@ -73,7 +74,8 @@ defmodule ReWeb.Listing.MutationHelpers do
         "hasElevator" => listing.has_elevator,
         "matterportCode" => listing.matterport_code,
         "isExclusive" => listing.is_exclusive,
-        "isRelease" => listing.is_release
+        "isRelease" => listing.is_release,
+        "score" => listing.score
       }
     }
   end
@@ -117,6 +119,7 @@ defmodule ReWeb.Listing.MutationHelpers do
           isActive
           isExclusive
           isRelease
+          score
         }
       }
     """
@@ -161,6 +164,7 @@ defmodule ReWeb.Listing.MutationHelpers do
           isActive
           isExclusive
           isRelease
+          score
         }
       }
     """


### PR DESCRIPTION
- Add score attribute to listing query
  - Returns score only if it's an admin user
  - Returns `null` if it's not an admin
- Add score attribute to listing input
  - Insert/update works only with admin
  - It ignores if user is not an admin