### PR TITLE
Mark non exportable listing

### DIFF
--- a/apps/re/lib/filtering/filtering.ex
+++ b/apps/re/lib/filtering/filtering.ex
@@ -33,11 +33,13 @@ defmodule Re.Filtering do
     field :cities, {:array, :string}
     field :cities_slug, {:array, :string}
     field :states_slug, {:array, :string}
+    field :exportable, :boolean
   end
 
   @filters ~w(max_price min_price max_rooms min_rooms max_suites min_suites min_area max_area
               neighborhoods types max_lat min_lat max_lng min_lng neighborhoods_slugs
-              max_garage_spots min_garage_spots garage_types cities cities_slug states_slug)a
+              max_garage_spots min_garage_spots garage_types cities cities_slug states_slug
+              exportable)a
 
   def changeset(struct, params \\ %{}), do: cast(struct, params, @filters)
 
@@ -198,6 +200,10 @@ defmodule Re.Filtering do
       on: ad.id == l.address_id,
       where: ad.state_slug in ^states_slug
     )
+  end
+
+  defp attr_filter({:exportable, exportable}, query) do
+    from(l in query, where: l.is_exportable == ^exportable)
   end
 
   defp attr_filter(_, query), do: query

--- a/apps/re/lib/listings/exporter.ex
+++ b/apps/re/lib/listings/exporter.ex
@@ -16,6 +16,8 @@ defmodule Re.Listings.Exporter do
   ]
 
   def exportable(filters, params) do
+    filters = Map.put(filters, :exportable, true)
+
     Queries.active()
     |> Filtering.apply(filters)
     |> Queries.preload_relations(@partial_preload)

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -31,6 +31,7 @@ defmodule Re.Listing do
     field :status, :string, default: "inactive"
     field :is_exclusive, :boolean, default: false
     field :is_release, :boolean
+    field :is_exportable, :boolean, default: true
     field :visualisations, :integer, virtual: true
     field :favorite_count, :integer, virtual: true
     field :interest_count, :integer, virtual: true

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -83,7 +83,7 @@ defmodule Re.Listing do
   @admin_required ~w(type description price rooms bathrooms area garage_spots garage_type
                      score address_id user_id suites dependencies has_elevator)a
   @admin_optional ~w(complement floor matterport_code is_exclusive status
-                     property_tax maintenance_fee balconies restrooms is_release)a
+                     property_tax maintenance_fee balconies restrooms is_release is_exportable)a
 
   @admin_attributes @admin_required ++ @admin_optional
   def changeset(struct, params, "admin") do

--- a/apps/re/priv/repo/migrations/20190228135338_add_exportable_flag_to_listings.exs
+++ b/apps/re/priv/repo/migrations/20190228135338_add_exportable_flag_to_listings.exs
@@ -1,0 +1,15 @@
+defmodule Re.Repo.Migrations.AddExportableFlagToListings do
+  use Ecto.Migration
+
+  def up do
+    alter table(:listings) do
+      add :is_exportable, :boolean, default: true
+    end
+  end
+
+  def down do
+    alter table(:listings) do
+      remove :is_exportable
+    end
+  end
+end

--- a/apps/re/test/listings/exporter_test.exs
+++ b/apps/re/test/listings/exporter_test.exs
@@ -82,5 +82,14 @@ defmodule Re.Listings.ExporterTest do
 
       assert [%{id: ^id_2}] = result
     end
+
+    test "should only return exportable listings" do
+      %{id: id} = insert(:listing, is_exportable: true)
+      insert(:listing, is_exportable: false)
+
+      result = Exporter.exportable(%{}, %{})
+
+      assert [%{id: ^id}] = result
+    end
   end
 end

--- a/apps/re/test/listings/exporter_test.exs
+++ b/apps/re/test/listings/exporter_test.exs
@@ -11,8 +11,8 @@ defmodule Re.Listings.ExporterTest do
 
       rio_de_janeiro = insert(:address, city_slug: "rio-de-janeiro", state_slug: "rj")
 
-      %{id: id_1} = insert(:listing, address_id: sao_paulo.id)
-      insert(:listing, address_id: rio_de_janeiro.id)
+      %{id: id_1} = insert(:listing, address_id: sao_paulo.id, is_exportable: true)
+      insert(:listing, address_id: rio_de_janeiro.id, is_exportable: true)
 
       result =
         Exporter.exportable(
@@ -29,7 +29,7 @@ defmodule Re.Listings.ExporterTest do
     test "should not return if state slug doesn't match" do
       sao_paulo = insert(:address, city_slug: "sao-paulo", state_slug: "sp")
 
-      insert(:listing, address_id: sao_paulo.id)
+      insert(:listing, address_id: sao_paulo.id, is_exportable: true)
 
       assert [] =
                Exporter.exportable(
@@ -41,7 +41,7 @@ defmodule Re.Listings.ExporterTest do
     test "should not return if city slug doesn't match" do
       sao_paulo = insert(:address, city_slug: "sao-paulo", state_slug: "sp")
 
-      insert(:listing, address_id: sao_paulo.id)
+      insert(:listing, address_id: sao_paulo.id, is_exportable: true)
 
       assert [] =
                Exporter.exportable(
@@ -56,8 +56,8 @@ defmodule Re.Listings.ExporterTest do
     test "should accept page_size" do
       sao_paulo = insert(:address, city_slug: "sao-paulo", state_slug: "sp")
 
-      %{id: id_1} = insert(:listing, address_id: sao_paulo.id)
-      insert(:listing, address_id: sao_paulo.id)
+      %{id: id_1} = insert(:listing, address_id: sao_paulo.id, is_exportable: true)
+      insert(:listing, address_id: sao_paulo.id, is_exportable: true)
 
       result =
         Exporter.exportable(
@@ -71,8 +71,8 @@ defmodule Re.Listings.ExporterTest do
     test "should accept offset" do
       sao_paulo = insert(:address, city_slug: "sao-paulo", state_slug: "sp")
 
-      insert(:listing, address_id: sao_paulo.id)
-      %{id: id_2} = insert(:listing, address_id: sao_paulo.id)
+      insert(:listing, address_id: sao_paulo.id, is_exportable: true)
+      %{id: id_2} = insert(:listing, address_id: sao_paulo.id, is_exportable: true)
 
       result =
         Exporter.exportable(

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -26,7 +26,8 @@ defmodule Re.ListingTest do
     score: 4,
     matterport_code: "",
     is_exclusive: false,
-    is_release: false
+    is_release: false,
+    is_exportable: true
   }
   @invalid_attrs %{
     type: "ApartmentApartmentApartmentApartmentApartment",
@@ -43,7 +44,8 @@ defmodule Re.ListingTest do
     garage_type: "mine",
     score: 5,
     is_exclusive: "banana",
-    is_release: "banana"
+    is_release: "banana",
+    is_exportable: "banana"
   }
 
   describe "user" do
@@ -158,6 +160,9 @@ defmodule Re.ListingTest do
                {"is invalid", [type: :boolean, validation: :cast]}
 
       assert Keyword.get(changeset.errors, :is_release) ==
+               {"is invalid", [type: :boolean, validation: :cast]}
+
+      assert Keyword.get(changeset.errors, :is_exportable) ==
                {"is invalid", [type: :boolean, validation: :cast]}
 
       changeset = Listing.changeset(%Listing{}, %{score: 0, price: 110_000_000}, "admin")

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -44,7 +44,8 @@ defmodule Re.Factory do
       matterport_code: Faker.String.base64(),
       status: "active",
       is_exclusive: Enum.random([true, false]),
-      is_release: Enum.random([true, false])
+      is_release: Enum.random([true, false]),
+      is_exportable: true
     }
   end
 

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -45,7 +45,7 @@ defmodule Re.Factory do
       status: "active",
       is_exclusive: Enum.random([true, false]),
       is_release: Enum.random([true, false]),
-      is_exportable: true
+      is_exportable: Enum.random([true, false])
     }
   end
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -34,6 +34,7 @@ defmodule ReWeb.Types.Listing do
     field :is_active, :boolean, resolve: &Resolvers.Listings.is_active/3
     field :is_exclusive, :boolean
     field :is_release, :boolean
+    field :is_exportable, :boolean
     field :inserted_at, :naive_datetime
     field :score, :integer, resolve: &Resolvers.Listings.score/3
 
@@ -94,6 +95,7 @@ defmodule ReWeb.Types.Listing do
     field :matterport_code, :string
     field :is_exclusive, :boolean
     field :is_release, :boolean
+    field :is_exportable, :boolean
     field :score, :integer
 
     field :phone, :string

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -69,8 +69,8 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["matterportCode"] == listing.matterport_code
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
-      assert inserted_listing["score"] == listing.score
       assert inserted_listing["isExportable"] == listing.is_exportable
+      assert inserted_listing["score"] == listing.score
 
       refute inserted_listing["isActive"]
 
@@ -124,7 +124,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["matterportCode"] == nil
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
-      assert inserted_listing["isExportable"] == listing.is_exportable
+      assert inserted_listing["isExportable"] == true
       assert inserted_listing["score"] == nil
 
       refute inserted_listing["isActive"]
@@ -399,7 +399,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["matterportCode"] == old_listing.matterport_code
       assert updated_listing["isExclusive"] == new_listing.is_exclusive
       assert updated_listing["isRelease"] == new_listing.is_release
-      assert updated_listing["isExportable"] == new_listing.is_exportable
+      assert updated_listing["isExportable"] == old_listing.is_exportable
 
       refute updated_listing["score"]
       refute updated_listing["isActive"]

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -70,6 +70,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
       assert inserted_listing["score"] == listing.score
+      assert inserted_listing["isExportable"] == listing.is_exportable
 
       refute inserted_listing["isActive"]
 
@@ -123,6 +124,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["matterportCode"] == nil
       assert inserted_listing["isExclusive"] == listing.is_exclusive
       assert inserted_listing["isRelease"] == listing.is_release
+      assert inserted_listing["isExportable"] == listing.is_exportable
       assert inserted_listing["score"] == nil
 
       refute inserted_listing["isActive"]
@@ -348,6 +350,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["matterportCode"] == new_listing.matterport_code
       assert updated_listing["isExclusive"] == new_listing.is_exclusive
       assert updated_listing["isRelease"] == new_listing.is_release
+      assert updated_listing["isExportable"] == new_listing.is_exportable
       assert updated_listing["score"] == new_listing.score
 
       assert inserted_address["city"] == new_address.city
@@ -396,6 +399,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["matterportCode"] == old_listing.matterport_code
       assert updated_listing["isExclusive"] == new_listing.is_exclusive
       assert updated_listing["isRelease"] == new_listing.is_release
+      assert updated_listing["isExportable"] == new_listing.is_exportable
 
       refute updated_listing["score"]
       refute updated_listing["isActive"]

--- a/apps/re_web/test/support/mutation_helpers.ex
+++ b/apps/re_web/test/support/mutation_helpers.ex
@@ -36,6 +36,7 @@ defmodule ReWeb.Listing.MutationHelpers do
         "matterportCode" => listing.matterport_code,
         "isExclusive" => listing.is_exclusive,
         "isRelease" => listing.is_release,
+        "isExportable" => listing.is_exportable,
         "score" => listing.score
       }
     }
@@ -75,6 +76,7 @@ defmodule ReWeb.Listing.MutationHelpers do
         "matterportCode" => listing.matterport_code,
         "isExclusive" => listing.is_exclusive,
         "isRelease" => listing.is_release,
+        "isExportable" => listing.is_exportable,
         "score" => listing.score
       }
     }
@@ -119,6 +121,7 @@ defmodule ReWeb.Listing.MutationHelpers do
           isActive
           isExclusive
           isRelease
+          isExportable
           score
         }
       }
@@ -164,6 +167,7 @@ defmodule ReWeb.Listing.MutationHelpers do
           isActive
           isExclusive
           isRelease
+          isExportable
           score
         }
       }


### PR DESCRIPTION
There are sellers that won't allow us to list their realty in other sites. To control this behavior, we're adding a new column to `Re.Listing`, that will be used to determine if a given listing can be show in integration or not. This flag is editable by both admin and listing owner.