### PR TITLE
Add missing info in vivareal integration

### DIFF
--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -131,7 +131,7 @@ defmodule Re.Exporters.Vivareal do
   end
 
   defp build_details(:description, acc, listing) do
-    [{"Description", %{}, "<![CDATA[" <> (listing.description || "") <> "]]>"} | acc]
+    [{"Description", %{}, {:cdata, listing.description || ""}} | acc]
   end
 
   defp build_details(:price, acc, listing) do
@@ -168,7 +168,7 @@ defmodule Re.Exporters.Vivareal do
   end
 
   defp build_details(:garage_spots, acc, listing) do
-    [{"Garage", %{}, listing.garage_spots || 0} | acc]
+    [{"Garage", %{type: "Parking Space"}, listing.garage_spots || 0} | acc]
   end
 
   defp build_image(%{filename: filename, description: description}) do

--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -90,7 +90,7 @@ defmodule Re.Exporters.Vivareal do
     {"Media", %{}, Enum.map(images, &build_image/1)}
   end
 
-  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms)a
+  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms garage_spots)a
 
   defp convert_attribute(:details, listing, _) do
     {"Details", %{},
@@ -165,6 +165,10 @@ defmodule Re.Exporters.Vivareal do
 
   defp build_details(:bathrooms, acc, listing) do
     [{"Bathrooms", %{}, listing.bathrooms || 0} | acc]
+  end
+
+  defp build_details(:garage_spots, acc, listing) do
+    [{"Garage", %{}, listing.garage_spots || 0} | acc]
   end
 
   defp build_image(%{filename: filename, description: description}) do

--- a/apps/re/test/exporters/trovit_test.exs
+++ b/apps/re/test/exporters/trovit_test.exs
@@ -1,8 +1,6 @@
 defmodule Re.Exporters.TrovitTest do
   use Re.ModelCase
 
-  import Re.Factory
-
   alias Re.{
     Exporters.Trovit,
     Image,

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -39,6 +39,7 @@ defmodule Re.Exporters.VivarealTest do
           price: 1_000_000,
           rooms: 2,
           bathrooms: 2,
+          garage_spots: 2,
           inserted_at: ~N[2018-06-07 15:30:00.000000],
           updated_at: ~N[2018-06-07 15:30:00.000000],
           maintenance_fee: 1000.00,
@@ -88,6 +89,7 @@ defmodule Re.Exporters.VivarealTest do
           price: 1_000_000,
           rooms: 2,
           bathrooms: 2,
+          garage_spots: 2,
           inserted_at: ~N[2018-06-07 15:30:00.000000],
           updated_at: ~N[2018-06-07 15:30:00.000000],
           maintenance_fee: nil,
@@ -137,6 +139,7 @@ defmodule Re.Exporters.VivarealTest do
           price: 1_000_000,
           rooms: nil,
           bathrooms: nil,
+          garage_spots: nil,
           inserted_at: ~N[2018-06-07 15:30:00.000000],
           updated_at: ~N[2018-06-07 15:30:00.000000],
           maintenance_fee: 1000.00,
@@ -186,6 +189,7 @@ defmodule Re.Exporters.VivarealTest do
           price: 1_000_000,
           rooms: nil,
           bathrooms: nil,
+          garage_spots: nil,
           inserted_at: ~N[2018-06-07 15:30:00.000000],
           updated_at: ~N[2018-06-07 15:30:00.000000],
           maintenance_fee: 1000.00,
@@ -263,32 +267,35 @@ defmodule Re.Exporters.VivarealTest do
   defp details_tags do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description>&lt;![CDATA[descr]]&gt;</Description>" <>
+      "<Description><![CDATA[descr]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>
       "<YearlyTax currency=\"BRL\">1000</YearlyTax>" <>
-      "<Bedrooms>2</Bedrooms>" <> "<Bathrooms>2</Bathrooms>" <> "</Details>"
+      "<Bedrooms>2</Bedrooms>" <>
+      "<Bathrooms>2</Bathrooms>" <> "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
   end
 
   defp details_tags_nils do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description>&lt;![CDATA[]]&gt;</Description>" <>
+      "<Description><![CDATA[]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
-      "<Bedrooms>2</Bedrooms>" <> "<Bathrooms>2</Bathrooms>" <> "</Details>"
+      "<Bedrooms>2</Bedrooms>" <>
+      "<Bathrooms>2</Bathrooms>" <> "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
   end
 
   defp rooms_nil_details_tags do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description>&lt;![CDATA[descr]]&gt;</Description>" <>
+      "<Description><![CDATA[descr]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>
       "<YearlyTax currency=\"BRL\">1000</YearlyTax>" <>
-      "<Bedrooms>0</Bedrooms>" <> "<Bathrooms>0</Bathrooms>" <> "</Details>"
+      "<Bedrooms>0</Bedrooms>" <>
+      "<Bathrooms>0</Bathrooms>" <> "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>"
   end
 
   defp location_tags do


### PR DESCRIPTION
VivaReal xml has a node for garage spots that wasn't populated in current integration.

This PR fixes this issue and add proper `CDATA` escape for description.