### PR TITLE
Do not send listing update e-mail if the modifier is an admin

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -126,7 +126,7 @@ defmodule Re.Listings do
 
     changeset
     |> Repo.update()
-    |> PubSub.publish_update(changeset, "update_listing")
+    |> PubSub.publish_update(changeset, "update_listing", %{user: user})
   end
 
   defp deactivate_if_not_admin(changeset, %{role: "user"}),

--- a/apps/re/lib/pubsub.ex
+++ b/apps/re/lib/pubsub.ex
@@ -5,10 +5,10 @@ defmodule Re.PubSub do
 
   def subscribe(topic), do: Phoenix.PubSub.subscribe(__MODULE__, topic)
 
-  def publish_new(new, topic) do
+  def publish_new(new, topic, metadata \\ %{}) do
     case new do
       {:ok, new} ->
-        Phoenix.PubSub.broadcast(__MODULE__, topic, %{topic: topic, type: :new, new: new})
+        Phoenix.PubSub.broadcast(__MODULE__, topic, %{topic: topic, type: :new, new: new, metadata: metadata})
 
         {:ok, new}
 
@@ -17,13 +17,14 @@ defmodule Re.PubSub do
     end
   end
 
-  def publish_update(content, changeset, topic) do
+  def publish_update(content, changeset, topic, metadata \\ %{}) do
     case content do
       {:ok, content} ->
         Phoenix.PubSub.broadcast(__MODULE__, topic, %{
           topic: topic,
           type: :update,
-          content: %{new: content, changeset: changeset}
+          content: %{new: content, changeset: changeset},
+          metadata: metadata
         })
 
         {:ok, content}

--- a/apps/re/lib/pubsub.ex
+++ b/apps/re/lib/pubsub.ex
@@ -8,7 +8,12 @@ defmodule Re.PubSub do
   def publish_new(new, topic, metadata \\ %{}) do
     case new do
       {:ok, new} ->
-        Phoenix.PubSub.broadcast(__MODULE__, topic, %{topic: topic, type: :new, new: new, metadata: metadata})
+        Phoenix.PubSub.broadcast(__MODULE__, topic, %{
+          topic: topic,
+          type: :new,
+          new: new,
+          metadata: metadata
+        })
 
         {:ok, new}
 

--- a/apps/re_integrations/lib/notifications/emails/server.ex
+++ b/apps/re_integrations/lib/notifications/emails/server.ex
@@ -121,8 +121,12 @@ defmodule ReIntegrations.Notifications.Emails.Server do
   end
 
   def handle_info(
-        %{topic: "update_listing", type: :update, content: %{new: listing, changeset: changeset},
-        metadata: %{user: %{role: "user"} = user}},
+        %{
+          topic: "update_listing",
+          type: :update,
+          content: %{new: listing, changeset: changeset},
+          metadata: %{user: %{role: "user"} = user}
+        },
         state
       ) do
     handle_cast({Emails.User, :listing_updated, [listing, user, changeset.changes]}, state)

--- a/apps/re_integrations/lib/notifications/emails/server.ex
+++ b/apps/re_integrations/lib/notifications/emails/server.ex
@@ -121,12 +121,11 @@ defmodule ReIntegrations.Notifications.Emails.Server do
   end
 
   def handle_info(
-        %{topic: "update_listing", type: :update, content: %{new: listing, changeset: changeset}},
+        %{topic: "update_listing", type: :update, content: %{new: listing, changeset: changeset},
+        metadata: %{user: %{role: "user"} = user}},
         state
       ) do
-    listing = Repo.preload(listing, :user)
-
-    handle_cast({Emails.User, :listing_updated, [listing, changeset.changes]}, state)
+    handle_cast({Emails.User, :listing_updated, [listing, user, changeset.changes]}, state)
   end
 
   def handle_info(

--- a/apps/re_integrations/lib/notifications/emails/user.ex
+++ b/apps/re_integrations/lib/notifications/emails/user.ex
@@ -88,7 +88,7 @@ defmodule ReIntegrations.Notifications.Emails.User do
                   <a href=\"#{listing_url}\">Imóvel</a>")
   end
 
-  def listing_updated(%Listing{user: %User{name: name, email: email}} = listing, changes) do
+  def listing_updated(listing, user, changes) do
     listing_url = build_url(@listing_path, to_string(listing.id))
     {changes_html, changes_txt} = build_changes(changes)
 
@@ -96,12 +96,14 @@ defmodule ReIntegrations.Notifications.Emails.User do
     |> to(@to)
     |> from(@admin_email)
     |> subject("Um usuário modificou o imóvel")
-    |> html_body("Nome: #{name}<br>
-                  Email: #{email}<br>
+    |> html_body("Nome: #{user.name}<br>
+                  Email: #{user.email || "sem e-mail"}<br>
+                  Telefone: #{user.phone || "sem telefone"}<br>
                   <a href=\"#{listing_url}\">Imóvel</a><br>
                   #{changes_html}")
-    |> text_body("Nome: #{name}
-                  Email: #{email}
+    |> text_body("Nome: #{user.name}\n
+                  Email: #{user.email || "sem e-mail"}\n
+                  Telefone: #{user.phone || "sem telefone"}\n
                   <a href=\"#{listing_url}\">Imóvel</a>
                   #{changes_txt}")
   end

--- a/apps/re_integrations/test/emails/server_test.exs
+++ b/apps/re_integrations/test/emails/server_test.exs
@@ -59,8 +59,12 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
         changeset = Listing.changeset(listing, %{price: 1_000_000, rooms: 4}, "user")
 
       Emails.Server.handle_info(
-        %{topic: "update_listing", type: :update, content: %{new: listing, changeset: changeset},
-        metadata: %{user: user}},
+        %{
+          topic: "update_listing",
+          type: :update,
+          content: %{new: listing, changeset: changeset},
+          metadata: %{user: user}
+        },
         []
       )
 
@@ -75,8 +79,12 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
         changeset = Listing.changeset(listing, %{price: 1_000_000, rooms: 4}, "admin")
 
       Emails.Server.handle_info(
-        %{topic: "update_listing", type: :update, content: %{new: listing, changeset: changeset},
-        metadata: %{user: user}},
+        %{
+          topic: "update_listing",
+          type: :update,
+          content: %{new: listing, changeset: changeset},
+          metadata: %{user: user}
+        },
         []
       )
 

--- a/apps/re_web/test/graphql/images/subscription_test.exs
+++ b/apps/re_web/test/graphql/images/subscription_test.exs
@@ -194,19 +194,21 @@ defmodule ReWeb.GraphQL.Images.SubscriptionTest do
       admin_socket: admin_socket
     } do
       %{id: listing_id} = insert(:listing)
-      ref = push_doc(admin_socket, """
-        subscription {
-          imageInserted(listingId: #{listing_id}) {
-            image {
-              id
-              filename
-            }
-            parentListing {
-              id
+
+      ref =
+        push_doc(admin_socket, """
+          subscription {
+            imageInserted(listingId: #{listing_id}) {
+              image {
+                id
+                filename
+              }
+              parentListing {
+                id
+              }
             }
           }
-        }
-      """)
+        """)
 
       assert_reply(ref, :ok, %{subscriptionId: subscription_id})
 
@@ -261,19 +263,20 @@ defmodule ReWeb.GraphQL.Images.SubscriptionTest do
     test "user should not subscribe to insertImage", %{
       user_socket: user_socket
     } do
-      ref = push_doc(user_socket, """
-        subscription {
-          imageInserted(listingId: 1) {
-            image {
-              id
-              filename
-            }
-            parentListing {
-              id
+      ref =
+        push_doc(user_socket, """
+          subscription {
+            imageInserted(listingId: 1) {
+              image {
+                id
+                filename
+              }
+              parentListing {
+                id
+              }
             }
           }
-        }
-      """)
+        """)
 
       assert_reply(ref, :error, %{errors: [%{message: :unauthorized}]})
     end
@@ -281,19 +284,20 @@ defmodule ReWeb.GraphQL.Images.SubscriptionTest do
     test "anonymous should not subscribe to insertImage", %{
       unauthenticated_socket: unauthenticated_socket
     } do
-      ref = push_doc(unauthenticated_socket, """
-        subscription {
-          imageInserted(listingId: 1) {
-            image {
-              id
-              filename
-            }
-            parentListing {
-              id
+      ref =
+        push_doc(unauthenticated_socket, """
+          subscription {
+            imageInserted(listingId: 1) {
+              image {
+                id
+                filename
+              }
+              parentListing {
+                id
+              }
             }
           }
-        }
-      """)
+        """)
 
       assert_reply(ref, :error, %{errors: [%{message: :unauthenticated}]})
     end


### PR DESCRIPTION
- Fix previously introduced e-mail fix that was sending e-mail when admin updated the listing
- Refactor `PubSub` to include metadata