### PR TITLE
Rename schema migration table

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: MIX_ENV=prod mix phx.server
-release: mix ecto.migrate

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,6 +21,8 @@ config :re, Re.Repo,
   password: System.get_env("POSTGRES_PASSWORD") || "postgres",
   database: "re_dev",
   hostname: System.get_env("POSTGRES_HOSTNAME") || "localhost",
-  pool_size: 10
+  pool_size: 10,
+  migration_source: "old_schema_migrations"
 
-config :re_integrations, ReIntegrations.Notifications.Emails.Mailer, adapter: Swoosh.Adapters.Local
+config :re_integrations, ReIntegrations.Notifications.Emails.Mailer,
+  adapter: Swoosh.Adapters.Local

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -28,7 +28,8 @@ config :re, Re.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: System.get_env("DATABASE_URL"),
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-  ssl: true
+  ssl: true,
+  migration_source: "old_schema_migrations"
 
 config :re_integrations, ReIntegrations.Notifications.Emails.Mailer,
   adapter: Swoosh.Adapters.Sendgrid,

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,13 +28,13 @@ config :re, Re.Repo,
   password: System.get_env("POSTGRES_PASSWORD") || "postgres",
   database: "re_test",
   hostname: System.get_env("POSTGRES_HOSTNAME") || "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  migration_source: "old_schema_migrations"
 
 config :account_kit,
   app_id: "123"
 
-config :re_integrations, ReIntegrations.Notifications.Emails.Mailer,
-  adapter: Swoosh.Adapters.Test
+config :re_integrations, ReIntegrations.Notifications.Emails.Mailer, adapter: Swoosh.Adapters.Test
 
 config :re,
   visualizations: Re.TestVisualizations,


### PR DESCRIPTION
This is an alternative to #419 
Before deploying this modification, we would take down the app and rename the table manually.
No migration fuss, plain and simple.