### PR TITLE
Duplicate schema migrations table

### DIFF
--- a/apps/re/priv/repo/migrations/20190221000053_duplicate_schema_migrations.exs
+++ b/apps/re/priv/repo/migrations/20190221000053_duplicate_schema_migrations.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.DuplicateSchemaMigrations do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE TABLE old_schema_migrations AS TABLE schema_migrations;")
+  end
+
+  def down, do: drop(table(:old_schema_migrations))
+end


### PR DESCRIPTION
Since `eventstore` doesn't allow schema migration table customization, we need to rename our current `schema_migrations` table. This is a PR to discuss doing it through a migration or just manually running a SQL with a new configuration.