### PR TITLE
Add deleted files as exception to format checking git hook

### DIFF
--- a/apps/re/test/mix/tasks/addresses/pad_right_postal_code_with_zeros.exs
+++ b/apps/re/test/mix/tasks/addresses/pad_right_postal_code_with_zeros.exs
@@ -8,7 +8,8 @@ defmodule Re.Tasks.Re.Addresses.PadRightPostalCodeWithZeros do
   }
 
   import Re.Factory
-   describe "when address already exists" do
+
+  describe "when address already exists" do
     test "should point listing replace address no listing" do
       params = params_for(:address, postal_code: "99999-000")
       invalid_params = Map.merge(params, %{postal_code: "99999"})
@@ -22,7 +23,8 @@ defmodule Re.Tasks.Re.Addresses.PadRightPostalCodeWithZeros do
 
       listing = Repo.get(Listing, listing_id)
 
-      %{listings: [%{id: returned_listing_id}]} = Repo.get(Address, valid_address_id)
+      %{listings: [%{id: returned_listing_id}]} =
+        Repo.get(Address, valid_address_id)
         |> Repo.preload(:listings)
 
       assert [listing_id] == [returned_listing_id]
@@ -40,7 +42,8 @@ defmodule Re.Tasks.Re.Addresses.PadRightPostalCodeWithZeros do
 
       Mix.Tasks.Re.FixInvalidPostalCodes.run(nil)
 
-      invalid_address = Repo.get(Address, invalid_address_id)
+      invalid_address =
+        Repo.get(Address, invalid_address_id)
         |> Repo.preload(:listings)
 
       assert [] == invalid_address.listings

--- a/priv/git/pre-commit
+++ b/priv/git/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-to_check=$(git diff --name-only --cached | grep '\.ex')
+to_check=$(git diff --name-only --cached --name-status=d | grep '\.ex')
 to_check_len=$(echo ${to_check} | wc -l)
 
 if [ "${to_check_len}" = 1 ] && [ "${to_check}" = "" ]; then


### PR DESCRIPTION
The pre-commit hook was getting deleted files from the diff and trying to check the formatting and was erroring since the file doesn't exist.