### PR TITLE
Add GraphQL insert mutation to units

### DIFF
--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -17,6 +17,8 @@ defmodule Re.Development do
     field :description, :string
 
     belongs_to :address, Re.Address
+
+    has_many :units, Re.Unit
     has_many :images, Re.Image
     has_many :listings, Re.Listing
 

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -130,6 +130,16 @@ defmodule Re.Listings do
     |> PubSub.publish_update(changeset, "update_listing", %{user: user})
   end
 
+  def update_price(listing, new_price) do
+    changeset =
+      listing
+      |> Changeset.change(price: new_price)
+
+    changeset
+    |> Repo.update()
+    |> PubSub.publish_update(changeset, "update_listing")
+  end
+
   defp deactivate_if_not_admin(changeset, %{role: "user"}),
     do: Changeset.change(changeset, status: "inactive")
 

--- a/apps/re/lib/listings/units/propagator.ex
+++ b/apps/re/lib/listings/units/propagator.ex
@@ -1,0 +1,18 @@
+defmodule Re.Listings.Units.Propagator do
+  @moduledoc """
+  Context module for listing units interactions, usually changes in units would
+  be replicated/reflected in listings until we migrate replicated structure to units.
+  """
+
+  alias Re.Listings
+
+  def update_listing(
+        %{price: listing_price} = listing,
+        %{price: unit_price}
+      )
+      when is_nil(listing_price) or unit_price < listing_price do
+    Listings.update_price(listing, unit_price)
+  end
+
+  def update_listing(listing, _new_unit), do: {:ok, listing}
+end

--- a/apps/re/lib/listings/units/server.ex
+++ b/apps/re/lib/listings/units/server.ex
@@ -1,0 +1,46 @@
+# maybe move this module to units
+defmodule Re.Listings.Units.Server do
+  @moduledoc """
+  Module responsible for replicate unit data on listings.
+  """
+  use GenServer
+
+  require Logger
+
+  alias Re.{
+    Listings.Units.Propagator,
+    PubSub
+  }
+
+  @spec start_link :: GenServer.start_link()
+  def start_link, do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  @spec init(term) :: {:ok, term}
+  def init(args) do
+    PubSub.subscribe("new_unit")
+
+    {:ok, args}
+  end
+
+  @spec handle_info(map(), any) :: {:noreply, any}
+  def handle_info(
+        %{
+          topic: "new_unit",
+          type: :new,
+          content: %{new: unit}
+        },
+        state
+      ) do
+    case Propagator.update_listing(unit.listing, unit) do
+      {:ok, _listing} ->
+        {:noreply, state}
+
+      error ->
+        Logger.warn("Error when copy unit info to listing. Reason: #{inspect(error)}")
+
+        {:noreply, [error | state]}
+    end
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+end

--- a/apps/re/lib/units/policy.ex
+++ b/apps/re/lib/units/policy.ex
@@ -1,0 +1,14 @@
+defmodule Re.Units.Policy do
+  @moduledoc """
+  Policy module for user permission on units
+  """
+
+  alias Re.{
+    User
+  }
+
+  def authorize(_, %User{role: "admin"}, _), do: :ok
+  def authorize(_, nil, _), do: {:error, :unauthorized}
+
+  def authorize(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/re/lib/units/policy.ex
+++ b/apps/re/lib/units/policy.ex
@@ -3,9 +3,7 @@ defmodule Re.Units.Policy do
   Policy module for user permission on units
   """
 
-  alias Re.{
-    User
-  }
+  alias Re.User
 
   def authorize(_, %User{role: "admin"}, _), do: :ok
   def authorize(_, nil, _), do: {:error, :unauthorized}

--- a/apps/re/lib/units/unit.ex
+++ b/apps/re/lib/units/unit.ex
@@ -25,13 +25,20 @@ defmodule Re.Unit do
     field :dependencies, :integer
     field :balconies, :integer
 
+    belongs_to :development, Re.Development,
+      references: :uuid,
+      foreign_key: :development_uuid,
+      type: Ecto.UUID
+
     belongs_to :listing, Re.Listing
+
     timestamps()
   end
 
   @garage_types ~w(contract condominium)
 
-  @required ~w(price rooms bathrooms area garage_type garage_spots suites dependencies)a
+  @required ~w(price rooms bathrooms area garage_type garage_spots suites dependencies
+               development_uuid)a
   @optional ~w(complement floor property_tax maintenance_fee balconies restrooms)a
 
   @attributes @required ++ @optional

--- a/apps/re/lib/units/unit.ex
+++ b/apps/re/lib/units/unit.ex
@@ -24,6 +24,7 @@ defmodule Re.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
+    field :status, :string
 
     belongs_to :development, Re.Development,
       references: :uuid,
@@ -36,9 +37,10 @@ defmodule Re.Unit do
   end
 
   @garage_types ~w(contract condominium)
+  @statuses ~w(active inactive)
 
   @required ~w(price rooms bathrooms area garage_type garage_spots suites dependencies
-               development_uuid listing_id)a
+               development_uuid listing_id status)a
   @optional ~w(complement floor property_tax maintenance_fee balconies restrooms)a
 
   @attributes @required ++ @optional
@@ -55,6 +57,9 @@ defmodule Re.Unit do
     )
     |> validate_inclusion(:garage_type, @garage_types,
       message: "should be one of: [#{Enum.join(@garage_types, " ")}]"
+    )
+    |> validate_inclusion(:status, @statuses,
+      message: "should be one of: [#{Enum.join(@statuses, " ")}]"
     )
     |> generate_uuid()
     |> unique_constraint(:uuid, name: :uuid)

--- a/apps/re/lib/units/unit.ex
+++ b/apps/re/lib/units/unit.ex
@@ -36,7 +36,7 @@ defmodule Re.Unit do
 
   @attributes @required ++ @optional
 
-  def changeset(struct, params, "development") do
+  def changeset(struct, params) do
     struct
     |> cast(params, @attributes)
     |> validate_required(@required)

--- a/apps/re/lib/units/unit.ex
+++ b/apps/re/lib/units/unit.ex
@@ -38,7 +38,7 @@ defmodule Re.Unit do
   @garage_types ~w(contract condominium)
 
   @required ~w(price rooms bathrooms area garage_type garage_spots suites dependencies
-               development_uuid)a
+               development_uuid listing_id)a
   @optional ~w(complement floor property_tax maintenance_fee balconies restrooms)a
 
   @attributes @required ++ @optional

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -8,6 +8,7 @@ defmodule Re.Units do
   alias Ecto.Changeset
 
   alias Re.{
+    Listings,
     Repo,
     Unit
   }
@@ -32,9 +33,7 @@ defmodule Re.Units do
          %{price: listing_price} = listing
        )
        when is_nil(listing_price) or unit_price < listing_price do
-    Changeset.change(listing, price: unit_price)
-    |> Repo.update()
-
+    Listings.update_price(listing, unit_price)
     new_unit
   end
 

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -8,7 +8,6 @@ defmodule Re.Units do
   alias Ecto.Changeset
 
   alias Re.{
-    Listings,
     PubSub,
     Repo,
     Unit
@@ -28,16 +27,6 @@ defmodule Re.Units do
     |> Repo.insert()
     |> publish_new()
   end
-
-  def update_listing_price(
-        %{price: unit_price} = new_unit,
-        %{price: listing_price} = listing
-      )
-      when is_nil(listing_price) or unit_price < listing_price do
-    Listings.update_price(listing, unit_price)
-  end
-
-  def update_listing_price(unit, _listing), do: unit
 
   defp publish_new(result), do: PubSub.publish_new(result, "new_unit")
 end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -4,7 +4,18 @@ defmodule Re.Units do
   for a listing. A listing can have one or more units.
   """
 
+  alias Re.{
+    Repo,
+    Unit
+  }
+
   def data(params), do: Dataloader.Ecto.new(Re.Repo, query: &query/2, default_params: params)
 
   def query(_query, _args), do: Re.Unit
+
+  def insert(params, user) do
+    %Unit{}
+    |> Unit.changeset(params)
+    |> Repo.insert()
+  end
 end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -18,9 +18,10 @@ defmodule Re.Units do
 
   def query(_query, _args), do: Re.Unit
 
-  def insert(params, development) do
+  def insert(params, development, listing) do
     %Unit{}
     |> Changeset.change(development_uuid: development.uuid)
+    |> Changeset.change(listing_id: listing.id)
     |> Unit.changeset(params)
     |> Repo.insert()
   end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -4,6 +4,8 @@ defmodule Re.Units do
   for a listing. A listing can have one or more units.
   """
 
+  alias Ecto.Changeset
+
   alias Re.{
     Repo,
     Unit
@@ -13,8 +15,9 @@ defmodule Re.Units do
 
   def query(_query, _args), do: Re.Unit
 
-  def insert(params, user) do
+  def insert(params, development) do
     %Unit{}
+    |> Changeset.change(development_uuid: development.uuid)
     |> Unit.changeset(params)
     |> Repo.insert()
   end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -24,5 +24,19 @@ defmodule Re.Units do
     |> Changeset.change(listing_id: listing.id)
     |> Unit.changeset(params)
     |> Repo.insert()
+    |> update_listing_price(listing)
   end
+
+  defp update_listing_price(
+         {:ok, %{price: unit_price}} = new_unit,
+         %{price: listing_price} = listing
+       )
+       when is_nil(listing_price) or unit_price < listing_price do
+    Changeset.change(listing, price: unit_price)
+    |> Repo.update()
+
+    new_unit
+  end
+
+  defp update_listing_price(unit, _listing), do: unit
 end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -3,6 +3,7 @@ defmodule Re.Units do
   Context module for unit. A unit represents realty/real estate properties,
   for a listing. A listing can have one or more units.
   """
+  @behaviour Bodyguard.Policy
 
   alias Ecto.Changeset
 
@@ -10,6 +11,8 @@ defmodule Re.Units do
     Repo,
     Unit
   }
+
+  defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def data(params), do: Dataloader.Ecto.new(Re.Repo, query: &query/2, default_params: params)
 

--- a/apps/re/priv/repo/migrations/20190320162333_add_development_to_units.exs
+++ b/apps/re/priv/repo/migrations/20190320162333_add_development_to_units.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddDevelopmentToUnits do
+  use Ecto.Migration
+
+  def change do
+    alter table(:units) do
+      add :development_uuid, references(:developments, column: :uuid, type: :uuid)
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190322130445_add_status_to_units.exs
+++ b/apps/re/priv/repo/migrations/20190322130445_add_status_to_units.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddStatusToUnits do
+  use Ecto.Migration
+
+  def change do
+    alter table(:units) do
+      add(:status, :string)
+    end
+  end
+end

--- a/apps/re/test/listings/units/propagator_test.exs
+++ b/apps/re/test/listings/units/propagator_test.exs
@@ -1,0 +1,48 @@
+defmodule Re.Listings.Units.PropagatorTest do
+  use Re.ModelCase
+
+  alias Re.Listings.Units.Propagator
+  import Re.Factory
+
+  describe "update_listing/2" do
+    @insert_unit_params %{
+      complement: "201",
+      price: 500_000,
+      rooms: 3,
+      bathrooms: 1,
+      area: 100,
+      garage_spots: 1,
+      garage_type: "contract",
+      dependencies: 0,
+      suites: 1,
+      status: "active"
+    }
+
+    test "replace listing price by unit price when unit price is lower than listing price" do
+      development = insert(:development)
+      listing = insert(:listing, price: 1_000_000, development_uuid: development.uuid)
+      new_unit = insert(:unit, @insert_unit_params)
+
+      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
+      assert listing.price == 500_000
+    end
+
+    test "replace listing price by unit price when listing price is nil" do
+      development = insert(:development)
+      listing = insert(:listing, price: nil, development_uuid: development.uuid)
+      new_unit = insert(:unit, @insert_unit_params)
+
+      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
+      assert listing.price == 500_000
+    end
+
+    test "doesn't update listing price when unit price is higher than listing price" do
+      development = insert(:development)
+      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
+      new_unit = insert(:unit, @insert_unit_params)
+
+      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
+      assert listing.price == 400_000
+    end
+  end
+end

--- a/apps/re/test/listings/units/server_test.exs
+++ b/apps/re/test/listings/units/server_test.exs
@@ -1,0 +1,33 @@
+defmodule Re.Listings.Units.ServerTest do
+  use Re.ModelCase
+
+  import Re.Factory
+
+  alias Re.Listings.Units.Server
+
+  describe "handle_info/2" do
+    @insert_unit_params %{
+      price: 500_000,
+      status: "active"
+    }
+
+    test "match new_unit topic" do
+      development = insert(:development)
+      listing = insert(:listing, price: 1_000_000, development_uuid: development.uuid)
+      attrs = Map.merge(@insert_unit_params, %{listing_id: listing.id})
+      new_unit = insert(:unit, attrs)
+
+      assert {:noreply, []} ==
+               Server.handle_info(
+                 %{
+                   topic: "new_unit",
+                   type: :new,
+                   content: %{
+                     new: new_unit
+                   }
+                 },
+                 []
+               )
+    end
+  end
+end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -172,7 +172,8 @@ defmodule Re.Factory do
       garage_type: Enum.random(~w(contract condominium)),
       suites: Enum.random(0..10),
       dependencies: Enum.random(0..10),
-      balconies: Enum.random(0..10)
+      balconies: Enum.random(0..10),
+      status: Enum.random(~w(active inactive))
     }
   end
 

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -173,7 +173,7 @@ defmodule Re.Factory do
       suites: Enum.random(0..10),
       dependencies: Enum.random(0..10),
       balconies: Enum.random(0..10),
-      status: Enum.random(~w(active inactive))
+      status: "active"
     }
   end
 

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -38,10 +38,12 @@ defmodule Re.UnitTest do
   describe "changeset/3" do
     test "with valid attributes for development" do
       %{id: listing_id} = insert(:listing)
+      %{uuid: development_uuid} = insert(:development)
 
       attrs =
         @valid_attrs
         |> Map.put(:listing_id, listing_id)
+        |> Map.put(:development_uuid, development_uuid)
 
       changeset = Unit.changeset(%Unit{}, attrs)
       assert changeset.valid?
@@ -66,6 +68,9 @@ defmodule Re.UnitTest do
       assert Keyword.get(changeset.errors, :suites) == {"can't be blank", [validation: :required]}
 
       assert Keyword.get(changeset.errors, :dependencies) ==
+               {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :development_uuid) ==
                {"can't be blank", [validation: :required]}
     end
 

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -43,12 +43,12 @@ defmodule Re.UnitTest do
         @valid_attrs
         |> Map.put(:listing_id, listing_id)
 
-      changeset = Unit.changeset(%Unit{}, attrs, "development")
+      changeset = Unit.changeset(%Unit{}, attrs)
       assert changeset.valid?
     end
 
     test "without required attributes for development" do
-      changeset = Unit.changeset(%Unit{}, %{}, "development")
+      changeset = Unit.changeset(%Unit{}, %{})
       refute changeset.valid?
 
       assert Keyword.get(changeset.errors, :price) == {"can't be blank", [validation: :required]}
@@ -70,7 +70,7 @@ defmodule Re.UnitTest do
     end
 
     test "with invalid attributes for development" do
-      changeset = Unit.changeset(%Unit{}, @invalid_attrs, "development")
+      changeset = Unit.changeset(%Unit{}, @invalid_attrs)
       refute changeset.valid?
 
       assert Keyword.get(changeset.errors, :price) ==

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -72,6 +72,9 @@ defmodule Re.UnitTest do
 
       assert Keyword.get(changeset.errors, :development_uuid) ==
                {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :listing_id) ==
+               {"can't be blank", [validation: :required]}
     end
 
     test "with invalid attributes for development" do

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -19,7 +19,8 @@ defmodule Re.UnitTest do
     balconies: 1,
     area: 150,
     garage_spots: 2,
-    garage_type: "contract"
+    garage_type: "contract",
+    status: "active"
   }
 
   @invalid_attrs %{
@@ -32,7 +33,8 @@ defmodule Re.UnitTest do
     dependencies: -1,
     garage_spots: -1,
     balconies: -1,
-    garage_type: "mine"
+    garage_type: "mine",
+    status: "invalid"
   }
 
   describe "changeset/3" do
@@ -75,6 +77,8 @@ defmodule Re.UnitTest do
 
       assert Keyword.get(changeset.errors, :listing_id) ==
                {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :status) == {"can't be blank", [validation: :required]}
     end
 
     test "with invalid attributes for development" do
@@ -119,6 +123,9 @@ defmodule Re.UnitTest do
 
       assert Keyword.get(changeset.errors, :garage_type) ==
                {"should be one of: [contract condominium]", [validation: :inclusion]}
+
+      assert Keyword.get(changeset.errors, :status) ==
+               {"should be one of: [active inactive]", [validation: :inclusion]}
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -23,13 +23,15 @@ defmodule Re.UtitsTest do
 
     test "insert new unit" do
       development = insert(:development)
+      listing = insert(:listing, development_uuid: development.uuid)
 
-      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development)
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
 
       retrieved_unit = Repo.get(Unit, inserted_unit.uuid)
 
       assert retrieved_unit == inserted_unit
       assert retrieved_unit.development_uuid == development.uuid
+      assert retrieved_unit.listing_id == listing.id
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -1,0 +1,29 @@
+defmodule Re.UtitsTest do
+  use Re.ModelCase
+
+  alias Re.{
+    Unit,
+    Units
+  }
+
+  import Re.Factory
+
+  describe "insert/2" do
+    @insert_unit_params %{
+      complement: "201",
+      price: 500_000,
+      rooms: 3,
+      bathrooms: 1,
+      area: 100,
+      garage_spots: 1,
+      garage_type: "contract",
+      suites: 1,
+      dependencies: 0
+    }
+
+    test "insert new unit" do
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, nil)
+      assert inserted_unit == Repo.get(Unit, inserted_unit.uuid)
+    end
+  end
+end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -18,7 +18,8 @@ defmodule Re.UtitsTest do
       garage_spots: 1,
       garage_type: "contract",
       dependencies: 0,
-      suites: 1
+      suites: 1,
+      status: "active"
     }
 
     test "insert new unit" do

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -17,13 +17,19 @@ defmodule Re.UtitsTest do
       area: 100,
       garage_spots: 1,
       garage_type: "contract",
-      suites: 1,
-      dependencies: 0
+      dependencies: 0,
+      suites: 1
     }
 
     test "insert new unit" do
-      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, nil)
-      assert inserted_unit == Repo.get(Unit, inserted_unit.uuid)
+      development = insert(:development)
+
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development)
+
+      retrieved_unit = Repo.get(Unit, inserted_unit.uuid)
+
+      assert retrieved_unit == inserted_unit
+      assert retrieved_unit.development_uuid == development.uuid
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -2,6 +2,7 @@ defmodule Re.UtitsTest do
   use Re.ModelCase
 
   alias Re.{
+    Listing,
     Unit,
     Units
   }
@@ -33,6 +34,40 @@ defmodule Re.UtitsTest do
       assert retrieved_unit == inserted_unit
       assert retrieved_unit.development_uuid == development.uuid
       assert retrieved_unit.listing_id == listing.id
+    end
+
+    test "replace listing price by unit price when unit price is lower than listing price" do
+      development = insert(:development)
+      listing = insert(:listing, price: 1_000_000, development_uuid: development.uuid)
+
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
+
+      listing = Repo.get(Listing, listing.id)
+
+      assert listing.price == 500_000
+    end
+
+    test "doesn't update listing price when unit price is higher than listing price" do
+      development = insert(:development)
+      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
+
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
+
+      listing = Repo.get(Listing, listing.id)
+
+      assert listing.price == 400_000
+    end
+
+    test "doesn't update listing price when unit is invalid" do
+      development = insert(:development)
+      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
+      invalid_attrs = Map.delete(@insert_unit_params, :price)
+
+      assert {:error, _} = Units.insert(invalid_attrs, development, listing)
+
+      listing = Repo.get(Listing, listing.id)
+
+      assert listing.price == 400_000
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -1,8 +1,7 @@
-defmodule Re.UtitsTest do
+defmodule Re.UnitsTest do
   use Re.ModelCase
 
   alias Re.{
-    Listing,
     Unit,
     Units
   }
@@ -34,40 +33,6 @@ defmodule Re.UtitsTest do
       assert retrieved_unit == inserted_unit
       assert retrieved_unit.development_uuid == development.uuid
       assert retrieved_unit.listing_id == listing.id
-    end
-
-    test "replace listing price by unit price when unit price is lower than listing price" do
-      development = insert(:development)
-      listing = insert(:listing, price: 1_000_000, development_uuid: development.uuid)
-
-      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
-
-      listing = Repo.get(Listing, listing.id)
-
-      assert listing.price == 500_000
-    end
-
-    test "doesn't update listing price when unit price is higher than listing price" do
-      development = insert(:development)
-      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
-
-      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
-
-      listing = Repo.get(Listing, listing.id)
-
-      assert listing.price == 400_000
-    end
-
-    test "doesn't update listing price when unit is invalid" do
-      development = insert(:development)
-      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
-      invalid_attrs = Map.delete(@insert_unit_params, :price)
-
-      assert {:error, _} = Units.insert(invalid_attrs, development, listing)
-
-      listing = Repo.get(Listing, listing.id)
-
-      assert listing.price == 400_000
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -2,6 +2,8 @@ defmodule Re.UnitsTest do
   use Re.ModelCase
 
   alias Re.{
+    Listing,
+    Listings.Units.Server,
     Unit,
     Units
   }
@@ -33,6 +35,19 @@ defmodule Re.UnitsTest do
       assert retrieved_unit == inserted_unit
       assert retrieved_unit.development_uuid == development.uuid
       assert retrieved_unit.listing_id == listing.id
+    end
+
+    test "update listing price" do
+      Server.start_link()
+      development = insert(:development)
+      listing = insert(:listing, development_uuid: development.uuid, price: 1_000_000)
+
+      assert {:ok, inserted_unit} = Units.insert(@insert_unit_params, development, listing)
+
+      GenServer.call(Server, :inspect)
+
+      listing = Repo.get(Listing, listing.id)
+      assert listing.price == 500_000
     end
   end
 end

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -6,13 +6,15 @@ defmodule ReWeb.Resolvers.Units do
 
   alias Re.{
     Developments,
+    Listings,
     Units
   }
 
-  def insert(%{input: unit_params}, %{context: %{current_user: current_user}}) do
-    with :ok <- Bodyguard.permit(Units, :create_unit, current_user, unit_params),
-         {:ok, development} <- get_development(unit_params),
-         {:ok, new_unit} <- Units.insert(unit_params, development) do
+  def insert(%{input: params}, %{context: %{current_user: current_user}}) do
+    with :ok <- Bodyguard.permit(Units, :create_unit, current_user, params),
+         {:ok, development} <- get_development(params),
+         {:ok, listing} <- get_listing(params),
+         {:ok, new_unit} <- Units.insert(params, development, listing) do
       {:ok, new_unit}
     else
       {:error, _, error, _} -> {:error, error}
@@ -30,4 +32,7 @@ defmodule ReWeb.Resolvers.Units do
 
   defp get_development(%{development_uuid: uuid}), do: Developments.get(uuid)
   defp get_development(_), do: {:error, :bad_request}
+
+  defp get_listing(%{listing_id: id}), do: Listings.get(id)
+  defp get_listing(_), do: {:error, :bad_request}
 end

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -9,9 +9,8 @@ defmodule ReWeb.Resolvers.Units do
     Units
   }
 
-  def insert(%{input: unit_params}, %{context: %{current_user: _current_user}}) do
-    with :ok <- :ok,
-         # with :ok <- Bodyguard.permit(Units, :create_unit, current_user, unit_params),
+  def insert(%{input: unit_params}, %{context: %{current_user: current_user}}) do
+    with :ok <- Bodyguard.permit(Units, :create_unit, current_user, unit_params),
          {:ok, development} <- get_development(unit_params),
          {:ok, new_unit} <- Units.insert(unit_params, development) do
       {:ok, new_unit}

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -5,8 +5,21 @@ defmodule ReWeb.Resolvers.Units do
   import Absinthe.Resolution.Helpers, only: [on_load: 2]
 
   alias Re.{
+    Developments,
     Units
   }
+
+  def insert(%{input: unit_params}, %{context: %{current_user: _current_user}}) do
+    with :ok <- :ok,
+         # with :ok <- Bodyguard.permit(Units, :create_unit, current_user, unit_params),
+         {:ok, development} <- get_development(unit_params),
+         {:ok, new_unit} <- Units.insert(unit_params, development) do
+      {:ok, new_unit}
+    else
+      {:error, _, error, _} -> {:error, error}
+      error -> error
+    end
+  end
 
   def per_listing(listing, _params, %{context: %{loader: loader}}) do
     loader
@@ -15,4 +28,7 @@ defmodule ReWeb.Resolvers.Units do
       {:ok, Dataloader.get(loader, Units, :units, listing)}
     end)
   end
+
+  defp get_development(%{development_uuid: uuid}), do: Developments.get(uuid)
+  defp get_development(_), do: {:error, :bad_request}
 end

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -43,6 +43,7 @@ defmodule ReWeb.Schema do
     import_fields(:dashboard_mutations)
     import_fields(:calendar_mutations)
     import_fields(:development_mutations)
+    import_fields(:unit_mutations)
   end
 
   subscription do

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -49,7 +49,7 @@ defmodule ReWeb.Types.Image do
   end
 
   object :image_mutations do
-    @desc "Inser image"
+    @desc "Insert image"
     field :insert_image, type: :image_output do
       arg :input, non_null(:image_insert_input)
 

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -4,6 +4,8 @@ defmodule ReWeb.Types.Unit do
   """
   use Absinthe.Schema.Notation
 
+  alias ReWeb.Resolvers
+
   object :unit do
     field :uuid, :uuid
     field :complement, :string
@@ -20,5 +22,34 @@ defmodule ReWeb.Types.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
+
+    # add development_assoc
+  end
+
+  input_object :unit_input do
+    field :complement, :string
+    field :price, :integer
+    field :property_tax, :float
+    field :maintenance_fee, :float
+    field :floor, :string
+    field :rooms, :integer
+    field :bathrooms, :integer
+    field :restrooms, :integer
+    field :area, :integer
+    field :garage_spots, :integer
+    field :garage_type, :string
+    field :suites, :integer
+    field :dependencies, :integer
+    field :balconies, :integer
+    field :development_uuid, :uuid
+  end
+
+  object :unit_mutations do
+    @desc "Insert unit"
+    field :insert_unit, type: :unit do
+      arg :input, non_null(:unit_input)
+
+      resolve &Resolvers.Units.insert/2
+    end
   end
 end

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -22,8 +22,6 @@ defmodule ReWeb.Types.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
-
-    # add development_assoc
   end
 
   input_object :unit_input do

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -47,7 +47,7 @@ defmodule ReWeb.Types.Unit do
 
   object :unit_mutations do
     @desc "Insert unit"
-    field :insert_unit, type: :unit do
+    field :add_unit, type: :unit do
       arg :input, non_null(:unit_input)
 
       resolve &Resolvers.Units.insert/2

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -39,7 +39,8 @@ defmodule ReWeb.Types.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
-    field :development_uuid, :uuid
+    field :development_uuid, non_null(:uuid)
+    field :listing_id, non_null(:id)
   end
 
   object :unit_mutations do

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -22,6 +22,7 @@ defmodule ReWeb.Types.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
+    field :status, :string
   end
 
   input_object :unit_input do
@@ -39,6 +40,7 @@ defmodule ReWeb.Types.Unit do
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer
+    field :status, :string
     field :development_uuid, non_null(:uuid)
     field :listing_id, non_null(:id)
   end

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -1,0 +1,107 @@
+defmodule ReWeb.GraphQL.Units.MutationTest do
+  use ReWeb.{AbsintheAssertions, ConnCase}
+
+  import Re.Factory
+
+  alias ReWeb.{
+    AbsintheHelpers
+  }
+
+  setup %{conn: conn} do
+    conn = put_req_header(conn, "accept", "application/json")
+    admin_user = insert(:user, email: "admin@email.com", role: "admin")
+    user_user = insert(:user, email: "user@email.com", role: "user")
+    development = insert(:development)
+
+    unit = build(:unit)
+
+    {:ok,
+     unauthenticated_conn: conn,
+     admin_conn: login_as(conn, admin_user),
+     user_conn: login_as(conn, user_user),
+     old_development: insert(:development),
+     unit: unit,
+     development: development}
+  end
+
+  # todo add devolpment on this query
+  describe "insert/2" do
+    @insert_mutation """
+      mutation InsertUnit ($input: UnitInput!) {
+        insertUnit(input: $input) {
+          uuid
+          complement
+          price
+          property_tax
+          maintenance_fee
+          floor
+          rooms
+          bathrooms
+          restrooms
+          area
+          garage_spots
+          garage_type
+          suites
+          dependencies
+          balconies
+          }
+        }
+    """
+    test "admin should insert unit", %{
+      admin_conn: conn,
+      unit: unit,
+      development: development
+    } do
+      variables = insert_unit_variables(unit, development)
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
+
+      # todo review association name
+      assert %{
+               "insertUnit" => insert_unit
+               #  "insertUnit" => %{"development" => inserted_development} = insert_unit
+             } = json_response(conn, 200)["data"]
+
+      assert insert_unit["uuid"]
+      assert insert_unit["complement"] == unit.complement
+      assert insert_unit["price"] == unit.price
+      assert insert_unit["property_tax"] == unit.property_tax
+      assert insert_unit["maintenance_fee"] == unit.maintenance_fee
+      assert insert_unit["floor"] == unit.floor
+      assert insert_unit["rooms"] == unit.rooms
+      assert insert_unit["bathrooms"] == unit.bathrooms
+      assert insert_unit["restrooms"] == unit.restrooms
+      assert insert_unit["area"] == unit.area
+      assert insert_unit["garage_spots"] == unit.garage_spots
+      assert insert_unit["garage_type"] == unit.garage_type
+      assert insert_unit["suites"] == unit.suites
+      assert insert_unit["dependencies"] == unit.dependencies
+      assert insert_unit["balconies"] == unit.balconies
+
+      # assert inserted_address["id"] == Integer.to_string(address.id)
+    end
+  end
+
+  def insert_unit_variables(unit, development) do
+    %{
+      "input" => %{
+        "complement" => unit.complement,
+        "price" => unit.price,
+        "property_tax" => unit.property_tax,
+        "maintenance_fee" => unit.maintenance_fee,
+        "floor" => unit.floor,
+        "rooms" => unit.rooms,
+        "bathrooms" => unit.bathrooms,
+        "restrooms" => unit.restrooms,
+        "area" => unit.area,
+        "garage_spots" => unit.garage_spots,
+        "garage_type" => unit.garage_type,
+        "suites" => unit.suites,
+        "dependencies" => unit.dependencies,
+        "balconies" => unit.balconies,
+        "development_uuid" => development.uuid
+      }
+    }
+  end
+end

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -12,6 +12,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     admin_user = insert(:user, email: "admin@email.com", role: "admin")
     user_user = insert(:user, email: "user@email.com", role: "user")
     development = insert(:development)
+    listing = insert(:listing, development: development)
 
     unit = build(:unit)
 
@@ -21,7 +22,8 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       admin_conn: login_as(conn, admin_user),
       user_conn: login_as(conn, user_user),
       unit: unit,
-      development: development
+      development: development,
+      listing: listing
     }
   end
 
@@ -51,9 +53,10 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     test "admin should insert unit", %{
       admin_conn: conn,
       unit: unit,
-      development: development
+      development: development,
+      listing: listing
     } do
-      variables = insert_unit_variables(unit, development)
+      variables = insert_unit_variables(unit, development, listing)
 
       conn =
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
@@ -82,9 +85,10 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     test "regular user should not insert unit", %{
       user_conn: conn,
       unit: unit,
-      development: development
+      development: development,
+      listing: listing
     } do
-      variables = insert_unit_variables(unit, development)
+      variables = insert_unit_variables(unit, development, listing)
 
       conn =
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
@@ -97,9 +101,10 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     test "unauthenticated user should not insert unit", %{
       unauthenticated_conn: conn,
       unit: unit,
-      development: development
+      development: development,
+      listing: listing
     } do
-      variables = insert_unit_variables(unit, development)
+      variables = insert_unit_variables(unit, development, listing)
 
       conn =
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
@@ -110,7 +115,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     end
   end
 
-  def insert_unit_variables(unit, development) do
+  def insert_unit_variables(unit, development, listing) do
     %{
       "input" => %{
         "complement" => unit.complement,
@@ -127,7 +132,8 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
         "suites" => unit.suites,
         "dependencies" => unit.dependencies,
         "balconies" => unit.balconies,
-        "development_uuid" => development.uuid
+        "development_uuid" => development.uuid,
+        "listing_id" => listing.id
       }
     }
   end

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -46,6 +46,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
           suites
           dependencies
           balconies
+          status
           }
         }
     """
@@ -132,6 +133,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
         "suites" => unit.suites,
         "dependencies" => unit.dependencies,
         "balconies" => unit.balconies,
+        "status" => unit.status,
         "development_uuid" => development.uuid,
         "listing_id" => listing.id
       }

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -33,8 +33,8 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
 
   describe "insert/2" do
     @insert_mutation """
-      mutation InsertUnit ($input: UnitInput!) {
-        insertUnit(input: $input) {
+      mutation AddUnit ($input: UnitInput!) {
+        addUnit(input: $input) {
           uuid
           complement
           price
@@ -55,7 +55,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
         }
     """
 
-    test "admin should insert unit", %{
+    test "admin should add unit", %{
       admin_conn: conn,
       unit_params: unit_params
     } do
@@ -65,7 +65,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert %{
-               "insertUnit" => insert_unit
+               "addUnit" => insert_unit
              } = json_response(conn, 200)["data"]
 
       assert insert_unit["uuid"]
@@ -86,7 +86,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       assert insert_unit["status"] == unit_params["status"]
     end
 
-    test "regular user should not insert unit", %{
+    test "regular user should not add unit", %{
       user_conn: conn,
       unit_params: unit_params
     } do
@@ -95,12 +95,12 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       conn =
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
-      assert %{"insertUnit" => nil} == json_response(conn, 200)["data"]
+      assert %{"addUnit" => nil} == json_response(conn, 200)["data"]
 
       assert_forbidden_response(json_response(conn, 200))
     end
 
-    test "unauthenticated user should not insert unit", %{
+    test "unauthenticated user should not add unit", %{
       unauthenticated_conn: conn,
       unit_params: unit_params
     } do
@@ -109,7 +109,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       conn =
         post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
-      assert %{"insertUnit" => nil} == json_response(conn, 200)["data"]
+      assert %{"addUnit" => nil} == json_response(conn, 200)["data"]
 
       assert_unauthorized_response(json_response(conn, 200))
     end


### PR DESCRIPTION
Add GraphQL mutation to insert new units, as well all dependent logic (policy, context insertion, etc), also add the following structural changes: 
- Add relation between unit and development. 
- Add status attribute on units. 

Another thing that isn't a requirement but we agree is good enough until all filters are reimplemented on units is: development listings will use the lowest unit price by now. 