### PR TITLE
Add uuid for listing

### DIFF
--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -7,6 +7,7 @@ defmodule Re.Listing do
   import Ecto.Changeset
 
   schema "listings" do
+    field :uuid, :string
     field :type, :string
     field :complement, :string
     field :description, :string
@@ -74,6 +75,8 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types,
       message: "should be one of: [#{Enum.join(@garage_types, " ")}]"
     )
+    |> generate_uuid()
+    |> unique_constraint(:uuid, name: :uuid)
   end
 
   @admin_required ~w(type description price rooms bathrooms area garage_spots garage_type
@@ -96,7 +99,11 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types,
       message: "should be one of: [#{Enum.join(@garage_types, " ")}]"
     )
+    |> generate_uuid()
+    |> unique_constraint(:uuid, name: :uuid)
   end
+
+  def uuid_changeset(struct, params), do: cast(struct, params, ~w(uuid)a)
 
   @more_than_zero_attributes ~w(property_tax maintenance_fee
                                 bathrooms garage_spots suites
@@ -109,4 +116,6 @@ defmodule Re.Listing do
   defp greater_than(attr, changeset) do
     validate_number(changeset, attr, greater_than_or_equal_to: 0)
   end
+
+  defp generate_uuid(changeset), do: Ecto.Changeset.change(changeset, %{uuid: UUID.uuid4()})
 end

--- a/apps/re/priv/repo/migrations/20190215015821_generate_listing_uuids.exs
+++ b/apps/re/priv/repo/migrations/20190215015821_generate_listing_uuids.exs
@@ -1,0 +1,26 @@
+defmodule Re.Repo.Migrations.GenerateListingUuids do
+  use Ecto.Migration
+
+  def up do
+    alter table(:listings) do
+      add :uuid, :string
+    end
+
+    flush()
+
+    Re.Listing
+    |> Re.Repo.all()
+    |> Enum.map(&Re.Listing.uuid_changeset(&1, %{uuid: UUID.uuid4()}))
+    |> Enum.each(&Re.Repo.update/1)
+
+    flush()
+
+    create unique_index(:listings, [:uuid])
+  end
+
+  def down do
+    alter table(:listings) do
+      remove :uuid
+    end
+  end
+end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -329,6 +329,7 @@ defmodule Re.ListingsTest do
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.address_id == address.id
       assert retrieved_listing.user_id == user.id
+      assert retrieved_listing.uuid
     end
 
     test "should insert inactive for admin user" do

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -22,6 +22,7 @@ defmodule Re.Factory do
 
   def listing_factory do
     %Re.Listing{
+      uuid: UUID.uuid4(),
       type: random(:listing_type),
       complement: Address.secondary_address(),
       description: Shakespeare.hamlet(),


### PR DESCRIPTION
For the upcoming architectural changes in the project, we're gonna need entities to migrate to `uuid`.

We'll gradually create the fields and generate on insertion and migrate the relationships as needs emerge. For now, we'll spin off with listing for some external references.