### PR TITLE
Refactor highlights

### DIFF
--- a/apps/re/lib/listings/highlights.ex
+++ b/apps/re/lib/listings/highlights.ex
@@ -29,19 +29,24 @@ defmodule Re.Listings.Highlights do
                                        )
 
   alias Re.{
+    Filtering,
     Listings.Queries,
     Repo
   }
 
-  def get_highlight_listing_ids(query, params \\ %{}) do
-    get_highlights(query, params)
+  def get_highlight_listing_ids(params \\ %{}) do
+    get_highlights(params)
     |> Enum.map(& &1.id)
   end
 
-  defp get_highlights(query, params) do
+  defp get_highlights(params) do
     order = %{order_by: [%{field: :updated_at, type: :desc}]}
+    filters = Map.get(params, :filters, %{})
 
-    query
+    Queries.active()
+    |> Filtering.apply(filters)
+    |> Queries.preload_relations([:address])
+    |> Queries.order_by_id()
     |> Queries.order_by(order)
     |> Queries.limit(params)
     |> Queries.offset(params)

--- a/apps/re/lib/listings/highlights.ex
+++ b/apps/re/lib/listings/highlights.ex
@@ -46,7 +46,6 @@ defmodule Re.Listings.Highlights do
     Queries.active()
     |> Filtering.apply(filters)
     |> Queries.preload_relations([:address])
-    |> Queries.order_by_id()
     |> Queries.order_by(order)
     |> Queries.limit(params)
     |> Queries.offset(params)

--- a/apps/re/lib/listings/queries/queries.ex
+++ b/apps/re/lib/listings/queries/queries.ex
@@ -4,7 +4,6 @@ defmodule Re.Listings.Queries do
   """
 
   alias Re.{
-    Filtering,
     Images,
     Interests,
     Listing
@@ -101,12 +100,5 @@ defmodule Re.Listings.Queries do
       join: a in assoc(l, :address),
       where: ^listing.address.city == a.city
     )
-  end
-
-  def highlights(query \\ Listing, filters) do
-    active()
-    |> Filtering.apply(filters)
-    |> preload_relations([:address])
-    |> order_by_id()
   end
 end

--- a/apps/re/test/exporters/zap_test.exs
+++ b/apps/re/test/exporters/zap_test.exs
@@ -312,7 +312,7 @@ defmodule Re.Exporters.ZapTest do
 
       assert ~s|<?xml version="1.0" encoding="UTF-8"?><Carga xmlns:xsd="http://www.w3.org/2001/XMLSchema" | <>
                ~s|xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">| <>
-               ~s|<Imoveis><Imovel><CodigoImovel>#{listing.id}</CodigoImovel><TipoOferta>1</TipoOferta></Imovel></Imoveis></Carga>| ==
+               ~s|<Imoveis><Imovel><CodigoImovel>#{listing.id}</CodigoImovel></Imovel></Imoveis></Carga>| ==
                Zap.export_listings_xml(listings, %{attributes: ~w(id)a})
     end
   end

--- a/apps/re/test/listings/highlights_test.exs
+++ b/apps/re/test/listings/highlights_test.exs
@@ -2,24 +2,52 @@ defmodule Re.Listings.HighlightsTest do
   use Re.ModelCase
 
   alias Re.{
-    Listing,
     Listings.Highlights
   }
 
   import Re.Factory
 
   describe "get_highlight_listing_ids/2" do
+    test "should filter by city and state slug" do
+      sao_paulo =
+        insert(
+          :address,
+          city_slug: "sao-paulo",
+          state_slug: "sp"
+        )
+
+      rio_de_janeiro =
+        insert(
+          :address,
+          city_slug: "rio-de-janeiro",
+          state_slug: "rj"
+        )
+
+      %{id: id1} = insert(:listing, address_id: sao_paulo.id)
+
+      insert(:listing, address_id: rio_de_janeiro.id)
+
+      filters =
+        Map.put(
+          %{},
+          :filters,
+          %{cities_slug: ["sao-paulo"], states_slug: ["sp"]}
+        )
+
+      assert [^id1] = Highlights.get_highlight_listing_ids(filters)
+    end
+
     test "should consider page_size value" do
       insert_list(2, :listing)
 
-      result = Highlights.get_highlight_listing_ids(Listing, %{page_size: 1})
+      result = Highlights.get_highlight_listing_ids(%{page_size: 1})
       assert 1 = length(result)
     end
 
     test "should consider offset value" do
       insert_list(2, :listing)
 
-      result = Highlights.get_highlight_listing_ids(Listing, %{offset: 1})
+      result = Highlights.get_highlight_listing_ids(%{offset: 1})
       assert 1 = length(result)
     end
 
@@ -27,7 +55,7 @@ defmodule Re.Listings.HighlightsTest do
       listing_1 = insert(:listing, updated_at: ~N[2019-01-01 15:30:00.000000])
       listing_2 = insert(:listing, updated_at: ~N[2019-01-01 15:00:00.000000])
 
-      assert [listing_1.id, listing_2.id] == Highlights.get_highlight_listing_ids(Listing, %{})
+      assert [listing_1.id, listing_2.id] == Highlights.get_highlight_listing_ids()
     end
   end
 end

--- a/apps/re_web/lib/exporters/vivareal/plug.ex
+++ b/apps/re_web/lib/exporters/vivareal/plug.ex
@@ -7,8 +7,7 @@ defmodule ReWeb.Exporters.Vivareal.Plug do
   alias Re.{
     Exporters.Vivareal,
     Listings.Exporter,
-    Listings.Highlights,
-    Listings.Queries
+    Listings.Highlights
   }
 
   def init(args), do: args
@@ -18,11 +17,8 @@ defmodule ReWeb.Exporters.Vivareal.Plug do
         _args
       ) do
     filters = %{cities_slug: [city_slug], states_slug: [state_slug]}
-    highlights_size = Highlights.get_vivareal_highlights_size(city_slug)
 
-    options =
-      Queries.highlights(filters)
-      |> get_highlights(highlights_size)
+    options = get_highlights(filters, query_params)
 
     xml_listings =
       Exporter.exportable(filters, query_params)
@@ -44,11 +40,15 @@ defmodule ReWeb.Exporters.Vivareal.Plug do
     |> send_resp(404, error_response)
   end
 
-  defp get_highlights(query, highlights_size) do
-    highlight_ids =
-      Highlights.get_highlight_listing_ids(query, %{
-        page_size: highlights_size
-      })
+  defp get_highlights(%{cities_slug: [city_slug]} = filters, query_params) do
+    highlights_size = Highlights.get_vivareal_highlights_size(city_slug)
+
+    params =
+      query_params
+      |> Map.put(:filters, filters)
+      |> Map.put(:page_size, highlights_size)
+
+    highlight_ids = Highlights.get_highlight_listing_ids(params)
 
     %{highlight_ids: highlight_ids}
   end


### PR DESCRIPTION
Main changes are: 
- Revert the interface for from `convert_highlight_type` to `convert_attributes` back, now the highlight lists are passed as optional param.
- Remove the query as a param to get highlights, once it's only used inside the module `Highlights` we have no reason to share it, I guess it's cleaner and more testable.

Suggestions are always welcome. 