### PR TITLE
Fix interest email

### DIFF
--- a/apps/re/lib/interests/interest.ex
+++ b/apps/re/lib/interests/interest.ex
@@ -28,5 +28,6 @@ defmodule Re.Interest do
     struct
     |> cast(params, @required ++ @optional)
     |> validate_required(@required)
+    |> foreign_key_constraint(:listing_id, [name: :interests_listing_id_fkey, message: "does not exist."])
   end
 end

--- a/apps/re/lib/interests/interests.ex
+++ b/apps/re/lib/interests/interests.ex
@@ -28,14 +28,6 @@ defmodule Re.Interests do
     |> PubSub.publish_new("new_interest")
   end
 
-  def show_interest(listing_id, params) do
-    params = Map.put(params, "listing_id", listing_id)
-
-    %Interest{}
-    |> Interest.changeset(params)
-    |> Repo.insert()
-  end
-
   def preload(interest), do: Repo.preload(interest, :interest_type)
 
   def get_types do

--- a/apps/re/test/interests/interests_test.exs
+++ b/apps/re/test/interests/interests_test.exs
@@ -3,6 +3,7 @@ defmodule Re.InterestsTest do
 
   alias Re.{
     PriceSuggestions.Request,
+    Interest,
     Interests,
     Repo
   }
@@ -164,6 +165,26 @@ defmodule Re.InterestsTest do
                city: {"can't be blank", [validation: :required]},
                neighborhood: {"can't be blank", [validation: :required]}
              ] == changeset.errors
+    end
+  end
+
+  describe "show_interest/1" do
+    test "should create interest in listing" do
+      Re.PubSub.subscribe("new_interest")
+      listing = insert(:listing)
+
+      {:ok, interest} = Interests.show_interest(%{name: "naem", phone: "123", interest_type: 2, listing_id: listing.id})
+
+      assert Repo.get(Interest, interest.id)
+      assert_receive %{new: _, topic: "new_interest", type: :new}
+    end
+
+    test "should not create interest in invalid listing" do
+      Re.PubSub.subscribe("new_interest")
+
+      {:error, _} = Interests.show_interest(%{name: "naem", phone: "123", interest_type: 2, listing_id: -1})
+
+      refute_receive %{new: _, topic: "new_interest", type: :new}
     end
   end
 end

--- a/apps/re_integrations/lib/notifications/emails/server.ex
+++ b/apps/re_integrations/lib/notifications/emails/server.ex
@@ -103,7 +103,7 @@ defmodule ReIntegrations.Notifications.Emails.Server do
   end
 
   def handle_info(%{topic: "new_interest", type: :new, new: interest}, state) do
-    interest = Repo.preload(interest, :interest_type)
+    interest = Repo.preload(interest, [:interest_type, listing: :address])
 
     handle_cast({Emails.User, :notify_interest, [interest]}, state)
   end

--- a/apps/re_integrations/lib/notifications/emails/user.ex
+++ b/apps/re_integrations/lib/notifications/emails/user.ex
@@ -23,7 +23,7 @@ defmodule ReIntegrations.Notifications.Emails.User do
         email: email,
         phone: phone,
         message: message,
-        listing_id: listing_id,
+        listing: listing = %{address: address},
         interest_type: interest_type,
         inserted_at: inserted_at
       }) do
@@ -31,18 +31,26 @@ defmodule ReIntegrations.Notifications.Emails.User do
     |> to(get_to_email(interest_type))
     |> from(@from)
     |> subject("Novo interesse em listagem EmCasa")
-    |> html_body(
-      "Nome: #{name}<br> Email: #{email}<br> Telefone: #{phone}<br> Id da listagem: #{listing_id}<br> Mensagem: #{
-        message
-      } <br> #{interest_type && interest_type.name}
-        <br> Inserido em (UTC): #{inserted_at}"
-    )
-    |> text_body(
-      "Nome: #{name}\n Email: #{email}\n Telefone: #{phone}\n Id da listagem: #{listing_id}<br> Mensagem: #{
-        message
-      } <br> #{interest_type && interest_type.name}
-        <br> Inserido em (UTC): #{inserted_at}"
-    )
+    |> html_body("Nome: #{name}<br>
+        Email: #{email}<br>
+        Telefone: #{phone}<br>
+        Id da listagem: #{listing.id}<br>
+        Valor: #{listing.price}<br>
+        Cidade: #{address.city}<br>
+        Bairro: #{address.neighborhood}<br>
+        Mensagem: #{message} <br>
+        #{interest_type && interest_type.name} <br>
+        Inserido em (UTC): #{inserted_at}")
+    |> text_body("Nome: #{name}\n
+        Email: #{email}\n
+        Telefone: #{phone}\n
+        Id da listagem: #{listing.id}\n
+        Valor: #{listing.price}\n
+        Cidade: #{address.city}\n
+        Bairro: #{address.neighborhood}\n
+        Mensagem: #{message} \n
+        #{interest_type && interest_type.name} \n
+        Inserido em (UTC): #{inserted_at}")
   end
 
   def user_registered(%User{name: name}) do

--- a/apps/re_integrations/test/emails/server_test.exs
+++ b/apps/re_integrations/test/emails/server_test.exs
@@ -19,8 +19,8 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
           listing: build(:listing, address: build(:address))
         )
 
-      Emails.Server.handle_cast({Emails.User, :notify_interest, [interest]}, [])
-      interest = Repo.preload(interest, :interest_type)
+      Emails.Server.handle_info(%{topic: "new_interest", type: :new, new: interest}, [])
+      interest = Repo.preload(interest, [:interest_type, listing: :address])
       assert_email_sent(Emails.User.notify_interest(interest))
     end
 
@@ -31,8 +31,8 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
           listing: build(:listing, address: build(:address))
         )
 
-      Emails.Server.handle_cast({Emails.User, :notify_interest, [interest]}, [])
-      interest = Repo.preload(interest, :interest_type)
+      Emails.Server.handle_info(%{topic: "new_interest", type: :new, new: interest}, [])
+      interest = Repo.preload(interest, [:interest_type, listing: :address])
       email = Emails.User.notify_interest(interest)
       assert_email_sent(email)
       assert [{"", "contato@emcasa.com"}] == email.to

--- a/apps/re_integrations/test/emails/server_test.exs
+++ b/apps/re_integrations/test/emails/server_test.exs
@@ -13,7 +13,12 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
 
   describe "handle_cast/2" do
     test "notify_interest/1" do
-      interest = insert(:interest, interest_type: build(:interest_type))
+      interest =
+        insert(:interest,
+          interest_type: build(:interest_type),
+          listing: build(:listing, address: build(:address))
+        )
+
       Emails.Server.handle_cast({Emails.User, :notify_interest, [interest]}, [])
       interest = Repo.preload(interest, :interest_type)
       assert_email_sent(Emails.User.notify_interest(interest))
@@ -21,7 +26,10 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
 
     test "notify_interest/1 with online scheduling" do
       interest =
-        insert(:interest, interest_type: build(:interest_type, name: "Agendamento online"))
+        insert(:interest,
+          interest_type: build(:interest_type, name: "Agendamento online"),
+          listing: build(:listing, address: build(:address))
+        )
 
       Emails.Server.handle_cast({Emails.User, :notify_interest, [interest]}, [])
       interest = Repo.preload(interest, :interest_type)
@@ -240,9 +248,12 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
 
     test "should notify when user shows interest in a listing" do
       interest_type = insert(:interest_type)
-      listing = insert(:listing)
 
-      interest = insert(:interest, listing: listing, interest_type: interest_type)
+      interest =
+        insert(:interest,
+          listing: build(:listing, address: build(:address)),
+          interest_type: interest_type
+        )
 
       Emails.Server.handle_info(%{topic: "new_interest", type: :new, new: interest}, [])
 

--- a/apps/re_web/lib/controllers/interest_controller.ex
+++ b/apps/re_web/lib/controllers/interest_controller.ex
@@ -1,27 +1,16 @@
 defmodule ReWeb.InterestController do
   use ReWeb, :controller
 
-  alias Re.{
-    Interests,
-    Listings
-  }
-
-  @emails Application.get_env(:re, :emails, ReIntegrations.Notifications.Emails)
+  alias Re.Interests
 
   action_fallback(ReWeb.FallbackController)
 
   def create(conn, %{"listing_id" => listing_id, "interest" => params}) do
-    with {:ok, listing} <- Listings.get(listing_id),
-         {:ok, interest} <- Interests.show_interest(listing_id, params),
-         interest <- Interests.preload(interest) do
-      notify_interest(listing, interest)
-
+    with params <- Map.merge(params, %{"listing_id" => listing_id}),
+         {:ok, interest} <- Interests.show_interest(params) do
       conn
       |> put_status(:created)
       |> render("show.json", interest: interest)
     end
   end
-
-  defp notify_interest(%{status: "active"}, interest), do: @emails.notify_interest(interest)
-  defp notify_interest(_, _interest), do: :nothing
 end

--- a/apps/re_web/test/controllers/interests/interest_controller_test.exs
+++ b/apps/re_web/test/controllers/interests/interest_controller_test.exs
@@ -22,5 +22,13 @@ defmodule ReWeb.InterestControllerTest do
       interest_id = response["data"]["id"]
       assert Repo.get(Interest, interest_id)
     end
+
+    test "show interest in invalid listing", %{conn: conn} do
+      conn = post(conn, listing_interest_path(conn, :create, -1), interest: @params)
+
+      assert response = json_response(conn, 422)
+
+      assert %{"listing_id" => ["does not exist."]} == response["errors"]
+    end
   end
 end


### PR DESCRIPTION
- Use the same `show_interest/1` function in REST route
- Remove manual e-mail sending call from the controller
- Add aditional tests
- Test `handle_info` call rather than `handle_cast`