### PR TITLE
Adding Facebook Dynamic Product Ads exporter

### DIFF
--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -1,0 +1,133 @@
+defmodule Re.Exporters.FacebookAds.Product do
+  @moduledoc """
+  Listing XML exporter for Facebook Dynamic Product Ads
+  https://developers.facebook.com/docs/marketing-api/dynamic-product-ads/product-catalog
+  """
+
+  @exported_attributes ~w(id url title sell_type condition brand description price
+  listing_type address rooms bathrooms area image)a
+  @default_options %{attributes: @exported_attributes}
+
+  @frontend_url Application.get_env(:re_integrations, :frontend_url)
+  @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+
+  def export_listings_xml(listings, options \\ %{}) do
+    options = merge_default_options(options)
+
+    listings
+    |> Enum.map(&build_node(&1, options))
+    |> build_root()
+    |> XmlBuilder.document()
+    |> XmlBuilder.generate(format: :none)
+  end
+
+  def merge_default_options(options) do
+    Map.merge(@default_options, options)
+  end
+
+  def build_node(listing, options) do
+    {"entry", %{}, convert_attributes(listing, options)}
+  end
+
+  defp build_root(nodes) do
+    {"feed", %{xmlns: "http://www.w3.org/2005/Atom"}, nodes}
+  end
+
+  def convert_attributes(listing, %{attributes: attributes}) do
+    Enum.map(attributes, &convert_attribute_with_cdata(&1, listing))
+  end
+
+  defp convert_attribute_with_cdata(attr, listing) do
+    {tag, attrs, value} = convert_attribute(attr, listing)
+    {tag, attrs, escape_cdata(value)}
+  end
+
+  defp convert_attribute(:id, %{id: id}) do
+    {"id", %{}, id}
+  end
+
+  defp convert_attribute(:url, %{id: id}) do
+    {"link", %{}, build_url(@frontend_url, "/imoveis/", to_string(id))}
+  end
+
+  defp convert_attribute(:title, %{type: type, address: %{city: city}}) do
+    {"title", %{}, "#{type} a venda em #{city}"}
+  end
+
+  defp convert_attribute(:sell_type, _) do
+    {"availability", %{}, "in stock"}
+  end
+
+  defp convert_attribute(:condition, _) do
+    {"condition", %{}, "new"}
+  end
+
+  defp convert_attribute(:brand, _) do
+    {"brand", %{}, "EmCasa"}
+  end
+
+  defp convert_attribute(:description, %{description: description}) do
+    {"description", %{}, description}
+  end
+
+  defp convert_attribute(:price, %{price: price}) do
+    {"price", %{}, "#{price} BRL"}
+  end
+
+  defp convert_attribute(:image, %{images: []}) do
+    {"image_link", %{}, nil}
+  end
+
+  defp convert_attribute(:image, %{images: images}) do
+    first_image = Enum.at(images, 0)
+
+    {
+      "image_link",
+      %{},
+      "#{@image_url}/#{first_image.filename}"
+    }
+  end
+
+  defp convert_attribute(:listing_type, %{type: type}) do
+    {"custom_label_0", %{}, type}
+  end
+
+  defp convert_attribute(:address, %{address: address}) do
+    {
+      "custom_label_1",
+      %{},
+      "#{address.street}, #{address.neighborhood}"
+    }
+  end
+
+  defp convert_attribute(:rooms, %{rooms: rooms}) do
+    {"custom_label_2", %{}, rooms || 0}
+  end
+
+  defp convert_attribute(:bathrooms, %{bathrooms: bathrooms}) do
+    {"custom_label_3", %{}, bathrooms || 0}
+  end
+
+  defp convert_attribute(:area, %{area: area}) do
+    {"custom_label_4", %{}, area}
+  end
+
+  defp escape_cdata(nil) do
+    nil
+  end
+
+  defp escape_cdata(value) when is_binary(value) do
+    {:cdata, value}
+  end
+
+  defp escape_cdata(value) do
+    escape_cdata(to_string(value))
+  end
+
+  defp build_url(host, path, param) do
+    host
+    |> URI.merge(path)
+    |> URI.merge(param)
+    |> URI.to_string()
+  end
+end

--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -5,7 +5,7 @@ defmodule Re.Exporters.FacebookAds.Product do
   """
 
   @exported_attributes ~w(id url title sell_type condition brand description price
-  listing_type address rooms bathrooms area image additional_image)a
+  listing_type street neighborhood rooms bathrooms area image additional_image)a
   @default_options %{attributes: @exported_attributes}
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
@@ -112,14 +112,22 @@ defmodule Re.Exporters.FacebookAds.Product do
   end
 
   defp convert_attribute(:listing_type, %{type: type}) do
-    {"custom_label_0", %{}, type}
+    {"product_type", %{}, type}
   end
 
-  defp convert_attribute(:address, %{address: address}) do
+  defp convert_attribute(:street, %{address: address}) do
+    {
+      "custom_label_0",
+      %{},
+      address.street
+    }
+  end
+
+  defp convert_attribute(:neighborhood, %{address: address}) do
     {
       "custom_label_1",
       %{},
-      "#{address.street}, #{address.neighborhood}"
+      address.neighborhood
     }
   end
 

--- a/apps/re/lib/exporters/facebook_ads/real_estate.ex
+++ b/apps/re/lib/exporters/facebook_ads/real_estate.ex
@@ -5,7 +5,7 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
   """
 
   @exported_attributes ~w(id url title sell_type description price listing_type
-    rooms bathrooms units area_unit area address latitude longitude image)a
+    rooms bathrooms units area_unit area neighborhood address latitude longitude image)a
   @default_options %{attributes: @exported_attributes}
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
@@ -108,11 +108,15 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
       [
         {"component", %{name: "addr1"}, escape_cdata("#{address.street}")},
         {"component", %{name: "city"}, escape_cdata("#{address.city}")},
-        {"component", %{name: "region"}, escape_cdata("#{address.neighborhood}")},
+        {"component", %{name: "region"}, escape_cdata("#{address.state}")},
         {"component", %{name: "country"}, escape_cdata("Brazil")},
         {"component", %{name: "postal_code"}, escape_cdata("#{address.postal_code}")}
       ]
     }
+  end
+
+  defp convert_attribute(:neighborhood, %{address: address}) do
+    {"neighborhood", %{}, address.neighborhood}
   end
 
   defp convert_attribute(:latitude, %{address: %{lat: lat}}) do

--- a/apps/re/lib/exporters/facebook_ads/real_estate.ex
+++ b/apps/re/lib/exporters/facebook_ads/real_estate.ex
@@ -1,6 +1,7 @@
-defmodule Re.Exporters.FacebookAds do
+defmodule Re.Exporters.FacebookAds.RealEstate do
   @moduledoc """
-  Listing XML exporter for Facebook Ads.
+  Listing XML exporter for Facebook Dynamic Ads for Real Estate
+  https://developers.facebook.com/docs/marketing-api/dynamic-ads-for-real-estate
   """
 
   @exported_attributes ~w(id url title sell_type description price listing_type

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -60,8 +60,9 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
-          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
-          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<product_type><![CDATA[Apartamento]]></product_type>" <>
+          "<custom_label_0><![CDATA[Rua do Ipiranga]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
           "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
@@ -116,8 +117,9 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
-          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
-          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<product_type><![CDATA[Apartamento]]></product_type>" <>
+          "<custom_label_0><![CDATA[Rua do Ipiranga]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
           "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
@@ -165,8 +167,9 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
-          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
-          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<product_type><![CDATA[Apartamento]]></product_type>" <>
+          "<custom_label_0><![CDATA[Rua do Ipiranga]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
           "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
@@ -213,8 +216,9 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
-          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
-          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<product_type><![CDATA[Apartamento]]></product_type>" <>
+          "<custom_label_0><![CDATA[Rua do Ipiranga]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[0]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[0]]></custom_label_3>" <>
           "<custom_label_4><![CDATA[300]]></custom_label_4>" <>

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -1,0 +1,181 @@
+defmodule Re.Exporters.FacebookAds.ProductTest do
+  use Re.ModelCase
+
+  alias Re.{
+    Exporters.FacebookAds,
+    Image,
+    Address,
+    Listing
+  }
+
+  @frontend_url Application.get_env(:re_integrations, :frontend_url)
+  @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+
+  describe "build_node/2" do
+    test "export XML including listing first image" do
+      listing = %Listing{
+        id: 7_004_578,
+        price: 800,
+        type: "Apartamento",
+        area: 300,
+        rooms: 4,
+        bathrooms: 4,
+        description:
+          "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+        address: %Address{
+          street: "Rua do Ipiranga",
+          street_number: 20,
+          neighborhood: "Ipiranga",
+          city: "São Paulo",
+          state: "SP",
+          postal_code: "04732-192",
+          lat: 51.496401,
+          lng: -0.179
+        },
+        matterport_code: "mY123",
+        images: [
+          %Image{
+            filename: "living_room.png",
+            description: "Living room"
+          },
+          %Image{
+            filename: "suite_1.png",
+            description: nil
+          }
+        ]
+      }
+
+      expected_xml =
+        "<entry>" <>
+          "<id><![CDATA[7004578]]></id>" <>
+          "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
+          "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
+          "<availability><![CDATA[in stock]]></availability>" <>
+          "<condition><![CDATA[new]]></condition>" <>
+          "<brand><![CDATA[EmCasa]]></brand>" <>
+          "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
+          "<price><![CDATA[800 BRL]]></price>" <>
+          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
+          "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
+          "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <> "</entry>"
+
+      generated_xml =
+        listing
+        |> FacebookAds.Product.build_node(FacebookAds.Product.merge_default_options(%{}))
+        |> XmlBuilder.generate(format: :none)
+
+      assert expected_xml == generated_xml
+    end
+
+    test "export XML without images from listing" do
+      listing = %Listing{
+        id: 7_004_578,
+        price: 800,
+        type: "Apartamento",
+        area: 300,
+        rooms: 4,
+        bathrooms: 4,
+        description:
+          "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+        address: %Address{
+          street: "Rua do Ipiranga",
+          street_number: 20,
+          neighborhood: "Ipiranga",
+          city: "São Paulo",
+          state: "SP",
+          postal_code: "04732-192",
+          lat: 51.496401,
+          lng: -0.179
+        },
+        images: []
+      }
+
+      expected_xml =
+        "<entry>" <>
+          "<id><![CDATA[7004578]]></id>" <>
+          "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
+          "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
+          "<availability><![CDATA[in stock]]></availability>" <>
+          "<condition><![CDATA[new]]></condition>" <>
+          "<brand><![CDATA[EmCasa]]></brand>" <>
+          "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
+          "<price><![CDATA[800 BRL]]></price>" <>
+          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
+          "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <> "<image_link/>" <> "</entry>"
+
+      generated_xml =
+        listing
+        |> FacebookAds.Product.build_node(FacebookAds.Product.merge_default_options(%{}))
+        |> XmlBuilder.generate(format: :none)
+
+      assert expected_xml == generated_xml
+    end
+
+    test "export XML without rooms/bathroms from listing" do
+      listing = %Listing{
+        id: 7_004_578,
+        price: 800,
+        type: "Apartamento",
+        area: 300,
+        rooms: nil,
+        bathrooms: nil,
+        description:
+          "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+        address: %Address{
+          street: "Rua do Ipiranga",
+          street_number: 20,
+          neighborhood: "Ipiranga",
+          city: "São Paulo",
+          state: "SP",
+          postal_code: "04732-192",
+          lat: 51.496401,
+          lng: -0.179
+        },
+        images: []
+      }
+
+      expected_xml =
+        "<entry>" <>
+          "<id><![CDATA[7004578]]></id>" <>
+          "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
+          "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
+          "<availability><![CDATA[in stock]]></availability>" <>
+          "<condition><![CDATA[new]]></condition>" <>
+          "<brand><![CDATA[EmCasa]]></brand>" <>
+          "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
+          "<price><![CDATA[800 BRL]]></price>" <>
+          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<custom_label_2><![CDATA[0]]></custom_label_2>" <>
+          "<custom_label_3><![CDATA[0]]></custom_label_3>" <>
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <> "<image_link/>" <> "</entry>"
+
+      generated_xml =
+        listing
+        |> FacebookAds.Product.build_node(FacebookAds.Product.merge_default_options(%{}))
+        |> XmlBuilder.generate(format: :none)
+
+      assert expected_xml == generated_xml
+    end
+  end
+
+  describe "export_listing/1" do
+    test "export listing with proper root node" do
+      expected_xml =
+        ~s|<?xml version="1.0" encoding="UTF-8"?>| <>
+          "<feed xmlns=\"http://www.w3.org/2005/Atom\">" <>
+          "<entry><id><![CDATA[1]]></id></entry></feed>"
+
+      generated_xml =
+        FacebookAds.Product.export_listings_xml([%Listing{id: 1}], %{attributes: [:id]})
+
+      assert expected_xml == generated_xml
+    end
+  end
+end

--- a/apps/re/test/exporters/facebook_ads/real_estate_test.exs
+++ b/apps/re/test/exporters/facebook_ads/real_estate_test.exs
@@ -60,10 +60,11 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
           "<num_units><![CDATA[1]]></num_units>" <>
           "<area_unit><![CDATA[sq_m]]></area_unit>" <>
           "<area_size><![CDATA[300]]></area_size>" <>
+          "<neighborhood><![CDATA[Ipiranga]]></neighborhood>" <>
           "<address format=\"simple\">" <>
           "<component name=\"addr1\"><![CDATA[Rua do Ipiranga]]></component>" <>
           "<component name=\"city\"><![CDATA[São Paulo]]></component>" <>
-          "<component name=\"region\"><![CDATA[Ipiranga]]></component>" <>
+          "<component name=\"region\"><![CDATA[SP]]></component>" <>
           "<component name=\"country\"><![CDATA[Brazil]]></component>" <>
           "<component name=\"postal_code\"><![CDATA[04732-192]]></component>" <>
           "</address>" <>
@@ -120,10 +121,11 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
           "<num_units><![CDATA[1]]></num_units>" <>
           "<area_unit><![CDATA[sq_m]]></area_unit>" <>
           "<area_size><![CDATA[300]]></area_size>" <>
+          "<neighborhood><![CDATA[Ipiranga]]></neighborhood>" <>
           "<address format=\"simple\">" <>
           "<component name=\"addr1\"><![CDATA[Rua do Ipiranga]]></component>" <>
           "<component name=\"city\"><![CDATA[São Paulo]]></component>" <>
-          "<component name=\"region\"><![CDATA[Ipiranga]]></component>" <>
+          "<component name=\"region\"><![CDATA[SP]]></component>" <>
           "<component name=\"country\"><![CDATA[Brazil]]></component>" <>
           "<component name=\"postal_code\"><![CDATA[04732-192]]></component>" <>
           "</address>" <>
@@ -175,10 +177,11 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
           "<num_units><![CDATA[1]]></num_units>" <>
           "<area_unit><![CDATA[sq_m]]></area_unit>" <>
           "<area_size><![CDATA[300]]></area_size>" <>
+          "<neighborhood><![CDATA[Ipiranga]]></neighborhood>" <>
           "<address format=\"simple\">" <>
           "<component name=\"addr1\"><![CDATA[Rua do Ipiranga]]></component>" <>
           "<component name=\"city\"><![CDATA[São Paulo]]></component>" <>
-          "<component name=\"region\"><![CDATA[Ipiranga]]></component>" <>
+          "<component name=\"region\"><![CDATA[SP]]></component>" <>
           "<component name=\"country\"><![CDATA[Brazil]]></component>" <>
           "<component name=\"postal_code\"><![CDATA[04732-192]]></component>" <>
           "</address>" <>

--- a/apps/re/test/exporters/facebook_ads/real_estate_test.exs
+++ b/apps/re/test/exporters/facebook_ads/real_estate_test.exs
@@ -1,4 +1,4 @@
-defmodule Re.Exporters.FacebookAdsTest do
+defmodule Re.Exporters.FacebookAds.RealEstateTest do
   use Re.ModelCase
 
   alias Re.{
@@ -73,7 +73,7 @@ defmodule Re.Exporters.FacebookAdsTest do
 
       generated_xml =
         listing
-        |> FacebookAds.build_node(FacebookAds.merge_default_options(%{}))
+        |> FacebookAds.RealEstate.build_node(FacebookAds.RealEstate.merge_default_options(%{}))
         |> XmlBuilder.generate(format: :none)
 
       assert expected_xml == generated_xml
@@ -128,7 +128,7 @@ defmodule Re.Exporters.FacebookAdsTest do
 
       generated_xml =
         listing
-        |> FacebookAds.build_node(FacebookAds.merge_default_options(%{}))
+        |> FacebookAds.RealEstate.build_node(FacebookAds.RealEstate.merge_default_options(%{}))
         |> XmlBuilder.generate(format: :none)
 
       assert expected_xml == generated_xml
@@ -183,7 +183,7 @@ defmodule Re.Exporters.FacebookAdsTest do
 
       generated_xml =
         listing
-        |> FacebookAds.build_node(FacebookAds.merge_default_options(%{}))
+        |> FacebookAds.RealEstate.build_node(FacebookAds.RealEstate.merge_default_options(%{}))
         |> XmlBuilder.generate(format: :none)
 
       assert expected_xml == generated_xml
@@ -196,7 +196,8 @@ defmodule Re.Exporters.FacebookAdsTest do
         ~s|<?xml version="1.0" encoding="UTF-8"?>| <>
           "<listings><listing><home_listing_id><![CDATA[1]]></home_listing_id></listing></listings>"
 
-      generated_xml = FacebookAds.export_listings_xml([%Listing{id: 1}], %{attributes: [:id]})
+      generated_xml =
+        FacebookAds.RealEstate.export_listings_xml([%Listing{id: 1}], %{attributes: [:id]})
 
       assert expected_xml == generated_xml
     end

--- a/apps/re_web/lib/exporters/facebook_ads/plug.ex
+++ b/apps/re_web/lib/exporters/facebook_ads/plug.ex
@@ -20,7 +20,7 @@ defmodule ReWeb.Exporters.FacebookAds.Plug do
     xml_listings =
       filters
       |> Exporter.exportable(query_params)
-      |> FacebookAds.export_listings_xml()
+      |> FacebookAds.RealEstate.export_listings_xml()
 
     conn
     |> put_resp_content_type("application/xml")

--- a/apps/re_web/lib/exporters/facebook_ads/plug.ex
+++ b/apps/re_web/lib/exporters/facebook_ads/plug.ex
@@ -12,7 +12,8 @@ defmodule ReWeb.Exporters.FacebookAds.Plug do
   def init(args), do: args
 
   def call(
-        %Plug.Conn{path_info: [state_slug, city_slug], query_params: query_params} = conn,
+        %Plug.Conn{path_info: ["real-estate", state_slug, city_slug], query_params: query_params} =
+          conn,
         _args
       ) do
     filters = %{cities_slug: [city_slug], states_slug: [state_slug]}
@@ -27,9 +28,26 @@ defmodule ReWeb.Exporters.FacebookAds.Plug do
     |> send_resp(200, xml_listings)
   end
 
+  def call(
+        %Plug.Conn{path_info: ["product", state_slug, city_slug], query_params: query_params} =
+          conn,
+        _args
+      ) do
+    filters = %{cities_slug: [city_slug], states_slug: [state_slug]}
+
+    xml_listings =
+      filters
+      |> Exporter.exportable(query_params)
+      |> FacebookAds.Product.export_listings_xml()
+
+    conn
+    |> put_resp_content_type("application/xml")
+    |> send_resp(200, xml_listings)
+  end
+
   def call(conn, _args) do
     error_response =
-      {"error", "Expect state and city on path"}
+      {"error", "Expect FacebookAds type, state and city on path"}
       |> XmlBuilder.document()
       |> XmlBuilder.generate(format: :none)
 

--- a/apps/re_web/test/exporters/facebook_ads/plug_test.exs
+++ b/apps/re_web/test/exporters/facebook_ads/plug_test.exs
@@ -5,26 +5,39 @@ defmodule ReWeb.Exporters.FacebookAds.PlugTest do
     {:ok, conn: conn}
   end
 
-  @empty_listings ~s|<?xml version="1.0" encoding="UTF-8"?><listings/>|
-  @error_message ~s|<?xml version="1.0" encoding="UTF-8"?><error>Expect state and city on path</error>|
+  @empty_real_estate ~s|<?xml version="1.0" encoding="UTF-8"?><listings/>|
+  @empty_product ~s|<?xml version="1.0" encoding="UTF-8"?><feed xmlns=\"http://www.w3.org/2005/Atom\"/>|
+  @error_message ~s|<?xml version="1.0" encoding="UTF-8"?><error>Expect FacebookAds type, state and city on path</error>|
 
   describe "with active city and state slugs on path" do
-    test "should render listings XML", %{conn: conn} do
-      conn = get(conn, "/exporters/facebook-ads/rj/rio-de-janeiro")
+    test "should render listings XML for real estate", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/real-estate/rj/rio-de-janeiro")
 
-      assert response(conn, 200) == @empty_listings
+      assert response(conn, 200) == @empty_real_estate
+    end
+
+    test "should render listings XML for product", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/product/rj/rio-de-janeiro")
+
+      assert response(conn, 200) == @empty_product
     end
   end
 
   describe "with nonexistent city and state slugs on path" do
-    test "should return an empty XML", %{conn: conn} do
-      conn = get(conn, "/exporters/facebook-ads/rs/porto-alegre")
+    test "should return an empty XML for real estate", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/real-estate/rs/porto-alegre")
 
-      assert response(conn, 200) == @empty_listings
+      assert response(conn, 200) == @empty_real_estate
+    end
+
+    test "should return an empty XML for product", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/product/rs/porto-alegre")
+
+      assert response(conn, 200) == @empty_product
     end
   end
 
-  describe "without city and state slugs on path" do
+  describe "without type, city and state slugs on path" do
     test "should return not found error", %{conn: conn} do
       conn = get(conn, "/exporters/facebook-ads")
 
@@ -33,8 +46,14 @@ defmodule ReWeb.Exporters.FacebookAds.PlugTest do
   end
 
   describe "with invalid slug" do
-    test "should return not found error", %{conn: conn} do
-      conn = get(conn, "/exporters/facebook-ads/invalid")
+    test "should return not found error for real estate", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/real-estate/invalid")
+
+      assert response(conn, 404) == @error_message
+    end
+
+    test "should return not found error for product", %{conn: conn} do
+      conn = get(conn, "/exporters/facebook-ads/product/invalid")
 
       assert response(conn, 404) == @error_message
     end


### PR DESCRIPTION
After introducing Facebook Dynamic Ads for Real Estate https://github.com/emcasa/backend/pull/444, we're now adding support for [Facebook Dynamic Product Ads](https://developers.facebook.com/docs/marketing-api/dynamic-product-ads/product-catalog)

* Renamed `Re.Exporters.FacebookAds` to `Re.Exporters.FacebookAds.RealEstate`
* Added `Re.Exporters.FacebookAds.Product`
* Changed `ReWeb.Exporters.FacebookAds.Plug` to support both formats:
  * `/exporters/facebook-ads/real-estate/<slug>/<city>`
  * `/exporters/facebook-ads/product/<slug>/<city>`
