### PR TITLE
Improve travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,35 @@ language: elixir
 elixir: 1.7.4
 otp_release: 21.1
 
+services:
+  - postgresql
+
 env:
   - MIX_ENV=test
 
 sudo: false
-addons:
-  postgresql: 9.6
 
-before_script: mix deps.get --only test
+addons:
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
+env:
+  global:
+  - PGPORT=5433
+  - POSTGRES_PORT=5433
+  - POSTGRES_USERNAME=travis_user
+cache:
+  directories:
+    - deps
+    - _build/
+
+before_script:
+  - sudo -u postgres psql -p 5433 -c "create user travis_user with superuser password 'postgres';"
+  - mix deps.get --only test
+  - mix ecto.create
+  - mix ecto.migrate
 
 script: mix coveralls.travis --umbrella
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,6 +27,7 @@ config :re, Re.Repo,
   username: System.get_env("POSTGRES_USERNAME") || "postgres",
   password: System.get_env("POSTGRES_PASSWORD") || "postgres",
   database: "re_test",
+  port: String.to_integer(System.get_env("POSTGRES_PORT")) || 5432,
   hostname: System.get_env("POSTGRES_HOSTNAME") || "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   migration_source: "old_schema_migrations"

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,7 +27,7 @@ config :re, Re.Repo,
   username: System.get_env("POSTGRES_USERNAME") || "postgres",
   password: System.get_env("POSTGRES_PASSWORD") || "postgres",
   database: "re_test",
-  port: String.to_integer(System.get_env("POSTGRES_PORT")) || 5432,
+  port: String.to_integer(System.get_env("POSTGRES_PORT") || "5432") ,
   hostname: System.get_env("POSTGRES_HOSTNAME") || "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   migration_source: "old_schema_migrations"


### PR DESCRIPTION
	* Update Travis' Postgres from 9.6 to 10.
	* Caching dependencies.

---- 

Today I notice we still on Postgres 9.6 in our CI, guessed it was a 2 minutes task, but Travis is a little trick on this. It doesn't fully support Postgres 10, so we need to create a new user (the Postgres user only connects without password param) and point our test database to 5433 ports ([Travis only accepts connections for Postgres 10 on this port](https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version)). 

Also, take the opportunity to cache dependencies, so build go from 6~ min to 2~3 min. 