### PR TITLE
Normalize neighborhood on acceptance

### DIFF
--- a/apps/re/lib/addresses/neighborhoods.ex
+++ b/apps/re/lib/addresses/neighborhoods.ex
@@ -8,6 +8,7 @@ defmodule Re.Addresses.Neighborhoods do
   alias Re.{
     Address,
     Addresses.District,
+    Addresses.Slugs,
     Listing,
     Repo
   }
@@ -58,30 +59,47 @@ defmodule Re.Addresses.Neighborhoods do
   def nearby("Leblon"), do: "Gávea"
   def nearby("São Conrado"), do: "Itanhangá"
 
-  @covered_neighborhoods MapSet.new([
-                           %{state: "RJ", neighborhood: "Humaitá", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Copacabana", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Botafogo", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Catete", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Cosme Velho", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Flamengo", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Gávea", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Ipanema", city: "Rio de Janeiro"},
-                           %{
-                             state: "RJ",
-                             neighborhood: "Jardim Botânico",
-                             city: "Rio de Janeiro"
-                           },
-                           %{state: "RJ", neighborhood: "Joá", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Lagoa", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Laranjeiras", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Leblon", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Leme", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "São Conrado", city: "Rio de Janeiro"},
-                           %{state: "RJ", neighborhood: "Urca", city: "Rio de Janeiro"},
-                           %{state: "SP", neighborhood: "Perdizes", city: "São Paulo"},
-                           %{state: "SP", neighborhood: "Vila Pompéia", city: "São Paulo"}
-                         ])
+  @covered_neighborhoods [
+    %{state: "RJ", neighborhood: "Humaitá", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Copacabana", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Botafogo", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Catete", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Cosme Velho", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Flamengo", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Gávea", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Ipanema", city: "Rio de Janeiro"},
+    %{
+      state: "RJ",
+      neighborhood: "Jardim Botânico",
+      city: "Rio de Janeiro"
+    },
+    %{state: "RJ", neighborhood: "Joá", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Lagoa", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Laranjeiras", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Leblon", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Leme", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "São Conrado", city: "Rio de Janeiro"},
+    %{state: "RJ", neighborhood: "Urca", city: "Rio de Janeiro"},
+    %{state: "SP", neighborhood: "Perdizes", city: "São Paulo"},
+    %{state: "SP", neighborhood: "Vila Pompéia", city: "São Paulo"}
+  ]
 
-  def is_covered(neighborhood), do: MapSet.member?(@covered_neighborhoods, neighborhood)
+  def is_covered(neighborhood) do
+    @covered_neighborhoods
+    |> sluggify_covered_neighborhoods()
+    |> MapSet.member?(sluggify_attributes(neighborhood))
+  end
+
+  defp sluggify_covered_neighborhoods(covered_neighborhoods) do
+    covered_neighborhoods
+    |> Enum.map(&sluggify_attributes(&1))
+    |> MapSet.new()
+  end
+
+  defp sluggify_attributes(neighborhoods) do
+    neighborhoods
+    |> Map.update!(:city, &Slugs.sluggify(&1))
+    |> Map.update!(:neighborhood, &Slugs.sluggify(&1))
+    |> Map.update!(:state, &Slugs.sluggify(&1))
+  end
 end

--- a/apps/re/test/addresses/neighborhoods_test.exs
+++ b/apps/re/test/addresses/neighborhoods_test.exs
@@ -48,4 +48,36 @@ defmodule Re.NeighborhoodsTest do
       assert {:error, :not_found} == Neighborhoods.get_description(address)
     end
   end
+
+  describe "is_covered/1" do
+    test "should be true when neighborhood exists" do
+      neighborhood = %{state: "RJ", neighborhood: "Humaitá", city: "Rio de Janeiro"}
+      assert Neighborhoods.is_covered(neighborhood)
+    end
+
+    test "should be true when neighborhood exists without consider accents" do
+      neighborhood = %{state: "RJ", neighborhood: "Humaita", city: "Rio de Janeiro"}
+      assert Neighborhoods.is_covered(neighborhood)
+    end
+
+    test "should be true when neighborhood exists and without consider case" do
+      neighborhood = %{state: "RJ", neighborhood: "humaitá", city: "Rio de Janeiro"}
+      assert Neighborhoods.is_covered(neighborhood)
+    end
+
+    test "should be false when neighborhood does not exists" do
+      neighborhood = %{state: "RJ", neighborhood: "Lapa", city: "Rio de Janeiro"}
+      refute Neighborhoods.is_covered(neighborhood)
+    end
+
+    test "should be false when city does not exists" do
+      neighborhood = %{state: "RS", neighborhood: "Humaitá", city: "Rio de Janeiro"}
+      refute Neighborhoods.is_covered(neighborhood)
+    end
+
+    test "should be false when state does not exists" do
+      neighborhood = %{state: "RJ", neighborhood: "Humaitá", city: "Porto Alegre"}
+      refute Neighborhoods.is_covered(neighborhood)
+    end
+  end
 end

--- a/apps/re/test/exporters/imovelweb_test.exs
+++ b/apps/re/test/exporters/imovelweb_test.exs
@@ -94,9 +94,7 @@ defmodule Re.Exporters.ImovelwebTest do
           "<ToursVirtual360>" <>
           "<TourVirtual360>" <>
           "<URLArquivo><![CDATA[#{@tour_url}/?m=mY123]]></URLArquivo>" <>
-          "</TourVirtual360>" <>
-          "</ToursVirtual360>" <>
-          "</Imovel>"
+          "</TourVirtual360>" <> "</ToursVirtual360>" <> "</Imovel>"
 
       generated_xml =
         listing
@@ -156,10 +154,7 @@ defmodule Re.Exporters.ImovelwebTest do
           "<PrecoIptuImovel/>" <>
           "<QtdDormitorios>4</QtdDormitorios>" <>
           "<QtdBanheiros>4</QtdBanheiros>" <>
-          "<QtdVagas>4</QtdVagas>" <>
-          "<Fotos/>" <>
-          "<ToursVirtual360/>" <>
-          "</Imovel>"
+          "<QtdVagas>4</QtdVagas>" <> "<Fotos/>" <> "<ToursVirtual360/>" <> "</Imovel>"
 
       generated_xml =
         listing
@@ -219,10 +214,7 @@ defmodule Re.Exporters.ImovelwebTest do
           "<PrecoIptuImovel/>" <>
           "<QtdDormitorios>0</QtdDormitorios>" <>
           "<QtdBanheiros>0</QtdBanheiros>" <>
-          "<QtdVagas>0</QtdVagas>" <>
-          "<Fotos/>" <>
-          "<ToursVirtual360/>" <>
-          "</Imovel>"
+          "<QtdVagas>0</QtdVagas>" <> "<Fotos/>" <> "<ToursVirtual360/>" <> "</Imovel>"
 
       generated_xml =
         listing
@@ -312,9 +304,7 @@ defmodule Re.Exporters.ImovelwebTest do
           "<ToursVirtual360>" <>
           "<TourVirtual360>" <>
           "<URLArquivo><![CDATA[#{@tour_url}/?m=mY123]]></URLArquivo>" <>
-          "</TourVirtual360>" <>
-          "</ToursVirtual360>" <>
-          "</Imovel>"
+          "</TourVirtual360>" <> "</ToursVirtual360>" <> "</Imovel>"
 
       generated_xml =
         listing
@@ -404,9 +394,7 @@ defmodule Re.Exporters.ImovelwebTest do
           "<ToursVirtual360>" <>
           "<TourVirtual360>" <>
           "<URLArquivo><![CDATA[#{@tour_url}/?m=mY123]]></URLArquivo>" <>
-          "</TourVirtual360>" <>
-          "</ToursVirtual360>" <>
-          "</Imovel>"
+          "</TourVirtual360>" <> "</ToursVirtual360>" <> "</Imovel>"
 
       generated_xml =
         listing

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -224,9 +224,7 @@ defmodule Re.Exporters.VivarealTest do
             "<LivingArea unit=\"square metres\"/>" <>
             "<Bedrooms>0</Bedrooms>" <>
             "<Bathrooms>0</Bathrooms>" <>
-            "<Garage type=\"Parking Space\">0</Garage>" <>
-            "</Details>" <>
-            "</Listing>"
+            "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>" <> "</Listing>"
 
         created_xml =
           listing

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -1,5 +1,4 @@
 defmodule ReWeb.Resolvers.Developments do
-
   alias Re.{
     Developments
   }


### PR DESCRIPTION
 Actually, some addresses which should be valid in our neighborhood range are not being accepted 'cause google has these addresses without accents characters. I take the opportunity and solve the sensitiveness cases as well. 

ie: [Rua do Bananal, Vila Pompeia should be Rua do Bananal, Vila pompéia.](https://www.google.com/maps/place/R.+Bar%C3%A3o+do+Bananal,+S%C3%A3o+Paulo+-+SP,+05024-000/@-23.5319355,-46.6898331,17z/data=!4m13!1m7!3m6!1s0x94ce57e0fc196623:0xf2b308e4fe1b119d!2sR.+Bar%C3%A3o+do+Bananal,+S%C3%A3o+Paulo+-+SP,+05024-000!3b1!8m2!3d-23.5319355!4d-46.6876444!3m4!1s0x94ce57e0fc196623:0xf2b308e4fe1b119d!8m2!3d-23.5319355!4d-46.6876444)  