### PR TITLE
Fix highlights variables type

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -36,16 +36,17 @@ config :re_integrations, ReIntegrations.Notifications.Emails.Mailer,
 
 config :re,
   vivareal_highlights_size_rio_de_janeiro:
-    Integer.parse(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+    String.to_integer(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
   vivareal_highlights_size_sao_paulo:
-    Integer.parse(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_SAO_PAULO")),
+    String.to_integer(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_SAO_PAULO")),
   zap_highlights_size_rio_de_janeiro:
-    Integer.parse(System.get_env("ZAP_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
-  zap_highlights_size_sao_paulo: Integer.parse(System.get_env("ZAP_HIGHLIGHTS_SIZE_SAO_PAULO")),
+    String.to_integer(System.get_env("ZAP_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+  zap_highlights_size_sao_paulo:
+    String.to_integer(System.get_env("ZAP_HIGHLIGHTS_SIZE_SAO_PAULO")),
   zap_super_highlights_size_rio_de_janeiro:
-    Integer.parse(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+    String.to_integer(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
   zap_super_highlights_size_sao_paulo:
-    Integer.parse(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO"))
+    String.to_integer(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO"))
 
 config :re_integrations,
   to: System.get_env("INTEREST_NOTIFICATION_EMAILS"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -35,12 +35,17 @@ config :re_integrations, ReIntegrations.Notifications.Emails.Mailer,
   api_key: System.get_env("SEND_GRID_API_KEY")
 
 config :re,
-  vivareal_highlights_size_rio_de_janeiro: System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO"),
-  vivareal_highlights_size_sao_paulo: System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_SAO_PAULO"),
-  zap_highlights_size_rio_de_janeiro: System.get_env("ZAP_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO"),
-  zap_highlights_size_sao_paulo: System.get_env("ZAP_HIGHLIGHTS_SIZE_SAO_PAULO"),
-  zap_super_highlights_size_rio_de_janeiro: System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO"),
-  zap_super_highlights_size_sao_paulo: System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO")
+  vivareal_highlights_size_rio_de_janeiro:
+    Integer.parse(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+  vivareal_highlights_size_sao_paulo:
+    Integer.parse(System.get_env("VIVAREAL_HIGHLIGHTS_SIZE_SAO_PAULO")),
+  zap_highlights_size_rio_de_janeiro:
+    Integer.parse(System.get_env("ZAP_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+  zap_highlights_size_sao_paulo: Integer.parse(System.get_env("ZAP_HIGHLIGHTS_SIZE_SAO_PAULO")),
+  zap_super_highlights_size_rio_de_janeiro:
+    Integer.parse(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_RIO_DE_JANEIRO")),
+  zap_super_highlights_size_sao_paulo:
+    Integer.parse(System.get_env("ZAP_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO"))
 
 config :re_integrations,
   to: System.get_env("INTEREST_NOTIFICATION_EMAILS"),


### PR DESCRIPTION
Locally highlights keys are set as integers, but in staging and production they are fetched from env vars, that are translated into string.

So we need to convert these keys into integer, before using them.