### PR TITLE
Updates in ops side

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ erl_crash.dump
 
 # docker artifacts
 priv/docker/postgres/dump
+priv/personal

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /*.ez
 /.elixir_ls
 /priv/docker/postgres/dump
+/priv/personal
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,6 @@ EXPOSE 4000
 # execution copy scripts
 COPY priv/docker/scripts/wait-for-it.sh /usr/local/bin/
 COPY priv/docker/scripts/docker-entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/wait-for-it.sh \
+    && chmod 755 /usr/local/bin/docker-entrypoint.sh
 CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/priv/git/pre-commit
+++ b/priv/git/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-to_check=$(git diff --name-only --cached --name-status=d | grep '\.ex')
+to_check=$(git diff --name-only --cached --diff-filter=d | grep '\.ex')
 to_check_len=$(echo ${to_check} | wc -l)
 
 if [ "${to_check_len}" = 1 ] && [ "${to_check}" = "" ]; then
@@ -9,7 +9,7 @@ fi
 
 echo "files to be checked ${to_check} (${to_check_len})"
 mix format --check-formatted ${to_check}
-if [ $? == 1 ]; then
+if [ $? = 1 ]; then
 	echo "commit failed due to format issues ..."
 	exit 1
 fi


### PR DESCRIPTION
The following changes are introduced by this PR:

1. Ignore folder `priv/personal`, in this path I add experimental scripts, that shouldn't be committed in the repo
2. Fix minor issue with pre-commit hook script, where it was failing in check if a file needed to be formatted
3. Add proper permission for scripts in dockerfile