### PR TITLE
Allow to add development related listings

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -93,10 +93,12 @@ defmodule Re.Listings do
 
   def insert(params, address, user, development) do
     %Listing{}
-    |> Changeset.change(development_uuid: development.uuid)
-    |> Changeset.change(address_id: address.id)
-    |> Changeset.change(user_id: user.id)
-    |> Changeset.change(is_exportable: false)
+    |> Changeset.change(%{
+      development_uuid: development.uuid,
+      address_id: address.id,
+      user_id: user.id,
+      is_exportable: false
+     })
     |> Listing.development_changeset(params)
     |> Repo.insert()
     |> publish_if_admin(user.role)

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -84,9 +84,21 @@ defmodule Re.Listings do
   def get_partial_preloaded(id, preload),
     do: do_get(Queries.preload_relations(Listing, preload), id)
 
-  def insert(params, address, user) do
+  def insert(params, address, user, development \\ nil)
+
+  def insert(params, address, user, nil) do
     with {:ok, user} <- validate_phone_number(params, user),
          do: do_insert(params, address, user)
+  end
+
+  def insert(params, address, user, development) do
+    %Listing{}
+    |> Changeset.change(development_uuid: development.uuid)
+    |> Changeset.change(address_id: address.id)
+    |> Changeset.change(user_id: user.id)
+    |> Changeset.change(is_exportable: false)
+    |> Listing.development_changeset(params)
+    |> Repo.insert()
   end
 
   defp do_insert(params, address, user) do

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -99,6 +99,7 @@ defmodule Re.Listings do
     |> Changeset.change(is_exportable: false)
     |> Listing.development_changeset(params)
     |> Repo.insert()
+    |> publish_if_admin(user.role)
   end
 
   defp do_insert(params, address, user) do

--- a/apps/re/lib/listings/policy.ex
+++ b/apps/re/lib/listings/policy.ex
@@ -10,6 +10,7 @@ defmodule Re.Listings.Policy do
 
   def authorize(_, %User{role: "admin"}, _), do: :ok
   def authorize(:create_listing, %User{role: "user"}, _), do: :ok
+  def authorize(:create_development_listing, %User{role: "admin"}, _), do: :ok
   def authorize(:show_listing, _, %{status: "active"}), do: :ok
   def authorize(:show_listing, %User{id: id}, %{user_id: id}), do: :ok
   def authorize(:show_listing, _, _), do: {:error, :not_found}

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -85,7 +85,7 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types,
       message: "should be one of: [#{Enum.join(@garage_types, " ")}]"
     )
-    |> Re.ChangesetHelper.generate_uuid()
+    |> generate_uuid()
   end
 
   @admin_required ~w(type description price rooms bathrooms area garage_spots garage_type
@@ -108,7 +108,22 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types,
       message: "should be one of: [#{Enum.join(@garage_types, " ")}]"
     )
-    |> Re.ChangesetHelper.generate_uuid()
+    |> generate_uuid()
+  end
+
+  @development_required ~w(type description has_elevator address_id user_id development_uuid)a
+
+  @development_optional ~w(matterport_code is_exclusive status is_release)a
+
+  @development_attributes @development_required ++ @development_optional
+
+  def development_changeset(struct, params) do
+    struct
+    |> cast(params, @development_attributes)
+    |> cast_assoc(:development)
+    |> validate_required(@development_required)
+    |> validate_inclusion(:type, @types, message: "should be one of: [#{Enum.join(@types, " ")}]")
+    |> generate_uuid()
   end
 
   @more_than_zero_attributes ~w(property_tax maintenance_fee
@@ -124,4 +139,6 @@ defmodule Re.Listing do
   end
 
   def listing_types(), do: @types
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
 end

--- a/apps/re/test/developments/development_test.exs
+++ b/apps/re/test/developments/development_test.exs
@@ -21,32 +21,35 @@ defmodule Re.DevelopmentTest do
     description: "description"
   }
 
-  test "changeset with valid attributes" do
-    %{id: address_id} = insert(:address)
+  describe "changeset/2" do
+    test "with valid attributes" do
+      %{id: address_id} = insert(:address)
 
-    attrs =
-      @valid_attrs
-      |> Map.put(:address_id, address_id)
+      attrs =
+        @valid_attrs
+        |> Map.put(:address_id, address_id)
 
-    changeset = Development.changeset(%Development{}, attrs)
-    assert changeset.valid?
-  end
+      changeset = Development.changeset(%Development{}, attrs)
+      assert changeset.valid?
+    end
 
-  test "changeset with invalid attributes" do
-    changeset = Development.changeset(%Development{}, @invalid_attrs)
-    refute changeset.valid?
+    test "with invalid attributes" do
+      changeset = Development.changeset(%Development{}, @invalid_attrs)
+      refute changeset.valid?
 
-    assert Keyword.get(changeset.errors, :phase) ==
-             {"should be one of: [pre-launch planning building delivered]",
-              [validation: :inclusion]}
+      assert Keyword.get(changeset.errors, :phase) ==
+               {"should be one of: [pre-launch planning building delivered]",
+                [validation: :inclusion]}
 
-    assert Keyword.get(changeset.errors, :name) == {"can't be blank", [validation: :required]}
+      assert Keyword.get(changeset.errors, :name) == {"can't be blank", [validation: :required]}
 
-    assert Keyword.get(changeset.errors, :title) == {"can't be blank", [validation: :required]}
+      assert Keyword.get(changeset.errors, :title) == {"can't be blank", [validation: :required]}
 
-    assert Keyword.get(changeset.errors, :builder) == {"can't be blank", [validation: :required]}
+      assert Keyword.get(changeset.errors, :builder) ==
+               {"can't be blank", [validation: :required]}
 
-    assert Keyword.get(changeset.errors, :address_id) ==
-             {"can't be blank", [validation: :required]}
+      assert Keyword.get(changeset.errors, :address_id) ==
+               {"can't be blank", [validation: :required]}
+    end
   end
 end

--- a/apps/re/test/developments/development_test.exs
+++ b/apps/re/test/developments/development_test.exs
@@ -21,35 +21,32 @@ defmodule Re.DevelopmentTest do
     description: "description"
   }
 
-  describe "changeset/2" do
-    test "with valid attributes" do
-      %{id: address_id} = insert(:address)
+  test "changeset with valid attributes" do
+    %{id: address_id} = insert(:address)
 
-      attrs =
-        @valid_attrs
-        |> Map.put(:address_id, address_id)
+    attrs =
+      @valid_attrs
+      |> Map.put(:address_id, address_id)
 
-      changeset = Development.changeset(%Development{}, attrs)
-      assert changeset.valid?
-    end
+    changeset = Development.changeset(%Development{}, attrs)
+    assert changeset.valid?
+  end
 
-    test "with invalid attributes" do
-      changeset = Development.changeset(%Development{}, @invalid_attrs)
-      refute changeset.valid?
+  test "changeset with invalid attributes" do
+    changeset = Development.changeset(%Development{}, @invalid_attrs)
+    refute changeset.valid?
 
-      assert Keyword.get(changeset.errors, :phase) ==
-               {"should be one of: [pre-launch planning building delivered]",
-                [validation: :inclusion]}
+    assert Keyword.get(changeset.errors, :phase) ==
+             {"should be one of: [pre-launch planning building delivered]",
+              [validation: :inclusion]}
 
-      assert Keyword.get(changeset.errors, :name) == {"can't be blank", [validation: :required]}
+    assert Keyword.get(changeset.errors, :name) == {"can't be blank", [validation: :required]}
 
-      assert Keyword.get(changeset.errors, :title) == {"can't be blank", [validation: :required]}
+    assert Keyword.get(changeset.errors, :title) == {"can't be blank", [validation: :required]}
 
-      assert Keyword.get(changeset.errors, :builder) ==
-               {"can't be blank", [validation: :required]}
+    assert Keyword.get(changeset.errors, :builder) == {"can't be blank", [validation: :required]}
 
-      assert Keyword.get(changeset.errors, :address_id) ==
-               {"can't be blank", [validation: :required]}
-    end
+    assert Keyword.get(changeset.errors, :address_id) ==
+             {"can't be blank", [validation: :required]}
   end
 end

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -193,4 +193,67 @@ defmodule Re.ListingTest do
                 [validation: :number, kind: :less_than_or_equal_to, number: 100_000_000]}
     end
   end
+
+  describe "development_changeset/2" do
+    @valid_development_attrs %{
+      type: "Apartamento",
+      description: "some content",
+      has_elevator: true,
+      matterport_code: "",
+      is_exclusive: nil,
+      is_release: nil
+    }
+
+    @invalid_development_attrs %{
+      type: "invalid",
+      description: "",
+      has_elevator: "apple",
+      is_exclusive: "apple",
+      is_release: "apple"
+    }
+
+    test "is valid with required params" do
+      address = insert(:address)
+      user = insert(:user)
+      development = insert(:development)
+
+      attrs =
+        @valid_development_attrs
+        |> Map.put(:address_id, address.id)
+        |> Map.put(:user_id, user.id)
+        |> Map.put(:development_uuid, development.uuid)
+
+      changeset = Listing.development_changeset(%Listing{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "is invalid without required attrs" do
+      changeset = Listing.development_changeset(%Listing{}, @invalid_development_attrs)
+      refute changeset.valid?
+
+      assert Keyword.get(changeset.errors, :type) ==
+               {"should be one of: [Apartamento Casa Cobertura]", [validation: :inclusion]}
+
+      assert Keyword.get(changeset.errors, :description) ==
+               {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :address_id) ==
+               {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :user_id) ==
+               {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :development_uuid) ==
+               {"can't be blank", [validation: :required]}
+
+      assert Keyword.get(changeset.errors, :has_elevator) ==
+               {"is invalid", [type: :boolean, validation: :cast]}
+
+      assert Keyword.get(changeset.errors, :is_exclusive) ==
+               {"is invalid", [type: :boolean, validation: :cast]}
+
+      assert Keyword.get(changeset.errors, :is_release) ==
+               {"is invalid", [type: :boolean, validation: :cast]}
+    end
+  end
 end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -307,7 +307,7 @@ defmodule Re.ListingsTest do
     end
   end
 
-  describe "insert/2" do
+  describe "insert/3" do
     @insert_listing_params %{
       "type" => "Apartamento",
       "complement" => "100",
@@ -375,6 +375,41 @@ defmodule Re.ListingsTest do
 
       assert {:ok, listing} = Listings.insert(@insert_listing_params, address, user)
       assert Repo.get(Listing, listing.id)
+    end
+  end
+
+  describe "insert/4" do
+    @insert_development_listing_params %{
+      "type" => "Apartamento",
+      "has_elevator" => true,
+      "description" => "Awesome new brand building"
+    }
+
+    test "should insert development listing" do
+      address = insert(:address)
+      development = insert(:development, address_id: address.id)
+      user = insert(:user, role: "admin")
+
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_development_listing_params, address, user, development)
+
+      assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
+      assert retrieved_listing.development_uuid == development.uuid
+      assert retrieved_listing.address_id == address.id
+      assert retrieved_listing.user_id == user.id
+      assert retrieved_listing.uuid
+    end
+
+    test "should set is_exportable to false" do
+      address = insert(:address)
+      development = insert(:development, address_id: address.id)
+      user = insert(:user, role: "admin")
+
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_development_listing_params, address, user, development)
+
+      assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
+      assert retrieved_listing.is_exportable == false
     end
   end
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -106,19 +106,11 @@ defmodule ReWeb.Types.Listing do
 
     field :address, :address_input
     field :address_id, :id
+
+    field :development_uuid, :uuid
   end
 
   enum :garage_type, values: ~w(contract condominium)
-
-  input_object :development_listing_input do
-    field :type, non_null(:string)
-    field :description, :string
-    field :has_elevator, :boolean
-    field :matterport_code, :string
-
-    field :address_id, :id
-    field :development_uuid, :uuid
-  end
 
   object :address do
     field :id, :id
@@ -313,13 +305,6 @@ defmodule ReWeb.Types.Listing do
     @desc "Insert listing"
     field :insert_listing, type: :listing do
       arg :input, non_null(:listing_input)
-
-      resolve &Resolvers.Listings.insert/2
-    end
-
-    @desc "Insert development listing"
-    field :insert_development_listing, type: :listing do
-      arg :input, non_null(:development_listing_input)
 
       resolve &Resolvers.Listings.insert/2
     end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -110,6 +110,16 @@ defmodule ReWeb.Types.Listing do
 
   enum :garage_type, values: ~w(contract condominium)
 
+  input_object :development_listing_input do
+    field :type, non_null(:string)
+    field :description, :string
+    field :has_elevator, :boolean
+    field :matterport_code, :string
+
+    field :address_id, :id
+    field :development_uuid, :uuid
+  end
+
   object :address do
     field :id, :id
     field :street, :string
@@ -303,6 +313,13 @@ defmodule ReWeb.Types.Listing do
     @desc "Insert listing"
     field :insert_listing, type: :listing do
       arg :input, non_null(:listing_input)
+
+      resolve &Resolvers.Listings.insert/2
+    end
+
+    @desc "Insert development listing"
+    field :insert_development_listing, type: :listing do
+      arg :input, non_null(:development_listing_input)
 
       resolve &Resolvers.Listings.insert/2
     end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -314,12 +314,10 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert [%{"message" => "price: must be greater than or equal to 250000", "code" => 422}] =
                json_response(conn, 200)["errors"]
     end
-  end
 
-  describe "insertDevelopmentListing" do
     @insert_development_listing_mutation """
-      mutation InsertDevelopmentListing ($input: DevelopmentListingInput!) {
-        insertDevelopmentListing(input: $input) {
+      mutation InsertListing ($input: ListingInput!) {
+        insertListing(input: $input) {
           id
           type
           address {
@@ -369,7 +367,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
         )
 
       assert %{
-               "insertDevelopmentListing" =>
+               "insertListing" =>
                  %{
                    "address" => associated_address,
                    "owner" => owner,
@@ -420,7 +418,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
           AbsintheHelpers.mutation_wrapper(@insert_development_listing_mutation, variables)
         )
 
-      assert %{"insertDevelopmentListing" => nil} == json_response(conn, 200)["data"]
+      assert %{"insertListing" => nil} == json_response(conn, 200)["data"]
 
       assert_forbidden_response(json_response(conn, 200))
     end
@@ -440,7 +438,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
           AbsintheHelpers.mutation_wrapper(@insert_development_listing_mutation, variables)
         )
 
-      assert %{"insertDevelopmentListing" => nil} == json_response(conn, 200)["data"]
+      assert %{"insertListing" => nil} == json_response(conn, 200)["data"]
 
       assert_unauthorized_response(json_response(conn, 200))
     end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -323,8 +323,8 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       listing: listing,
       old_address: address
     } do
-      %{uuid: development_uuid} = insert(:development, address_id: address.id)
-      variables = insert_development_listing_variables(listing, address.id, development_uuid)
+      development = insert(:development, address_id: address.id)
+      variables = insert_development_listing_variables(listing, address.id, development.uuid)
 
       mutation = insert_development_listing_mutation()
 
@@ -332,7 +332,11 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
 
       assert %{
                "insertDevelopmentListing" =>
-                 %{"address" => inserted_address, "owner" => owner} = inserted_listing
+                 %{
+                   "address" => inserted_address,
+                   "owner" => owner,
+                   "development" => inserted_development
+                 } = inserted_listing
              } = json_response(conn, 200)["data"]
 
       assert inserted_listing["id"]
@@ -352,6 +356,13 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_address["street"] == address.street
       assert inserted_address["streetNumber"] == address.street_number
       assert inserted_address["postalCode"] == address.postal_code
+
+      assert inserted_development["uuid"] == development.uuid
+      assert inserted_development["name"] == development.name
+      assert inserted_development["title"] == development.title
+      assert inserted_development["phase"] == development.phase
+      assert inserted_development["builder"] == development.builder
+      assert inserted_development["description"] == development.description
 
       assert owner["id"] == to_string(user.id)
     end
@@ -555,6 +566,14 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
           }
           owner {
             id
+          }
+          development {
+            uuid
+            name
+            title
+            phase
+            builder
+            description
           }
           description
           hasElevator

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -317,6 +317,41 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
   end
 
   describe "insertDevelopmentListing" do
+    @insert_development_listing_mutation """
+      mutation InsertDevelopmentListing ($input: DevelopmentListingInput!) {
+        insertDevelopmentListing(input: $input) {
+          id
+          type
+          address {
+            city
+            state
+            lat
+            lng
+            neighborhood
+            street
+            streetNumber
+            postalCode
+          }
+          owner {
+            id
+          }
+          development {
+            uuid
+            name
+            title
+            phase
+            builder
+            description
+          }
+          description
+          hasElevator
+          matterportCode
+          isActive
+          isExportable
+        }
+      }
+    """
+
     test "admin should insert development listing", %{
       admin_conn: conn,
       admin_user: user,
@@ -326,16 +361,19 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       development = insert(:development, address_id: address.id)
       variables = insert_development_listing_variables(listing, address.id, development.uuid)
 
-      mutation = insert_development_listing_mutation()
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@insert_development_listing_mutation, variables)
+        )
 
       assert %{
                "insertDevelopmentListing" =>
                  %{
-                   "address" => inserted_address,
+                   "address" => associated_address,
                    "owner" => owner,
-                   "development" => inserted_development
+                   "development" => associated_development
                  } = inserted_listing
              } = json_response(conn, 200)["data"]
 
@@ -348,21 +386,21 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       refute inserted_listing["isExportable"]
       refute inserted_listing["isActive"]
 
-      assert inserted_address["city"] == address.city
-      assert inserted_address["state"] == address.state
-      assert inserted_address["lat"] == address.lat
-      assert inserted_address["lng"] == address.lng
-      assert inserted_address["neighborhood"] == address.neighborhood
-      assert inserted_address["street"] == address.street
-      assert inserted_address["streetNumber"] == address.street_number
-      assert inserted_address["postalCode"] == address.postal_code
+      assert associated_address["city"] == address.city
+      assert associated_address["state"] == address.state
+      assert associated_address["lat"] == address.lat
+      assert associated_address["lng"] == address.lng
+      assert associated_address["neighborhood"] == address.neighborhood
+      assert associated_address["street"] == address.street
+      assert associated_address["streetNumber"] == address.street_number
+      assert associated_address["postalCode"] == address.postal_code
 
-      assert inserted_development["uuid"] == development.uuid
-      assert inserted_development["name"] == development.name
-      assert inserted_development["title"] == development.title
-      assert inserted_development["phase"] == development.phase
-      assert inserted_development["builder"] == development.builder
-      assert inserted_development["description"] == development.description
+      assert associated_development["uuid"] == development.uuid
+      assert associated_development["name"] == development.name
+      assert associated_development["title"] == development.title
+      assert associated_development["phase"] == development.phase
+      assert associated_development["builder"] == development.builder
+      assert associated_development["description"] == development.description
 
       assert owner["id"] == to_string(user.id)
     end
@@ -375,9 +413,12 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       %{uuid: development_uuid} = insert(:development, address_id: address.id)
       variables = insert_development_listing_variables(listing, address.id, development_uuid)
 
-      mutation = insert_development_listing_mutation()
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@insert_development_listing_mutation, variables)
+        )
 
       assert %{"insertDevelopmentListing" => nil} == json_response(conn, 200)["data"]
 
@@ -392,9 +433,12 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       %{uuid: development_uuid} = insert(:development, address_id: address.id)
       variables = insert_development_listing_variables(listing, address.id, development_uuid)
 
-      mutation = insert_development_listing_mutation()
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@insert_development_listing_mutation, variables)
+        )
 
       assert %{"insertDevelopmentListing" => nil} == json_response(conn, 200)["data"]
 
@@ -546,42 +590,5 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
         "development_uuid" => development_uuid
       }
     }
-  end
-
-  def insert_development_listing_mutation do
-    """
-      mutation InsertDevelopmentListing ($input: DevelopmentListingInput!) {
-        insertDevelopmentListing(input: $input) {
-          id
-          type
-          address {
-            city
-            state
-            lat
-            lng
-            neighborhood
-            street
-            streetNumber
-            postalCode
-          }
-          owner {
-            id
-          }
-          development {
-            uuid
-            name
-            title
-            phase
-            builder
-            description
-          }
-          description
-          hasElevator
-          matterportCode
-          isActive
-          isExportable
-        }
-      }
-    """
   end
 end


### PR DESCRIPTION
I've added a new schema to allow listing with other requirements, the same for the changeset, at first I consider create o new module like `Listings.Development` to put changesets, but I thought it would have low visibility. 

Some business rules: 
- In the first moment, these listings will not be exportable, once we don't know the better format to adapter them to the consumers and don't want to follow it by now. 
- We do not consider farol anymore for sorting (I'll open other PR removing the dependency for this field). 

I need to make tests about how the system as a whole will react with and fix the main problems well as some refactor before merging. But by now I think we have code enough to discuss the approach and some options in case we have less turbulent ways. 
