### PR TITLE
Drop highlights in the right way

### DIFF
--- a/apps/re/priv/repo/migrations/20190122191803_remove_zap_highlights_and_zap_super_highlights.exs
+++ b/apps/re/priv/repo/migrations/20190122191803_remove_zap_highlights_and_zap_super_highlights.exs
@@ -2,9 +2,37 @@ defmodule Re.Repo.Migrations.RemoveZapHighlightsAndZapSuperHighlights do
   use Ecto.Migration
 
   def change do
-    alter table(:listings) do
-      remove :zap_highlight
-      remove :zap_super_highlight
+    drop_if_exists unique_index(:zap_highlights, [:listing_id])
+    drop_if_exists table(:zap_highlights)
+
+    drop_if_exists unique_index(:zap_super_highlights, [:listing_id])
+    drop_if_exists table(:zap_super_highlights)
+
+    remove_column_if_exists(:listings, :zap_highlight)
+    remove_column_if_exists(:listings, :zap_super_highlight)
+  end
+
+  defp remove_column_if_exists(table, column) do
+    case column_exists?(table, column) do
+      true ->
+        alter table(table) do
+          remove column
+        end
+      _ -> nil
     end
+  end
+
+  defp column_exists?(table, column) do
+    table = Atom.to_string(table)
+    column = Atom.to_string(column)
+
+    {:ok, result} = Ecto.Adapters.SQL.query(Re.Repo,
+      "SELECT column_name " <>
+      "FROM information_schema.columns " <>
+      "WHERE table_name=$1 and column_name=$2",
+      [table, column]
+    )
+
+    Map.get(result, :num_rows) == 1
   end
 end


### PR DESCRIPTION
A kinky problem removing Zap's structure: 

All started when I [changed the migration dependent of `ZapHighlight`/`ZapSuperHighlight`](https://github.com/emcasa/backend/pull/383/files#diff-85038d292963e8fbba866d29260d38ffL23), the build pass, but the deploy for the commit `fd7979db` failed :x: . So I saw we [already removed the table](https://github.com/emcasa/backend/pull/383/files#diff-85038d292963e8fbba866d29260d38ffL47) and  I "fixed it", [edited the failing migration to remove the right field](https://github.com/emcasa/backend/commit/05f767326dfb23371ca4e22e55ba266af1d615bc) (I didn't see the problem coming :man_shrugging: ). After this, the build failed, because the field was not created yet (on CI only).

So we have the following problem: On CI we should remove the original structure (zap tables and indexes) while on staging/production we should remove only the field `zap_highlight` in `listings` table, it should be simple. But `Ecto` give us a `drop_if_exists` for tables and indexes but doesn't do the same for columns, neither give us a way to check if a column exists (maybe it's a good opportunity to implement it directly on Ecto). So I implement the `check_if_column_exists?/2` using [`Ecto...query`](https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.html#query/4-examples) to check if the columns exist before deleting them. 

Already successfully deployed in staging, everything looks running smoothly. 

 