### PR TITLE
git hook to check format before commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 ## Install
 
   * Install dependencies with `mix deps.get`
-
   * Create, migrate and seed your database with `cd apps/re && mix ecto.setup`
   * Rename `config/dev.secret-example.exs` to `config/dev.secret.exs` and follow instructions at the top of the file to generate necessary keys.
+  * Install git hooks with `mix git.hook`
 
 ## Setup elasticsearch (optional)
+
   * Download and install (comes with kibana): `mix elasticsearch.install . --version 6.2.4`
   * Run elasticsearch: `./elasticsearch/bin/elasticsearch` and check `http://localhost:9200`
   * Run kibana: `./kibana/bin/kibana` and check `http://localhost:5601`

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Re.Umbrella.Mixfile do
       apps_path: "apps",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test]
     ]
@@ -17,5 +18,16 @@ defmodule Re.Umbrella.Mixfile do
       {:timber, "~> 3.0.0"},
       {:excoveralls, "~> 0.10", only: :test}
     ]
+  end
+
+  defp aliases do
+    [
+      "git.hook": &git_hook/1
+    ]
+  end
+
+  defp git_hook(_) do
+    Mix.shell().cmd("cp priv/git/pre-commit .git/hooks/pre-commit")
+    Mix.shell().cmd("chmod +x .git/hooks/pre-commit")
   end
 end

--- a/priv/git/pre-commit
+++ b/priv/git/pre-commit
@@ -1,11 +1,13 @@
 #!/bin/sh
 to_check=$(git diff --name-only --cached | grep '\.ex')
-if [ $(echo ${to_check} | wc -l) == 1 ]; then
+to_check_len=$(echo ${to_check} | wc -l)
+
+if [ "${to_check_len}" = 1 ] && [ "${to_check}" = "" ]; then
 	echo "no files to be formatted"
 	exit 0
 fi
 
-echo "files to be checked ${to_check} ($(echo ${to_check} | wc -l))"
+echo "files to be checked ${to_check} (${to_check_len})"
 mix format --check-formatted ${to_check}
 if [ $? == 1 ]; then
 	echo "commit failed due to format issues ..."

--- a/priv/git/pre-commit
+++ b/priv/git/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+to_check=$(git diff --name-only --cached | grep '\.ex')
+if [ $(echo ${to_check} | wc -l) == 1 ]; then
+	echo "no files to be formatted"
+	exit 0
+fi
+
+echo "files to be checked ${to_check} ($(echo ${to_check} | wc -l))"
+mix format --check-formatted ${to_check}
+if [ $? == 1 ]; then
+	echo "commit failed due to format issues ..."
+	exit 1
+fi


### PR DESCRIPTION
To avoid situations where `mix format` isn't run before commiting, we can add this `pre-commit` hook, that checks that every staged change is properly formatted.

TODO:

- [x] create script to run before commit
- [x] add mix target to install script in `.git/hooks`