### PR TITLE
Deactivate images

### DIFF
--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -77,6 +77,12 @@ defmodule Re.Images do
     end
   end
 
+  def list_by_ids(ids) do
+    ids
+    |> Queries.with_ids()
+    |> Repo.all()
+  end
+
   defp do_get(input) do
     case Repo.get(Image, input.id) do
       nil -> {:error, :not_found, input}
@@ -91,6 +97,13 @@ defmodule Re.Images do
     end
   end
 
+  def is_same_listing(images) do
+    case Enum.uniq_by(images, fn %{listing_id: id} -> id end) do
+      [%{listing_id: listing_id}] -> Listings.get(listing_id)
+      _ -> {:error, :distinct_listings}
+    end
+  end
+
   def update_images(images_and_inputs), do: {:ok, Enum.map(images_and_inputs, &do_update_image/1)}
 
   defp do_update_image({:ok, image, input}) do
@@ -100,6 +113,18 @@ defmodule Re.Images do
     |> case do
       {:ok, image} -> image
       {:error, error} -> error
+    end
+  end
+
+  def deactivate_images(images) do
+    ids = Enum.map(images, fn %{id: id} -> id end)
+
+    Image
+    |> Queries.with_ids(ids)
+    |> Repo.update_all(set: [is_active: false])
+    |> case do
+      {_, nil} -> {:ok, images}
+      error -> error
     end
   end
 

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -97,7 +97,7 @@ defmodule Re.Images do
     end
   end
 
-  def is_same_listing(images) do
+  def fetch_listing(images) do
     case Enum.uniq_by(images, fn %{listing_id: id} -> id end) do
       [%{listing_id: listing_id}] -> Listings.get(listing_id)
       _ -> {:error, :distinct_listings}

--- a/apps/re/lib/images/policy.ex
+++ b/apps/re/lib/images/policy.ex
@@ -13,6 +13,7 @@ defmodule Re.Images.Policy do
   def authorize(:index_images, %User{id: id, role: "user"}, %Listing{user_id: id}), do: :ok
   def authorize(:create_images, %User{id: id, role: "user"}, %Listing{user_id: id}), do: :ok
   def authorize(:update_images, %User{id: id, role: "user"}, %Listing{user_id: id}), do: :ok
+  def authorize(:deactivate_images, %User{id: id, role: "user"}, %Listing{user_id: id}), do: :ok
   def authorize(:delete_images, %User{id: id, role: "user"}, %Listing{user_id: id}), do: :ok
 
   def authorize(_, _, _), do: {:error, :forbidden}

--- a/apps/re/lib/images/queries.ex
+++ b/apps/re/lib/images/queries.ex
@@ -26,4 +26,8 @@ defmodule Re.Images.Queries do
     |> listing_preload()
     |> limit(1)
   end
+
+  def with_ids(query \\ Image, ids)
+
+  def with_ids(query, ids), do: (from i in query, where: i.id in ^ids)
 end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -49,7 +49,7 @@ defmodule ReWeb.Resolvers.Images do
 
   def deactivate_images(%{input: %{image_ids: image_ids}}, %{context: %{current_user: current_user}}) do
     with images <- Images.list_by_ids(image_ids),
-         {:ok, listing} <- Images.is_same_listing(images),
+         {:ok, listing} <- Images.fetch_listing(images),
          :ok <- Bodyguard.permit(Images, :deactivate_images, current_user, listing),
          do: Images.deactivate_images(images)
   end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -47,6 +47,13 @@ defmodule ReWeb.Resolvers.Images do
          do: Images.update_images(images_and_inputs)
   end
 
+  def deactivate_images(%{input: %{image_ids: image_ids}}, %{context: %{current_user: current_user}}) do
+    with images <- Images.list_by_ids(image_ids),
+         {:ok, listing} <- Images.is_same_listing(images),
+         :ok <- Bodyguard.permit(Images, :deactivate_images, current_user, listing),
+         do: Images.deactivate_images(images)
+  end
+
   defp is_admin(%{user_id: user_id}, %{id: user_id}), do: true
   defp is_admin(_, %{role: "admin"}), do: true
   defp is_admin(_, _), do: false

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -5,6 +5,7 @@ defmodule ReWeb.Schema do
   use Absinthe.Schema
 
   import_types ReWeb.Types.Listing
+  import_types ReWeb.Types.Image
   import_types ReWeb.Types.User
   import_types ReWeb.Types.Interest
   import_types ReWeb.Types.Dashboard
@@ -32,6 +33,7 @@ defmodule ReWeb.Schema do
 
   mutation do
     import_fields(:listing_mutations)
+    import_fields(:image_mutations)
     import_fields(:user_mutations)
     import_fields(:interest_mutations)
     import_fields(:dashboard_mutations)

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -43,6 +43,7 @@ defmodule ReWeb.Schema do
   subscription do
     import_fields(:interest_subscriptions)
     import_fields(:listing_subscriptions)
+    import_fields(:image_subscriptions)
     import_fields(:calendar_subscriptions)
     import_fields(:dashboard_subscriptions)
   end

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -1,0 +1,45 @@
+defmodule ReWeb.Types.Image do
+  @moduledoc """
+  GraphQL types for images
+  """
+  use Absinthe.Schema.Notation
+
+  alias ReWeb.Resolvers
+
+  object :image do
+    field :id, :id
+    field :filename, :string
+    field :position, :integer
+    field :is_active, :boolean
+    field :description, :string
+  end
+
+  input_object :image_insert_input do
+    field :listing_id, non_null(:id)
+    field :filename, non_null(:string)
+    field :is_active, :boolean
+    field :description, :string
+  end
+
+  input_object :image_update_input do
+    field :id, non_null(:id)
+    field :position, :integer
+    field :description, :string
+  end
+
+  object :image_mutations do
+    @desc "Inser image"
+    field :insert_image, type: :image do
+      arg :input, non_null(:image_insert_input)
+
+      resolve &Resolvers.Images.insert_image/2
+    end
+
+    @desc "Update images"
+    field :update_images, type: list_of(:image) do
+      arg :input, non_null(list_of(non_null(:image_update_input)))
+
+      resolve &Resolvers.Images.update_images/2
+    end
+  end
+end

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -53,4 +53,20 @@ defmodule ReWeb.Types.Image do
       resolve &Resolvers.Images.deactivate_images/2
     end
   end
+
+  object :image_subscriptions do
+    @desc "Subscribe to image deactivation"
+    field :images_deactivated, list_of(:image) do
+      config(fn _args, %{context: %{current_user: current_user}} ->
+        case current_user do
+          %{role: "admin"} -> {:ok, topic: "images_deactivated"}
+          %{} -> {:error, :unauthorized}
+          _ -> {:error, :unauthenticated}
+        end
+      end)
+
+      trigger :deactivate_images,
+        topic: fn _ -> "images_deactivated" end
+    end
+  end
 end

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -27,6 +27,10 @@ defmodule ReWeb.Types.Image do
     field :description, :string
   end
 
+  input_object :image_deactivate_input do
+    field :image_ids, non_null(list_of(non_null(:id)))
+  end
+
   object :image_mutations do
     @desc "Inser image"
     field :insert_image, type: :image do
@@ -40,6 +44,13 @@ defmodule ReWeb.Types.Image do
       arg :input, non_null(list_of(non_null(:image_update_input)))
 
       resolve &Resolvers.Images.update_images/2
+    end
+
+    @desc "Deactivate images"
+    field :deactivate_images, type: list_of(:image) do
+      arg :input, non_null(:image_deactivate_input)
+
+      resolve &Resolvers.Images.deactivate_images/2
     end
   end
 end

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -47,7 +47,7 @@ defmodule ReWeb.Types.Image do
     end
 
     @desc "Deactivate images"
-    field :deactivate_images, type: list_of(:image) do
+    field :images_deactivate, type: list_of(:image) do
       arg :input, non_null(:image_deactivate_input)
 
       resolve &Resolvers.Images.deactivate_images/2
@@ -65,7 +65,7 @@ defmodule ReWeb.Types.Image do
         end
       end)
 
-      trigger :deactivate_images,
+      trigger :images_deactivate,
         topic: fn _ -> "images_deactivated" end
     end
   end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -151,27 +151,6 @@ defmodule ReWeb.Types.Listing do
     field :lng, non_null(:float)
   end
 
-  object :image do
-    field :id, :id
-    field :filename, :string
-    field :position, :integer
-    field :is_active, :boolean
-    field :description, :string
-  end
-
-  input_object :image_insert_input do
-    field :listing_id, non_null(:id)
-    field :filename, non_null(:string)
-    field :is_active, :boolean
-    field :description, :string
-  end
-
-  input_object :image_update_input do
-    field :id, non_null(:id)
-    field :position, :integer
-    field :description, :string
-  end
-
   object :listing_user do
     field :listing, :listing
     field :user, :user
@@ -367,20 +346,6 @@ defmodule ReWeb.Types.Listing do
       arg :id, non_null(:id)
 
       resolve &Resolvers.ListingStats.tour_visualized/2
-    end
-
-    @desc "Inser image"
-    field :insert_image, type: :image do
-      arg :input, non_null(:image_insert_input)
-
-      resolve &Resolvers.Images.insert_image/2
-    end
-
-    @desc "Update images"
-    field :update_images, type: list_of(:image) do
-      arg :input, non_null(list_of(non_null(:image_update_input)))
-
-      resolve &Resolvers.Images.update_images/2
     end
   end
 

--- a/apps/re_web/test/graphql/images/mutation_test.exs
+++ b/apps/re_web/test/graphql/images/mutation_test.exs
@@ -367,4 +367,99 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
       assert [%{"message" => "Unauthorized", "code" => 401}] = json_response(conn, 200)["errors"]
     end
   end
+
+  describe "deactivate" do
+    test "admin should deactivate image", %{admin_conn: conn} do
+      %{id: listing_id} = insert(:listing)
+
+      [%{id: id1}, %{id: id2}, %{id: id3}] =
+        insert_list(
+          3,
+          :image,
+          listing_id: listing_id,
+          position: 5,
+          description: "wah",
+          filename: "test.jpg"
+        )
+
+      variables = %{
+        "input" => %{
+          "image_ids" => [id1, id2, id3]
+        }
+      }
+
+      mutation = """
+        mutation DeactivateImages ($input: ImageDeactivateInput!) {
+          deactivateImages(input: $input) {
+            id
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert [
+               %{"id" => to_string(id1)},
+               %{"id" => to_string(id2)},
+               %{"id" => to_string(id3)}
+             ] == json_response(conn, 200)["data"]["deactivateImages"]
+
+      refute Repo.get(Re.Image, id1).is_active
+      refute Repo.get(Re.Image, id2).is_active
+      refute Repo.get(Re.Image, id3).is_active
+    end
+
+    test "admin should not deactivate images from different listings", %{admin_conn: conn} do
+      %{id: listing_id1} = insert(:listing)
+
+      [%{id: id1}, %{id: id2}, %{id: id3}] =
+        insert_list(
+          3,
+          :image,
+          listing_id: listing_id1,
+          position: 5,
+          description: "wah",
+          filename: "test.jpg",
+          is_active: true
+        )
+
+      %{id: listing_id2} = insert(:listing)
+
+      [%{id: id4}, %{id: id5}, %{id: id6}] =
+        insert_list(
+          3,
+          :image,
+          listing_id: listing_id2,
+          position: 5,
+          description: "wah",
+          filename: "test.jpg",
+          is_active: true
+        )
+
+      variables = %{
+        "input" => %{
+          "image_ids" => [id1, id2, id3, id4, id5, id6]
+        }
+      }
+
+      mutation = """
+        mutation DeactivateImages ($input: ImageDeactivateInput!) {
+          deactivateImages(input: $input) {
+            id
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert [%{"message" => "distinct_listings"}] = json_response(conn, 200)["errors"]
+
+      assert Repo.get(Re.Image, id1).is_active
+      assert Repo.get(Re.Image, id2).is_active
+      assert Repo.get(Re.Image, id3).is_active
+      assert Repo.get(Re.Image, id4).is_active
+      assert Repo.get(Re.Image, id5).is_active
+      assert Repo.get(Re.Image, id6).is_active
+    end
+  end
 end

--- a/apps/re_web/test/graphql/images/mutation_test.exs
+++ b/apps/re_web/test/graphql/images/mutation_test.exs
@@ -389,8 +389,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
       }
 
       mutation = """
-        mutation DeactivateImages ($input: ImageDeactivateInput!) {
-          deactivateImages(input: $input) {
+        mutation ImagesDeactivate ($input: ImageDeactivateInput!) {
+          imagesDeactivate(input: $input) {
             id
           }
         }
@@ -402,7 +402,7 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
                %{"id" => to_string(id1)},
                %{"id" => to_string(id2)},
                %{"id" => to_string(id3)}
-             ] == json_response(conn, 200)["data"]["deactivateImages"]
+             ] == json_response(conn, 200)["data"]["imagesDeactivate"]
 
       refute Repo.get(Re.Image, id1).is_active
       refute Repo.get(Re.Image, id2).is_active
@@ -443,8 +443,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
       }
 
       mutation = """
-        mutation DeactivateImages ($input: ImageDeactivateInput!) {
-          deactivateImages(input: $input) {
+        mutation ImagesDeactivate ($input: ImageDeactivateInput!) {
+          imagesDeactivate(input: $input) {
             id
           }
         }

--- a/apps/re_web/test/graphql/images/subscription_test.exs
+++ b/apps/re_web/test/graphql/images/subscription_test.exs
@@ -8,7 +8,7 @@ defmodule ReWeb.GraphQL.Images.SubscriptionTest do
          id
        }
      }
-     """, "imagesDeactivated", "deactivateImages"}
+     """, "imagesDeactivated", "imagesDeactivate"}
   ]
 
   import Re.Factory

--- a/apps/re_web/test/graphql/images/subscription_test.exs
+++ b/apps/re_web/test/graphql/images/subscription_test.exs
@@ -1,0 +1,96 @@
+defmodule ReWeb.GraphQL.Images.SubscriptionTest do
+  use ReWeb.SubscriptionCase
+
+  @subscriptions [
+    {"""
+     subscription {
+       imagesDeactivated {
+         id
+       }
+     }
+     """, "imagesDeactivated", "deactivateImages"}
+  ]
+
+  import Re.Factory
+
+  Enum.each(@subscriptions, fn {subscription, subscription_name, mutation} ->
+    @subscription subscription
+    @subscription_name subscription_name
+    @mutation mutation
+
+    test "admin should subscribe to #{@mutation}", %{
+      admin_socket: admin_socket
+    } do
+      ref = push_doc(admin_socket, @subscription)
+      %{id: listing_id} = insert(:listing)
+
+      [%{id: id1}, %{id: id2}, %{id: id3}] =
+        insert_list(
+          3,
+          :image,
+          listing_id: listing_id,
+          position: 5,
+          description: "wah",
+          filename: "test.jpg",
+          is_active: true
+        )
+
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      mutation = """
+        mutation {
+          #{@mutation}(input: {
+            imageIds: [#{id1},#{id2},#{id3}]
+          }) {
+            id
+          }
+        }
+      """
+
+      ref = push_doc(admin_socket, mutation)
+
+      assert_reply(
+        ref,
+        :ok,
+        %{data: %{@mutation => [
+          %{"id" => id1},
+          %{"id" => id2},
+          %{"id" => id3},
+          ]}},
+        3000
+      )
+
+      expected = %{
+        result: %{
+          data: %{
+            @subscription_name => [
+              %{"id" => id1},
+              %{"id" => id2},
+              %{"id" => id3}
+            ]
+          }
+        },
+        subscriptionId: subscription_id
+      }
+
+      assert_push("subscription:data", push)
+      assert expected == push
+    end
+
+    test "user should not subscribe to #{@mutation}", %{
+      user_socket: user_socket
+    } do
+      ref = push_doc(user_socket, @subscription)
+
+      assert_reply(ref, :error, %{errors: [%{message: :unauthorized}]})
+    end
+
+    test "anonymous should not subscribe to #{@mutation}", %{
+      unauthenticated_socket: unauthenticated_socket
+    } do
+      ref = push_doc(unauthenticated_socket, @subscription)
+
+      assert_reply(ref, :error, %{errors: [%{message: :unauthenticated}]})
+    end
+  end)
+end


### PR DESCRIPTION
- `imageDeactivate` mutation
  - Receives a list of images, checks for `listing_id` in common
  - Returns the list of images deactivated
  - Admin and user that owns the listing
- `imageDeactivated` subscription
  - Receives a list of images that were deactivated
  - Admin-only subscription (at least for now)