### PR TITLE
Fix unit nonconformities

### DIFF
--- a/apps/re/lib/units/unit.ex
+++ b/apps/re/lib/units/unit.ex
@@ -39,9 +39,9 @@ defmodule Re.Unit do
   @garage_types ~w(contract condominium)
   @statuses ~w(active inactive)
 
-  @required ~w(price rooms bathrooms area garage_type garage_spots suites dependencies
-               development_uuid listing_id status)a
-  @optional ~w(complement floor property_tax maintenance_fee balconies restrooms)a
+  @required ~w(price rooms bathrooms area garage_spots suites development_uuid listing_id status)a
+  @optional ~w(complement floor property_tax maintenance_fee balconies restrooms garage_type
+              dependencies)a
 
   @attributes @required ++ @optional
 

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -64,13 +64,7 @@ defmodule Re.UnitTest do
 
       assert Keyword.get(changeset.errors, :area) == {"can't be blank", [validation: :required]}
 
-      assert Keyword.get(changeset.errors, :garage_type) ==
-               {"can't be blank", [validation: :required]}
-
       assert Keyword.get(changeset.errors, :suites) == {"can't be blank", [validation: :required]}
-
-      assert Keyword.get(changeset.errors, :dependencies) ==
-               {"can't be blank", [validation: :required]}
 
       assert Keyword.get(changeset.errors, :development_uuid) ==
                {"can't be blank", [validation: :required]}

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -36,7 +36,7 @@ defmodule ReWeb.Types.Unit do
     field :restrooms, :integer
     field :area, :integer
     field :garage_spots, :integer
-    field :garage_type, :string
+    field :garage_type, :garage_type
     field :suites, :integer
     field :dependencies, :integer
     field :balconies, :integer

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -18,7 +18,8 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     unit_params =
       string_params_for(:unit, %{
         development_uuid: development.uuid,
-        listing_id: listing.id
+        listing_id: listing.id,
+        garage_type: "CONDOMINIUM"
       })
       |> Map.delete("uuid")
 
@@ -79,7 +80,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       assert insert_unit["restrooms"] == unit_params["restrooms"]
       assert insert_unit["area"] == unit_params["area"]
       assert insert_unit["garage_spots"] == unit_params["garage_spots"]
-      assert insert_unit["garage_type"] == unit_params["garage_type"]
+      assert insert_unit["garage_type"] == String.downcase(unit_params["garage_type"])
       assert insert_unit["suites"] == unit_params["suites"]
       assert insert_unit["dependencies"] == unit_params["dependencies"]
       assert insert_unit["balconies"] == unit_params["balconies"]


### PR DESCRIPTION
@gabiseabra pointed out these differences between unit and listings behaviors. 

- Both `garage_type` and `dependencies` should not be required. 
- Use enum on `garage_type` instead of plain strings. 

Fixing them with this PR. 