### PR TITLE
Reverse calendar options order

### DIFF
--- a/apps/re/lib/calendars/calendars.ex
+++ b/apps/re/lib/calendars/calendars.ex
@@ -50,7 +50,7 @@ defmodule Re.Calendars do
       |> Timex.shift(weeks: 1)
       |> beginning_of_week()
 
-    Enum.reduce(0..(number_of_options - 1), [], &generate_time(&1, &2, beginning_of_week))
+    Enum.reduce((number_of_options - 1)..0, [], &generate_time(&1, &2, beginning_of_week))
   end
 
   defp generate_time(offset, acc, beginning_of_week) do

--- a/apps/re/test/calendars/calendars_test.exs
+++ b/apps/re/test/calendars/calendars_test.exs
@@ -38,7 +38,7 @@ defmodule Re.CalendarsTest do
                ~N[2018-09-26 17:00:00],
                ~N[2018-09-27 09:00:00],
                ~N[2018-09-27 17:00:00]
-             ] == now |> Calendars.generate_tour_options(4) |> Enum.sort()
+             ] == Calendars.generate_tour_options(now, 4)
     end
   end
 end


### PR DESCRIPTION
- Send it in ascending chronological order
- Do not sort when testing to catch sorting problems