### PR TITLE
Truncate postal code with 5 digits

### DIFF
--- a/apps/re/lib/addresses/address.ex
+++ b/apps/re/lib/addresses/address.ex
@@ -47,7 +47,7 @@ defmodule Re.Address do
     |> unique_constraint(:postal_code, name: :unique_address)
     |> validate_number(:lat, greater_than: -90, less_than: 90)
     |> validate_number(:lng, greater_than: -180, less_than: 180)
-    |> truncate_postal_code()
+    |> pad_trailing_with_zeros()
     |> generate_slugs()
   end
 
@@ -58,7 +58,7 @@ defmodule Re.Address do
   end
 
 
-  def truncate_postal_code(changeset) do
+  def pad_trailing_with_zeros(changeset) do
     postal_code = Ecto.Changeset.get_field(changeset, :postal_code, "")
 
     if partial_postal_code?(postal_code) do

--- a/apps/re/lib/addresses/address.ex
+++ b/apps/re/lib/addresses/address.ex
@@ -47,6 +47,7 @@ defmodule Re.Address do
     |> unique_constraint(:postal_code, name: :unique_address)
     |> validate_number(:lat, greater_than: -90, less_than: 90)
     |> validate_number(:lng, greater_than: -180, less_than: 180)
+    |> truncate_postal_code()
     |> generate_slugs()
   end
 
@@ -54,5 +55,23 @@ defmodule Re.Address do
 
   def generate_slugs(changeset) do
     Enum.reduce(@sluggified_attr, changeset, &Slugs.generate_slug(&1, &2))
+  end
+
+
+  def truncate_postal_code(changeset) do
+    postal_code = Ecto.Changeset.get_field(changeset, :postal_code, "")
+
+    if partial_postal_code?(postal_code) do
+      changeset
+      |> Ecto.Changeset.put_change(:postal_code, "#{postal_code}-000")
+    else
+      changeset
+    end
+  end
+
+  @partial_postal_code_regex ~r/^[0-9]{5}$/
+
+  defp partial_postal_code?(postal_code) do
+    not is_nil(postal_code) && Regex.match?(@partial_postal_code_regex, postal_code)
   end
 end

--- a/apps/re/test/addresses/address_test.exs
+++ b/apps/re/test/addresses/address_test.exs
@@ -74,7 +74,7 @@ defmodule Re.AddressTest do
     assert changeset.errors == [postal_code: {"has already been taken", []}]
   end
 
-  test "five digits postal code should be truncated to eight digits" do
+  test "five digits postal code should be padded to eight digits" do
     attr = Map.put(@valid_attrs, :postal_code, "22041")
     changeset = Address.changeset(%Address{}, attr)
 

--- a/apps/re/test/addresses/address_test.exs
+++ b/apps/re/test/addresses/address_test.exs
@@ -74,9 +74,11 @@ defmodule Re.AddressTest do
     assert changeset.errors == [postal_code: {"has already been taken", []}]
   end
 
-  test "five digits posta code should be valid" do
+  test "five digits postal code should be truncated to eight digits" do
     attr = Map.put(@valid_attrs, :postal_code, "22041")
     changeset = Address.changeset(%Address{}, attr)
+
+    assert Map.get(changeset.changes, :postal_code) == "22041-000"
     assert changeset.valid?
   end
 end


### PR DESCRIPTION
Some listings would be not exported to portals due to the invalid postal code. Google maps probably return some postal codes in a 5 digits format (old and invalid format), on these cases we are now truncating "-000" (nevertheless it does not reflect the generated code be the correct one). 

While digging to this I found [we removed the validation on zip code some time ago](https://github.com/emcasa/backend/commit/114c14a4cf094adaa9255137d782a40f7c083b6f) (probably duo the same issue), should it be reinserted now all the know cases are formatted?