### PR TITLE
Improve docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,10 @@ _build
 deps
 releases
 *.ez
+.elixir_ls
 
-# erlarng artifacts
+# erlang artifacts
 erl_crash.dump
+
+# docker artifacts
+priv/docker/postgres/dump

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = True
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ex,exs,yml}]
+indent_size = 2
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /db
 /deps
 /*.ez
+/.elixir_ls
+/priv/docker/postgres/dump
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ If you prefer, mix has some aliases for the common commands:
 * `mix compose down`: stop all services.
 * `mix compose ps`: check `status` for all services.
 
+### Load database backup
+
+To restore a database backup execute the command:
+
+```bash
+pg_restore -d re_dev --clean --no-owner --no-acl <path-to-backup-file>
+```
+
 ## Production
 
 To see backend endpoint in production: `https://api.emcasa.com/`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,23 @@ services:
     hostname: &pg_hostname db
     volumes:
       - './priv/docker/postgres/init-emcasa.sql:/docker-entrypoint-initdb.d/init-emcasa.sql'
+      - './priv/docker/postgres/dump:/opt/dump'
       - 'db_data:/var/lib/postgresql/data'
     environment:
       POSTGRES_USER: &pg_username postgres
       POSTGRES_PASSWORD: &pg_password postgres
+  pgcli:
+    image: 'pygmy/pgcli:stable'
+    depends_on:
+      - db
+    hostname: pgcli
+    environment:
+      PGHOST: *pg_hostname
+      PGDATABASE: re_dev
+      PGUSER: *pg_username
+      PGPASSWORD: *pg_password
+    entrypoint: sleep
+    command: 365d
   es:
     image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.4'
     hostname: &es_hostname es
@@ -65,8 +78,9 @@ services:
         aliases:
           - app
           - dev.emcasa.com
-          - local.emcasa.com
-          - kibana.local.emcasa.com
+          - api.dev.emcasa.com
+          - kibana.dev.emcasa.com
+          - sentry.dev.emcasa.com
       default:
         aliases:
           - app
@@ -80,7 +94,7 @@ services:
       - '80:80'
       - '443:443'
 volumes:
-  db_data:
-  es_data:
+  db_data: {}
+  es_data: {}
 networks:
-  reverse:
+  reverse: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   db:
-    image: 'postgres:9.6-alpine'
+    image: 'postgres:10.6-alpine'
     hostname: &pg_hostname db
     volumes:
       - './priv/docker/postgres/init-emcasa.sql:/docker-entrypoint-initdb.d/init-emcasa.sql'
@@ -86,6 +86,7 @@ services:
           - app
     depends_on:
       - backend
+      - es
     volumes:
       - './priv/docker/certs/dev:/etc/emcasa'
       - './priv/docker/caddy/Caddyfile:/etc/Caddyfile'


### PR DESCRIPTION
This PR mainly introduces updates in docker-compose:

1. Add [`pgcli`][0] to access postgres
2. Add directory  to hold database backups
3. Upgrade hostnames for proxy aap

Also an [`editorconfig`][1] was added, and, instructions to reload a database backup.

[0]: https://www.pgcli.com/
[1]: https://editorconfig.org/