### PR TITLE
Remove unecessary preload on related controller

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -83,6 +83,9 @@ defmodule Re.Listings do
 
   def get_preloaded(id), do: do_get(Queries.preload_relations(), id)
 
+  def get_partial_preloaded(id, preload),
+    do: do_get(Queries.preload_relations(Listing, preload), id)
+
   def insert(params, address, user) do
     with {:ok, user} <- validate_phone_number(params, user),
          do: do_insert(params, address, user)

--- a/apps/re_web/lib/controllers/listings/related_controller.ex
+++ b/apps/re_web/lib/controllers/listings/related_controller.ex
@@ -7,10 +7,14 @@ defmodule ReWeb.RelatedController do
     Listings.Related
   }
 
+  @partial_preload [
+    :address
+  ]
+
   action_fallback(ReWeb.FallbackController)
 
   def index(conn, %{"listing_id" => id} = params, user) do
-    with {:ok, listing} <- Listings.get_preloaded(id),
+    with {:ok, listing} <- Listings.get_partial_preloaded(id, @partial_preload),
          params <- Map.put(params, "current_user", user),
          results <- Related.get(listing, params) do
       conn


### PR DESCRIPTION
This PR aims to reduce timeouts from the production database, these looks to be caused by full preloads on listings (my suspects are on visualization assoc). 

I'll keep one eye on it and if it seems to reduce the timeouts will replicate this solution for all other get_preloaded use cases. 

