### PR TITLE
Add land development structure

### DIFF
--- a/apps/re/lib/addresses/address.ex
+++ b/apps/re/lib/addresses/address.ex
@@ -24,6 +24,7 @@ defmodule Re.Address do
     field :state_slug, :string
 
     has_many :listings, Re.Listing
+    has_many :developments, Re.Development
 
     timestamps()
   end

--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -15,8 +15,8 @@ defmodule Re.Development do
     field :description, :string
 
     belongs_to :address, Re.Address
-
     has_many :images, Re.Image
+
     timestamps()
   end
 

--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -10,7 +10,7 @@ defmodule Re.Development do
   schema "developments" do
     field :name, :string
     field :title, :string
-    field :status, :string
+    field :phase, :string
     field :builder, :string
     field :description, :string
 
@@ -20,16 +20,16 @@ defmodule Re.Development do
     timestamps()
   end
 
-  @statuses ~w(pre-launch planning building delivered)
+  @phases ~w(pre-launch planning building delivered)
 
-  @required ~w(name title status builder description address_id)a
+  @required ~w(name title phase builder description address_id)a
 
   def changeset(struct, params) do
     struct
     |> cast(params, @required)
     |> validate_required(@required)
-    |> validate_inclusion(:status, @statuses,
-      message: "should be one of: [#{Enum.join(@statuses, " ")}]"
+    |> validate_inclusion(:phase, @phases,
+      message: "should be one of: [#{Enum.join(@phases, " ")}]"
     )
   end
 end

--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -1,0 +1,33 @@
+defmodule Re.Development do
+  @moduledoc """
+  Module for land developments.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "developments" do
+    field :name, :string
+    field :title, :string
+    field :status, :string
+    field :builder, :string
+    field :description, :string
+    belongs_to :address, Re.Address
+
+    timestamps()
+  end
+
+  @statuses ~w(pre-launch planning building delivered)
+
+  @required ~w(name title status builder description address_id)a
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, @required)
+    |> validate_required(@required)
+    |> validate_inclusion(:status, @statuses,
+      message: "should be one of: [#{Enum.join(@statuses, " ")}]"
+    )
+  end
+end

--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -13,8 +13,10 @@ defmodule Re.Development do
     field :status, :string
     field :builder, :string
     field :description, :string
+
     belongs_to :address, Re.Address
 
+    has_many :images, Re.Image
     timestamps()
   end
 

--- a/apps/re/lib/images/image.ex
+++ b/apps/re/lib/images/image.ex
@@ -13,6 +13,7 @@ defmodule Re.Image do
     field :description, :string
 
     belongs_to :listing, Re.Listing
+    belongs_to :development, Re.Development
 
     timestamps()
   end

--- a/apps/re/lib/images/image.ex
+++ b/apps/re/lib/images/image.ex
@@ -28,7 +28,7 @@ defmodule Re.Image do
     struct
     |> cast(params, @create_required ++ @create_optional)
     |> cast_assoc(:listing)
-    |> cast_assoc(:listing)
+    |> cast_assoc(:development)
     |> validate_required(@create_required)
   end
 

--- a/apps/re/lib/images/image.ex
+++ b/apps/re/lib/images/image.ex
@@ -28,6 +28,7 @@ defmodule Re.Image do
     struct
     |> cast(params, @create_required ++ @create_optional)
     |> cast_assoc(:listing)
+    |> cast_assoc(:listing)
     |> validate_required(@create_required)
   end
 

--- a/apps/re/priv/repo/migrations/20190221135204_create_developments.exs
+++ b/apps/re/priv/repo/migrations/20190221135204_create_developments.exs
@@ -5,7 +5,7 @@ defmodule Re.Repo.Migrations.CreateDevelopments do
     create table(:developments) do
       add(:name, :string)
       add(:title, :string)
-      add(:status, :string)
+      add(:phase, :string)
       add(:builder, :string)
       add(:description, :text)
       add(:address_id, references(:addresses))

--- a/apps/re/priv/repo/migrations/20190221135204_create_developments.exs
+++ b/apps/re/priv/repo/migrations/20190221135204_create_developments.exs
@@ -1,0 +1,20 @@
+defmodule Re.Repo.Migrations.CreateDevelopments do
+  use Ecto.Migration
+
+  def up do
+    create table(:developments) do
+      add(:name, :string)
+      add(:title, :string)
+      add(:status, :string)
+      add(:builder, :string)
+      add(:description, :text)
+      add(:address_id, references(:addresses))
+
+      timestamps()
+    end
+  end
+
+  def down do
+    drop table(:developments)
+  end
+end

--- a/apps/re/priv/repo/migrations/20190225150301_add_development_to_images.exs
+++ b/apps/re/priv/repo/migrations/20190225150301_add_development_to_images.exs
@@ -1,0 +1,15 @@
+defmodule Re.Repo.Migrations.AddDevelopmentToImages do
+  use Ecto.Migration
+
+  def up do
+    alter table(:images) do
+      add(:development_id, references(:developments))
+    end
+  end
+
+  def down do
+    alter table(:images) do
+      remove :development_id
+    end
+  end
+end

--- a/apps/re/test/developments/development_test.exs
+++ b/apps/re/test/developments/development_test.exs
@@ -8,7 +8,7 @@ defmodule Re.DevelopmentTest do
   @invalid_attrs %{
     name: "",
     title: "",
-    status: "unexpected",
+    phase: "unexpected",
     builder: "",
     description: ""
   }
@@ -16,7 +16,7 @@ defmodule Re.DevelopmentTest do
   @valid_attrs %{
     name: "Em casa development",
     title: "Em casa - living in your dream",
-    status: "pre-launch",
+    phase: "pre-launch",
     builder: "EmCasa",
     description: "description"
   }
@@ -36,7 +36,7 @@ defmodule Re.DevelopmentTest do
     changeset = Development.changeset(%Development{}, @invalid_attrs)
     refute changeset.valid?
 
-    assert Keyword.get(changeset.errors, :status) ==
+    assert Keyword.get(changeset.errors, :phase) ==
              {"should be one of: [pre-launch planning building delivered]",
               [validation: :inclusion]}
 

--- a/apps/re/test/developments/development_test.exs
+++ b/apps/re/test/developments/development_test.exs
@@ -1,0 +1,52 @@
+defmodule Re.DevelopmentTest do
+  use Re.ModelCase
+
+  alias Re.Development
+
+  import Re.Factory
+
+  @invalid_attrs %{
+    name: "",
+    title: "",
+    status: "unexpected",
+    builder: "",
+    description: ""
+  }
+
+  @valid_attrs %{
+    name: "Em casa development",
+    title: "Em casa - living in your dream",
+    status: "pre-launch",
+    builder: "EmCasa",
+    description: "description"
+  }
+
+  test "changeset with valid attributes" do
+    %{id: address_id} = insert(:address)
+
+    attrs =
+      @valid_attrs
+      |> Map.put(:address_id, address_id)
+
+    changeset = Development.changeset(%Development{}, attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Development.changeset(%Development{}, @invalid_attrs)
+    refute changeset.valid?
+
+    assert Keyword.get(changeset.errors, :status) ==
+             {"should be one of: [pre-launch planning building delivered]",
+              [validation: :inclusion]}
+
+    assert Keyword.get(changeset.errors, :name) == {"can't be blank", [validation: :required]}
+
+    assert Keyword.get(changeset.errors, :title) == {"can't be blank", [validation: :required]}
+
+    assert Keyword.get(changeset.errors, :builder) == {"can't be blank", [validation: :required]}
+
+    assert Keyword.get(changeset.errors, :address_id) ==
+             {"can't be blank", [validation: :required]}
+  end
+end

--- a/apps/re/test/images/image_test.exs
+++ b/apps/re/test/images/image_test.exs
@@ -1,0 +1,43 @@
+defmodule Re.ImageTest do
+  use Re.ModelCase
+
+  alias Re.Image
+
+  import Re.Factory
+
+  @valid_attrs %{
+    filename: "my_picture.jpg",
+    position: 1,
+    description: "Home sweet home"
+  }
+
+  @invalid_attrs %{
+    filename: ""
+  }
+
+  describe "create_changeset" do
+    test "should be valid with listing assoc" do
+      listing_params = params_for(:listing)
+      attrs = Map.put(@valid_attrs, :listing, listing_params)
+      changeset = Image.create_changeset(%Image{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "should be valid with development assoc" do
+      development_params = params_for(:development)
+      attrs = Map.put(@valid_attrs, :development, development_params)
+      changeset = Image.create_changeset(%Image{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "should be invalid" do
+      changeset = Image.create_changeset(%Image{}, @invalid_attrs)
+      refute changeset.valid?
+
+      assert Keyword.get(changeset.errors, :filename) ==
+               {"can't be blank", [validation: :required]}
+    end
+  end
+end

--- a/apps/re/test/images/image_test.exs
+++ b/apps/re/test/images/image_test.exs
@@ -25,7 +25,7 @@ defmodule Re.ImageTest do
     end
 
     test "should be valid with development assoc" do
-      development_params = params_for(:development)
+      development_params = params_for(:development, %{address_id: 1})
       attrs = Map.put(@valid_attrs, :development, development_params)
       changeset = Image.create_changeset(%Image{}, attrs)
 

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -143,6 +143,16 @@ defmodule Re.Factory do
 
   def tour_appointment_factory, do: %Re.Calendars.TourAppointment{}
 
+  def development_factory do
+    %{
+      name: Name.name(),
+      title: Name.name(),
+      status: ~w(pre-launch planning building delivered),
+      builder: Name.name(),
+      description: Shakespeare.hamlet()
+    }
+  end
+
   defp random_postcode do
     first =
       10_000..99_999

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -147,7 +147,7 @@ defmodule Re.Factory do
     %{
       name: Name.name(),
       title: Name.name(),
-      status: Enum.random(~w(pre-launch planning building delivered)),
+      phase: Enum.random(~w(pre-launch planning building delivered)),
       builder: Name.name(),
       description: Shakespeare.hamlet()
     }

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -147,7 +147,7 @@ defmodule Re.Factory do
     %{
       name: Name.name(),
       title: Name.name(),
-      status: ~w(pre-launch planning building delivered),
+      status: Enum.random(~w(pre-launch planning building delivered)),
       builder: Name.name(),
       description: Shakespeare.hamlet()
     }


### PR DESCRIPTION
First version for land development for early feedback in some points I'm not 100% comfortable.   

- We mapped "empreendimentos" to development, which is a common name to this kind of venture but sounds too wide for me. Another common option is `land development` (this one sounds too raw for me), but it's another way to go, any thoughts on it? 

- Another point is what we call `status`. This one could be launch phase or even phase (status could be inactive/active related). Which one makes more sense for you guys?  
---
Also, I'll refactor images before merging this PR, once on our current state one image needs point to a listing, which will not be true anymore after this PR. 

Last but not least, I'll open the GraphQL queries in another PR, I guess I'll take some discovery time while doing it.  