### PR TITLE
Export all listing images on FacebookAds exporter

### DIFF
--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -5,7 +5,7 @@ defmodule Re.Exporters.FacebookAds.Product do
   """
 
   @exported_attributes ~w(id url title sell_type condition brand description price
-  listing_type address rooms bathrooms area image)a
+  listing_type address rooms bathrooms area image additional_image)a
   @default_options %{attributes: @exported_attributes}
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
@@ -92,6 +92,20 @@ defmodule Re.Exporters.FacebookAds.Product do
     }
   end
 
+  defp convert_attribute(:additional_image, %{images: []}) do
+    {"additional_image_link", %{}, nil}
+  end
+
+  defp convert_attribute(:additional_image, %{images: images}) do
+    additional_images = Enum.slice(images, 1..20)
+
+    {
+      "additional_image_link",
+      %{},
+      Enum.join(additional_images |> Enum.map(&build_image_url(&1)), ",")
+    }
+  end
+
   defp convert_attribute(:listing_type, %{type: type}) do
     {"custom_label_0", %{}, type}
   end
@@ -133,5 +147,9 @@ defmodule Re.Exporters.FacebookAds.Product do
     |> URI.merge(path)
     |> URI.merge(param)
     |> URI.to_string()
+  end
+
+  defp build_image_url(image) do
+    "#{@image_url}/#{image.filename}"
   end
 end

--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -10,6 +10,7 @@ defmodule Re.Exporters.FacebookAds.Product do
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+  @max_additional_images 20
 
   def export_listings_xml(listings, options \\ %{}) do
     options = merge_default_options(options)
@@ -31,6 +32,16 @@ defmodule Re.Exporters.FacebookAds.Product do
 
   def build_node(listing, options) do
     {"entry", %{}, convert_attributes(listing, options)}
+  end
+
+  def build_additional_image_node(images) do
+    additional_images = Enum.slice(images, 1, @max_additional_images)
+
+    {
+      "additional_image_link",
+      %{},
+      Enum.join(additional_images |> Enum.map(&build_image_url(&1)), ",")
+    }
   end
 
   defp build_root(nodes) do
@@ -97,13 +108,7 @@ defmodule Re.Exporters.FacebookAds.Product do
   end
 
   defp convert_attribute(:additional_image, %{images: images}) do
-    additional_images = Enum.slice(images, 1..19)
-
-    {
-      "additional_image_link",
-      %{},
-      Enum.join(additional_images |> Enum.map(&build_image_url(&1)), ",")
-    }
+    build_additional_image_node(images)
   end
 
   defp convert_attribute(:listing_type, %{type: type}) do

--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -97,7 +97,7 @@ defmodule Re.Exporters.FacebookAds.Product do
   end
 
   defp convert_attribute(:additional_image, %{images: images}) do
-    additional_images = Enum.slice(images, 1..20)
+    additional_images = Enum.slice(images, 1..19)
 
     {
       "additional_image_link",

--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -15,11 +15,15 @@ defmodule Re.Exporters.FacebookAds.Product do
     options = merge_default_options(options)
 
     listings
+    |> Enum.filter(&has_image?/1)
     |> Enum.map(&build_node(&1, options))
     |> build_root()
     |> XmlBuilder.document()
     |> XmlBuilder.generate(format: :none)
   end
+
+  defp has_image?(%{images: []}), do: false
+  defp has_image?(_), do: true
 
   def merge_default_options(options) do
     Map.merge(@default_options, options)

--- a/apps/re/lib/exporters/facebook_ads/real_estate.ex
+++ b/apps/re/lib/exporters/facebook_ads/real_estate.ex
@@ -15,11 +15,15 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
     options = merge_default_options(options)
 
     listings
+    |> Enum.filter(&has_image?/1)
     |> Enum.map(&build_node(&1, options))
     |> build_root()
     |> XmlBuilder.document()
     |> XmlBuilder.generate(format: :none)
   end
+
+  defp has_image?(%{images: []}), do: false
+  defp has_image?(_), do: true
 
   def merge_default_options(options) do
     Map.merge(@default_options, options)

--- a/apps/re/lib/exporters/facebook_ads/real_estate.ex
+++ b/apps/re/lib/exporters/facebook_ads/real_estate.ex
@@ -10,6 +10,7 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+  @max_images 20
 
   def export_listings_xml(listings, options \\ %{}) do
     options = merge_default_options(options)
@@ -31,6 +32,12 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
 
   def build_node(listing, options) do
     {"listing", %{}, convert_attributes(listing, options)}
+  end
+
+  def build_images_node(images) do
+    images
+    |> Enum.map(&build_image_node(&1))
+    |> Enum.take(@max_images)
   end
 
   defp build_root(nodes) do
@@ -121,7 +128,7 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
   end
 
   defp convert_attribute(:image, %{images: images}) do
-    images |> Enum.map(&build_image_node(&1)) |> Enum.slice(0..19)
+    build_images_node(images)
   end
 
   defp convert_attribute(:area, %{area: area}) do

--- a/apps/re/lib/exporters/facebook_ads/real_estate.ex
+++ b/apps/re/lib/exporters/facebook_ads/real_estate.ex
@@ -121,15 +121,7 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
   end
 
   defp convert_attribute(:image, %{images: images}) do
-    first_image = Enum.at(images, 0)
-
-    {
-      "image",
-      %{},
-      [
-        {"url", %{}, escape_cdata("#{@image_url}/#{first_image.filename}")}
-      ]
-    }
+    images |> Enum.map(&build_image_node(&1)) |> Enum.slice(0..19)
   end
 
   defp convert_attribute(:area, %{area: area}) do
@@ -162,5 +154,15 @@ defmodule Re.Exporters.FacebookAds.RealEstate do
     |> URI.merge(path)
     |> URI.merge(param)
     |> URI.to_string()
+  end
+
+  defp build_image_node(image) do
+    {
+      "image",
+      %{},
+      [
+        {"url", %{}, escape_cdata("#{@image_url}/#{image.filename}")}
+      ]
+    }
   end
 end

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -12,7 +12,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
 
   describe "build_node/2" do
-    test "export XML including listing first image" do
+    test "export XML with images from listing" do
       listing = %Listing{
         id: 7_004_578,
         price: 800,
@@ -41,6 +41,10 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           %Image{
             filename: "suite_1.png",
             description: nil
+          },
+          %Image{
+            filename: "bath_1.png",
+            description: nil
           }
         ]
       }
@@ -60,7 +64,64 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
           "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
-          "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <> "</entry>"
+          "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <>
+          "<additional_image_link><![CDATA[#{@image_url}/suite_1.png,#{@image_url}/bath_1.png]]></additional_image_link>" <>
+          "</entry>"
+
+      generated_xml =
+        listing
+        |> FacebookAds.Product.build_node(FacebookAds.Product.merge_default_options(%{}))
+        |> XmlBuilder.generate(format: :none)
+
+      assert expected_xml == generated_xml
+    end
+
+    test "export XML of a listing with a single image" do
+      listing = %Listing{
+        id: 7_004_578,
+        price: 800,
+        type: "Apartamento",
+        area: 300,
+        rooms: 4,
+        bathrooms: 4,
+        description:
+          "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+        address: %Address{
+          street: "Rua do Ipiranga",
+          street_number: 20,
+          neighborhood: "Ipiranga",
+          city: "São Paulo",
+          state: "SP",
+          postal_code: "04732-192",
+          lat: 51.496401,
+          lng: -0.179
+        },
+        matterport_code: "mY123",
+        images: [
+          %Image{
+            filename: "living_room.png",
+            description: "Living room"
+          }
+        ]
+      }
+
+      expected_xml =
+        "<entry>" <>
+          "<id><![CDATA[7004578]]></id>" <>
+          "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
+          "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
+          "<availability><![CDATA[in stock]]></availability>" <>
+          "<condition><![CDATA[new]]></condition>" <>
+          "<brand><![CDATA[EmCasa]]></brand>" <>
+          "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
+          "<price><![CDATA[800 BRL]]></price>" <>
+          "<custom_label_0><![CDATA[Apartamento]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
+          "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
+          "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
+          "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <>
+          "<additional_image_link><![CDATA[]]></additional_image_link>" <> "</entry>"
 
       generated_xml =
         listing
@@ -107,7 +168,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
-          "<custom_label_4><![CDATA[300]]></custom_label_4>" <> "<image_link/>" <> "</entry>"
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
+          "<image_link/><additional_image_link/>" <> "</entry>"
 
       generated_xml =
         listing
@@ -154,7 +216,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<custom_label_1><![CDATA[Rua do Ipiranga, Ipiranga]]></custom_label_1>" <>
           "<custom_label_2><![CDATA[0]]></custom_label_2>" <>
           "<custom_label_3><![CDATA[0]]></custom_label_3>" <>
-          "<custom_label_4><![CDATA[300]]></custom_label_4>" <> "<image_link/>" <> "</entry>"
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
+          "<image_link/><additional_image_link/>" <> "</entry>"
 
       generated_xml =
         listing

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -177,5 +177,18 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
 
       assert expected_xml == generated_xml
     end
+
+    test "should not export listings without images" do
+      expected_xml =
+        ~s|<?xml version="1.0" encoding="UTF-8"?>| <>
+          "<feed xmlns=\"http://www.w3.org/2005/Atom\"/>"
+
+      generated_xml =
+        FacebookAds.Product.export_listings_xml([%Listing{id: 1, images: []}], %{
+          attributes: [:id, :images]
+        })
+
+      assert expected_xml == generated_xml
+    end
   end
 end

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -10,6 +10,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+  @max_additional_images 20
 
   describe "build_node/2" do
     test "export XML with images from listing" do
@@ -225,6 +226,21 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
         |> XmlBuilder.generate(format: :none)
 
       assert expected_xml == generated_xml
+    end
+  end
+
+  describe "build_additional_image_node/1" do
+    test "should not exceed max number of images" do
+      images = Enum.map(1..30, fn x -> %{filename: "#{x}.png"} end)
+      {_, _, urls} = FacebookAds.Product.build_additional_image_node(images)
+      assert length(String.split(urls, ",")) == @max_additional_images
+    end
+
+    test "should slice first image" do
+      images = Enum.map(1..5, fn x -> %{filename: "#{x}.png"} end)
+      {_, _, urls} = FacebookAds.Product.build_additional_image_node(images)
+      images_urls = String.split(urls, ",")
+      assert Enum.at(images_urls, 0) == "#{@image_url}/2.png"
     end
   end
 

--- a/apps/re/test/exporters/facebook_ads/real_estate_test.exs
+++ b/apps/re/test/exporters/facebook_ads/real_estate_test.exs
@@ -10,6 +10,7 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
+  @max_images 20
 
   describe "build_node/2" do
     test "export XML with images from listings" do
@@ -190,6 +191,14 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
         |> XmlBuilder.generate(format: :none)
 
       assert expected_xml == generated_xml
+    end
+  end
+
+  describe "build_images_node/1" do
+    test "should not exceed max number of images" do
+      images = Enum.map(1..30, fn x -> %{filename: "#{x}.png"} end)
+      images_node = FacebookAds.RealEstate.build_images_node(images)
+      assert length(images_node) == @max_images
     end
   end
 

--- a/apps/re/test/exporters/facebook_ads/real_estate_test.exs
+++ b/apps/re/test/exporters/facebook_ads/real_estate_test.exs
@@ -12,7 +12,7 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
 
   describe "build_node/2" do
-    test "export XML including listing first image" do
+    test "export XML with images from listings" do
       listing = %Listing{
         id: 7_004_578,
         price: 800,
@@ -69,7 +69,10 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
           "<latitude><![CDATA[51.496401]]></latitude>" <>
           "<longitude><![CDATA[-0.179]]></longitude>" <>
           "<image>" <>
-          "<url><![CDATA[#{@image_url}/living_room.png]]></url>" <> "</image>" <> "</listing>"
+          "<url><![CDATA[#{@image_url}/living_room.png]]></url>" <>
+          "</image>" <>
+          "<image>" <>
+          "<url><![CDATA[#{@image_url}/suite_1.png]]></url>" <> "</image>" <> "</listing>"
 
       generated_xml =
         listing

--- a/apps/re/test/exporters/facebook_ads/real_estate_test.exs
+++ b/apps/re/test/exporters/facebook_ads/real_estate_test.exs
@@ -201,5 +201,16 @@ defmodule Re.Exporters.FacebookAds.RealEstateTest do
 
       assert expected_xml == generated_xml
     end
+
+    test "should not export listings without images" do
+      expected_xml = ~s|<?xml version="1.0" encoding="UTF-8"?>| <> "<listings/>"
+
+      generated_xml =
+        FacebookAds.RealEstate.export_listings_xml([%Listing{id: 1, images: []}], %{
+          attributes: [:id, :images]
+        })
+
+      assert expected_xml == generated_xml
+    end
   end
 end


### PR DESCRIPTION
* Do not export listings without images
* Export all listing images (max 20 according to FB docs) for both formats: `RealEstate` and `Product`

Depends on: #456 