### PR TITLE
Exposes development to graphql

### DIFF
--- a/apps/re/lib/developments/developments.ex
+++ b/apps/re/lib/developments/developments.ex
@@ -1,0 +1,26 @@
+defmodule Re.Developments do
+  @moduledoc """
+  Context for developments.
+  """
+
+  require Ecto.Query
+
+  alias Re.{
+    Development,
+    Repo
+  }
+
+  def all do
+    Re.Development
+    |> Re.Repo.all()
+  end
+
+  def get(id), do: do_get(Development, id)
+
+  defp do_get(query, id) do
+    case Repo.get(query, id) do
+      nil -> {:error, :not_found}
+      development -> {:ok, development}
+    end
+  end
+end

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -24,8 +24,6 @@ defmodule Re.Listings do
 
   def query(query, params), do: DataloaderQueries.build(query, params)
 
-  def index, do: Repo.all(Listing)
-
   def all do
     Queries.active()
     |> Queries.preload_relations([:address])

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -144,7 +144,7 @@ defmodule Re.Factory do
   def tour_appointment_factory, do: %Re.Calendars.TourAppointment{}
 
   def development_factory do
-    %{
+    %Re.Development{
       name: Name.name(),
       title: Name.name(),
       phase: Enum.random(~w(pre-launch planning building delivered)),

--- a/apps/re_web/lib/graphql/resolvers/addresses.ex
+++ b/apps/re_web/lib/graphql/resolvers/addresses.ex
@@ -9,13 +9,13 @@ defmodule ReWeb.Resolvers.Addresses do
   }
 
   def per_listing(listing, params, %{context: %{current_user: current_user}}) do
-    admin? = admin_rights?(listing, current_user)
+    admin? = admin_permissions?(listing, current_user)
 
     {:address, Map.put(params, :has_admin_rights, admin?)}
   end
 
   def per_development(_development, params, %{context: %{current_user: current_user}}) do
-    admin? = admin_rights?(nil, current_user)
+    admin? = admin_permissions?(nil, current_user)
 
     {:address, Map.put(params, :has_admin_rights, admin?)}
   end
@@ -44,7 +44,7 @@ defmodule ReWeb.Resolvers.Addresses do
 
   def is_covered(address, _, _), do: {:ok, Addresses.is_covered(address)}
 
-  defp admin_rights?(%{user_id: user_id}, %{id: user_id}), do: true
-  defp admin_rights?(_, %{role: "admin"}), do: true
-  defp admin_rights?(_, _), do: false
+  defp admin_permissions?(%{user_id: user_id}, %{id: user_id}), do: true
+  defp admin_permissions?(_, %{role: "admin"}), do: true
+  defp admin_permissions?(_, _), do: false
 end

--- a/apps/re_web/lib/graphql/resolvers/addresses.ex
+++ b/apps/re_web/lib/graphql/resolvers/addresses.ex
@@ -14,6 +14,12 @@ defmodule ReWeb.Resolvers.Addresses do
     {:address, Map.put(params, :has_admin_rights, admin?)}
   end
 
+  def per_development(_development, params, %{context: %{current_user: current_user}}) do
+    admin? = is_admin(nil, current_user)
+
+    {:address, Map.put(params, :has_admin_rights, admin?)}
+  end
+
   def insert(%{input: params}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Addresses, :insert, current_user, %{}),
          {:ok, address} <- Addresses.insert_or_update(params) do
@@ -38,6 +44,7 @@ defmodule ReWeb.Resolvers.Addresses do
 
   def is_covered(address, _, _), do: {:ok, Addresses.is_covered(address)}
 
+  # rename to can access or has_access
   defp is_admin(%{user_id: user_id}, %{id: user_id}), do: true
   defp is_admin(_, %{role: "admin"}), do: true
   defp is_admin(_, _), do: false

--- a/apps/re_web/lib/graphql/resolvers/addresses.ex
+++ b/apps/re_web/lib/graphql/resolvers/addresses.ex
@@ -9,13 +9,13 @@ defmodule ReWeb.Resolvers.Addresses do
   }
 
   def per_listing(listing, params, %{context: %{current_user: current_user}}) do
-    admin? = is_admin(listing, current_user)
+    admin? = admin_rights?(listing, current_user)
 
     {:address, Map.put(params, :has_admin_rights, admin?)}
   end
 
   def per_development(_development, params, %{context: %{current_user: current_user}}) do
-    admin? = is_admin(nil, current_user)
+    admin? = admin_rights?(nil, current_user)
 
     {:address, Map.put(params, :has_admin_rights, admin?)}
   end
@@ -44,8 +44,7 @@ defmodule ReWeb.Resolvers.Addresses do
 
   def is_covered(address, _, _), do: {:ok, Addresses.is_covered(address)}
 
-  # rename to can access or has_access
-  defp is_admin(%{user_id: user_id}, %{id: user_id}), do: true
-  defp is_admin(_, %{role: "admin"}), do: true
-  defp is_admin(_, _), do: false
+  defp admin_rights?(%{user_id: user_id}, %{id: user_id}), do: true
+  defp admin_rights?(_, %{role: "admin"}), do: true
+  defp admin_rights?(_, _), do: false
 end

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -1,0 +1,13 @@
+defmodule ReWeb.Resolvers.Developments do
+  import Absinthe.Resolution.Helpers
+
+  require Ecto.Query
+
+  def index(_params, _context) do
+    developments =
+      Re.Development
+      |> Re.Repo.all()
+
+    {:ok, developments}
+  end
+end

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -10,11 +10,7 @@ defmodule ReWeb.Resolvers.Developments do
     {:ok, developments}
   end
 
-  def show(%{id: id}, %{context: %{current_user: current_user}}) do
-    with {:ok, development} <- Developments.get(id),
-         #  :ok <- Bodyguard.permit(Listings, :show_listing, current_user, listing) do
-         :ok <- :ok do
-      {:ok, development}
-    end
+  def show(%{id: id}, _context) do
+    Developments.get(id)
   end
 end

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -1,13 +1,20 @@
 defmodule ReWeb.Resolvers.Developments do
-  import Absinthe.Resolution.Helpers
 
-  require Ecto.Query
+  alias Re.{
+    Developments
+  }
 
   def index(_params, _context) do
-    developments =
-      Re.Development
-      |> Re.Repo.all()
+    developments = Developments.all()
 
     {:ok, developments}
+  end
+
+  def show(%{id: id}, %{context: %{current_user: current_user}}) do
+    with {:ok, development} <- Developments.get(id),
+         #  :ok <- Bodyguard.permit(Listings, :show_listing, current_user, listing) do
+         :ok <- :ok do
+      {:ok, development}
+    end
   end
 end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -32,26 +32,10 @@ defmodule ReWeb.Resolvers.Images do
     end)
   end
 
-  def per_development(development, params, %{context: %{loader: loader}}) do
-    is_admin? = true
+  def per_development(_development, params, %{context: %{current_user: current_user}}) do
+    is_admin? = is_admin(nil, current_user)
 
-    loader
-    |> Dataloader.load(
-      Re.Images,
-      {:images, Map.put(params, :has_admin_rights, is_admin?)},
-      development
-    )
-    |> on_load(fn loader ->
-      images =
-        loader
-        |> Dataloader.get(
-          Re.Images,
-          {:images, Map.put(params, :has_admin_rights, is_admin?)},
-          development
-        )
-
-      {:ok, images}
-    end)
+    {:images, Map.put(params, :has_admin_rights, is_admin?)}
   end
 
   def insert_image(%{input: %{listing_id: listing_id} = params}, %{

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -32,6 +32,28 @@ defmodule ReWeb.Resolvers.Images do
     end)
   end
 
+  def per_development(development, params, %{context: %{loader: loader}}) do
+    is_admin? = true
+
+    loader
+    |> Dataloader.load(
+      Re.Images,
+      {:images, Map.put(params, :has_admin_rights, is_admin?)},
+      development
+    )
+    |> on_load(fn loader ->
+      images =
+        loader
+        |> Dataloader.get(
+          Re.Images,
+          {:images, Map.put(params, :has_admin_rights, is_admin?)},
+          development
+        )
+
+      {:ok, images}
+    end)
+  end
+
   def insert_image(%{input: %{listing_id: listing_id} = params}, %{
         context: %{current_user: current_user}
       }) do

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -10,7 +10,7 @@ defmodule ReWeb.Resolvers.Images do
   }
 
   def per_listing(listing, params, %{context: %{loader: loader, current_user: current_user}}) do
-    is_admin? = is_admin(listing, current_user)
+    is_admin? = admin_rights?(listing, current_user)
 
     loader
     |> Dataloader.load(
@@ -35,7 +35,7 @@ defmodule ReWeb.Resolvers.Images do
   def per_development(development, params, %{
         context: %{loader: loader, current_user: current_user}
       }) do
-    is_admin? = is_admin(nil, current_user)
+    is_admin? = admin_rights?(nil, current_user)
 
     loader
     |> Dataloader.load(
@@ -121,9 +121,9 @@ defmodule ReWeb.Resolvers.Images do
   defp config_subscription(_args, %{}, _topic), do: {:error, :unauthorized}
   defp config_subscription(_args, _, _topic), do: {:error, :unauthenticated}
 
-  defp is_admin(%{user_id: user_id}, %{id: user_id}), do: true
-  defp is_admin(_, %{role: "admin"}), do: true
-  defp is_admin(_, _), do: false
+  defp admin_rights?(%{user_id: user_id}, %{id: user_id}), do: true
+  defp admin_rights?(_, %{role: "admin"}), do: true
+  defp admin_rights?(_, _), do: false
 
   defp limit(images, %{limit: limit}), do: Enum.take(images, limit)
   defp limit(images, _), do: images

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -32,10 +32,28 @@ defmodule ReWeb.Resolvers.Images do
     end)
   end
 
-  def per_development(_development, params, %{context: %{current_user: current_user}}) do
+  def per_development(development, params, %{
+        context: %{loader: loader, current_user: current_user}
+      }) do
     is_admin? = is_admin(nil, current_user)
 
-    {:images, Map.put(params, :has_admin_rights, is_admin?)}
+    loader
+    |> Dataloader.load(
+      Re.Images,
+      {:images, Map.put(params, :has_admin_rights, is_admin?)},
+      development
+    )
+    |> on_load(fn loader ->
+      images =
+        loader
+        |> Dataloader.get(
+          Re.Images,
+          {:images, Map.put(params, :has_admin_rights, is_admin?)},
+          development
+        )
+
+      {:ok, images}
+    end)
   end
 
   def insert_image(%{input: %{listing_id: listing_id} = params}, %{

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -10,6 +10,7 @@ defmodule ReWeb.Schema do
   import_types ReWeb.Types.Interest
   import_types ReWeb.Types.Dashboard
   import_types ReWeb.Types.Calendar
+  import_types ReWeb.Types.Development
   import_types Absinthe.Type.Custom
 
   alias ReWeb.GraphQL.Middlewares
@@ -29,6 +30,7 @@ defmodule ReWeb.Schema do
     import_fields(:dashboard_queries)
     import_fields(:interest_queries)
     import_fields(:calendar_queries)
+    import_fields(:development_queries)
   end
 
   mutation do

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -32,5 +32,12 @@ defmodule ReWeb.Types.Development do
     field :developments, list_of(:development) do
       resolve &Resolvers.Developments.index/2
     end
+
+    @desc "Show development"
+    field :development, :development do
+      arg :id, non_null(:id)
+
+      resolve &Resolvers.Developments.show/2
+    end
   end
 end

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -16,13 +16,14 @@ defmodule ReWeb.Types.Development do
     field :builder, :string
     field :description, :string
 
-    field :address, :address, resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_development/3)
+    field :address, :address,
+      resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_development/3)
 
-    field :images, list_of(:image), resolve: &Resolvers.Images.per_development/3
+    field :images, list_of(:image),
+      resolve: dataloader(Re.Images, &Resolvers.Images.per_development/3)
   end
 
   object :development_queries do
-
     @desc "Developments index"
     field :developments, list_of(:development) do
       resolve &Resolvers.Developments.index/2

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -1,0 +1,9 @@
+defmodule ReWeb.Types.Development do
+  @module
+  @moduledoc """
+  GraphQL types for developments
+  """
+  use Absinthe.Schema.Notation
+
+  alias ReWeb.Resolvers
+end

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -1,9 +1,31 @@
 defmodule ReWeb.Types.Development do
-  @module
   @moduledoc """
   GraphQL types for developments
   """
   use Absinthe.Schema.Notation
 
+  import Absinthe.Resolution.Helpers, only: [dataloader: 2]
+
   alias ReWeb.Resolvers
+
+  object :development do
+    field :id, :id
+    field :name, :string
+    field :title, :string
+    field :phase, :string
+    field :builder, :string
+    field :description, :string
+
+    field :address, :address, resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_development/3)
+
+    field :images, list_of(:image), resolve: &Resolvers.Images.per_development/3
+  end
+
+  object :development_queries do
+
+    @desc "Developments index"
+    field :developments, list_of(:development) do
+      resolve &Resolvers.Developments.index/2
+    end
+  end
 end

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -19,8 +19,12 @@ defmodule ReWeb.Types.Development do
     field :address, :address,
       resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_development/3)
 
-    field :images, list_of(:image),
-      resolve: dataloader(Re.Images, &Resolvers.Images.per_development/3)
+    field :images, list_of(:image) do
+      arg :is_active, :boolean
+      arg :limit, :integer
+
+      resolve &Resolvers.Images.per_development/3
+    end
   end
 
   object :development_queries do

--- a/apps/re_web/test/graphql/developments/query_test.exs
+++ b/apps/re_web/test/graphql/developments/query_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ReWeb.GraphQL.Developments.QueryTest do
   use ReWeb.ConnCase
 
@@ -20,8 +19,34 @@ defmodule ReWeb.GraphQL.Developments.QueryTest do
   end
 
   describe "developments" do
-    test "admin should query development index", %{admin_conn: conn} do
-      assert 1 == 1
+    @developments_query """
+    query Developments {
+      developments {
+        name
+        title
+        phase
+        builder
+        description
+      }
+    }
+    """
+
+    test "admin should query developments", %{admin_conn: conn} do
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(@developments_query))
+
+      assert json_response(conn, 200)["data"] == %{"developments" => []}
+    end
+
+    test "user should query developments", %{user_conn: conn} do
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(@developments_query))
+
+      assert json_response(conn, 200)["data"] == %{"developments" => []}
+    end
+
+    test "anonymous should query developments", %{unauthenticated_conn: conn} do
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(@developments_query))
+
+      assert json_response(conn, 200)["data"] == %{"developments" => []}
     end
   end
 end

--- a/apps/re_web/test/graphql/developments/query_test.exs
+++ b/apps/re_web/test/graphql/developments/query_test.exs
@@ -49,4 +49,183 @@ defmodule ReWeb.GraphQL.Developments.QueryTest do
       assert json_response(conn, 200)["data"] == %{"developments" => []}
     end
   end
+
+  describe "development" do
+    test "admin should query development", %{admin_conn: conn} do
+      %{filename: image_filename1} = image1 = insert(:image, is_active: true, position: 1)
+      %{filename: image_filename2} = image2 = insert(:image, is_active: true, position: 2)
+
+      %{id: address_id, street: street, street_number: street_number} = insert(:address)
+
+      %{
+        id: development_id,
+        name: name,
+        title: title,
+        phase: phase,
+        builder: builder,
+        description: description
+      } = insert(:development, address_id: address_id, images: [image1, image2])
+
+      variables = %{
+        "id" => development_id
+      }
+
+      query = """
+        query Development (
+          $id: ID!,
+          ) {
+          development (id: $id) {
+            name
+            title
+            phase
+            builder
+            description
+            address {
+              street_number
+              street
+            }
+            images {
+              filename
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+      assert %{
+               "name" => name,
+               "title" => title,
+               "phase" => phase,
+               "builder" => builder,
+               "description" => description,
+               "address" => %{
+                 "street_number" => street_number,
+                 "street" => street
+               },
+               "images" => [
+                 %{"filename" => image_filename1},
+                 %{"filename" => image_filename2}
+               ]
+             } == json_response(conn, 200)["data"]["development"]
+    end
+
+    test "user should query development", %{user_conn: conn} do
+      %{filename: image_filename1} = image1 = insert(:image, is_active: true, position: 1)
+      %{filename: image_filename2} = image2 = insert(:image, is_active: true, position: 2)
+
+      %{id: address_id, street: street} = insert(:address)
+
+      %{
+        id: development_id,
+        name: name,
+        title: title,
+        phase: phase,
+        builder: builder,
+        description: description
+      } = insert(:development, address_id: address_id, images: [image1, image2])
+
+      variables = %{
+        "id" => development_id
+      }
+
+      query = """
+        query Development (
+          $id: ID!,
+          ) {
+          development (id: $id) {
+            name
+            title
+            phase
+            builder
+            description
+            address {
+              street_number
+              street
+            }
+            images {
+              filename
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+      assert %{
+               "name" => name,
+               "title" => title,
+               "phase" => phase,
+               "builder" => builder,
+               "description" => description,
+               "address" => %{
+                 "street_number" => nil,
+                 "street" => street
+               },
+               "images" => [
+                 %{"filename" => image_filename1},
+                 %{"filename" => image_filename2}
+               ]
+             } == json_response(conn, 200)["data"]["development"]
+    end
+
+    test "unauthenticated user should query development", %{unauthenticated_conn: conn} do
+      %{filename: image_filename1} = image1 = insert(:image, is_active: true, position: 1)
+      %{filename: image_filename2} = image2 = insert(:image, is_active: true, position: 2)
+
+      %{id: address_id, street: street} = insert(:address)
+
+      %{
+        id: development_id,
+        name: name,
+        title: title,
+        phase: phase,
+        builder: builder,
+        description: description
+      } = insert(:development, address_id: address_id, images: [image1, image2])
+
+      variables = %{
+        "id" => development_id
+      }
+
+      query = """
+        query Development (
+          $id: ID!,
+          ) {
+          development (id: $id) {
+            name
+            title
+            phase
+            builder
+            description
+            address {
+              street_number
+              street
+            }
+            images {
+              filename
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+      assert %{
+               "name" => name,
+               "title" => title,
+               "phase" => phase,
+               "builder" => builder,
+               "description" => description,
+               "address" => %{
+                 "street_number" => nil,
+                 "street" => street
+               },
+               "images" => [
+                 %{"filename" => image_filename1},
+                 %{"filename" => image_filename2}
+               ]
+             } == json_response(conn, 200)["data"]["development"]
+    end
+  end
 end

--- a/apps/re_web/test/graphql/developments/query_test.exs
+++ b/apps/re_web/test/graphql/developments/query_test.exs
@@ -1,0 +1,27 @@
+
+defmodule ReWeb.GraphQL.Developments.QueryTest do
+  use ReWeb.ConnCase
+
+  import Re.Factory
+
+  alias ReWeb.AbsintheHelpers
+
+  setup %{conn: conn} do
+    conn = put_req_header(conn, "accept", "application/json")
+    admin_user = insert(:user, email: "admin@email.com", role: "admin")
+    user_user = insert(:user, email: "user@email.com", role: "user")
+
+    {:ok,
+     unauthenticated_conn: conn,
+     admin_user: admin_user,
+     user_user: user_user,
+     admin_conn: login_as(conn, admin_user),
+     user_conn: login_as(conn, user_user)}
+  end
+
+  describe "developments" do
+    test "admin should query development index", %{admin_conn: conn} do
+      assert 1 == 1
+    end
+  end
+end


### PR DESCRIPTION
Exposing development query to Graphql, I used the plural to exposes the lists and the singular a single resource. This PR only exposes the queries, will submit the mutations on another PR.

Also made other minor changes, removed an unused function (`Re.Listings.index`), and renamed `ReWeb.Resolvers{Images, Address}.is_admin/3` to `ReWeb.Resolvers{Images, Addresses}.admin_rights?/3`. My expectation on rename is to give a better visibility about what it really checks and follow [Elixir name conventions](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Naming%20Conventions.md#trailing-question-mark-foo).  