### PR TITLE
Add update unit mutation

### DIFF
--- a/apps/re/lib/listings/units/propagator.ex
+++ b/apps/re/lib/listings/units/propagator.ex
@@ -6,13 +6,14 @@ defmodule Re.Listings.Units.Propagator do
 
   alias Re.Listings
 
-  def update_listing(
-        %{price: listing_price} = listing,
-        %{price: unit_price}
-      )
-      when is_nil(listing_price) or unit_price < listing_price do
-    Listings.update_price(listing, unit_price)
-  end
+  def update_listing(listing, []), do: {:ok, listing}
 
-  def update_listing(listing, _new_unit), do: {:ok, listing}
+  def update_listing(listing, unit_prices_list) when is_nil(unit_prices_list),
+    do: {:ok, listing}
+
+  def update_listing(listing, unit_price_list) do
+    min_price = Enum.min(unit_price_list)
+
+    Listings.update_price(listing, min_price)
+  end
 end

--- a/apps/re/lib/listings/units/server.ex
+++ b/apps/re/lib/listings/units/server.ex
@@ -63,7 +63,6 @@ defmodule Re.Listings.Units.Server do
   def handle_call(:inspect, _caller, state), do: {:reply, state, state}
 
   defp create_price_list(units) do
-    units
-    |> Enum.map(fn unit -> unit.price end)
+    Enum.map(units, fn unit -> unit.price end)
   end
 end

--- a/apps/re/lib/units/queries.ex
+++ b/apps/re/lib/units/queries.ex
@@ -1,0 +1,13 @@
+defmodule Re.Units.Queries do
+  @moduledoc """
+  Module for grouping unit queries
+  """
+
+  alias Re.Unit
+
+  import Ecto.Query
+
+  def by_listing(query \\ Unit, id)
+
+  def by_listing(query, id), do: where(query, [u], u.listing_id == ^id)
+end

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -26,6 +26,15 @@ defmodule Re.Units do
     |> Repo.all()
   end
 
+  def get(uuid), do: do_get(Unit, uuid)
+
+  defp do_get(query, uuid) do
+    case Repo.get(query, uuid) do
+      nil -> {:error, :not_found}
+      unit -> {:ok, unit}
+    end
+  end
+
   def insert(params, development, listing) do
     %Unit{}
     |> Changeset.change(development_uuid: development.uuid)
@@ -35,9 +44,11 @@ defmodule Re.Units do
     |> publish_new()
   end
 
-  def update(unit, params) do
+  def update(unit, params, development, listing) do
     changeset =
       unit
+      |> Changeset.change(development_uuid: development.uuid)
+      |> Changeset.change(listing_id: listing.id)
       |> Unit.changeset(params)
 
     changeset

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -10,7 +10,8 @@ defmodule Re.Units do
   alias Re.{
     PubSub,
     Repo,
-    Unit
+    Unit,
+    Units.Queries
   }
 
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
@@ -26,6 +27,12 @@ defmodule Re.Units do
     |> Unit.changeset(params)
     |> Repo.insert()
     |> publish_new()
+  end
+
+  def by_listing(listing_id) do
+    Unit
+    |> Queries.by_listing(listing_id)
+    |> Repo.all()
   end
 
   defp publish_new(result), do: PubSub.publish_new(result, "new_unit")

--- a/apps/re/lib/units/units.ex
+++ b/apps/re/lib/units/units.ex
@@ -20,6 +20,12 @@ defmodule Re.Units do
 
   def query(_query, _args), do: Re.Unit
 
+  def by_listing(listing_id) do
+    Unit
+    |> Queries.by_listing(listing_id)
+    |> Repo.all()
+  end
+
   def insert(params, development, listing) do
     %Unit{}
     |> Changeset.change(development_uuid: development.uuid)
@@ -29,11 +35,18 @@ defmodule Re.Units do
     |> publish_new()
   end
 
-  def by_listing(listing_id) do
-    Unit
-    |> Queries.by_listing(listing_id)
-    |> Repo.all()
+  def update(unit, params) do
+    changeset =
+      unit
+      |> Unit.changeset(params)
+
+    changeset
+    |> Repo.update()
+    |> publish_update(changeset)
   end
 
   defp publish_new(result), do: PubSub.publish_new(result, "new_unit")
+
+  defp publish_update(result, changeset),
+    do: PubSub.publish_update(result, changeset, "update_unit")
 end

--- a/apps/re/test/listings/units/propagator_test.exs
+++ b/apps/re/test/listings/units/propagator_test.exs
@@ -5,44 +5,26 @@ defmodule Re.Listings.Units.PropagatorTest do
   import Re.Factory
 
   describe "update_listing/2" do
-    @insert_unit_params %{
-      complement: "201",
-      price: 500_000,
-      rooms: 3,
-      bathrooms: 1,
-      area: 100,
-      garage_spots: 1,
-      garage_type: "contract",
-      dependencies: 0,
-      suites: 1,
-      status: "active"
-    }
+    test "update listing with lower price from price_list" do
+      listing = insert(:listing, price: 1_000_000)
+      price_list = [400_000, 800_000, 1_200_000]
 
-    test "replace listing price by unit price when unit price is lower than listing price" do
-      development = insert(:development)
-      listing = insert(:listing, price: 1_000_000, development_uuid: development.uuid)
-      new_unit = insert(:unit, @insert_unit_params)
-
-      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
-      assert listing.price == 500_000
-    end
-
-    test "replace listing price by unit price when listing price is nil" do
-      development = insert(:development)
-      listing = insert(:listing, price: nil, development_uuid: development.uuid)
-      new_unit = insert(:unit, @insert_unit_params)
-
-      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
-      assert listing.price == 500_000
-    end
-
-    test "doesn't update listing price when unit price is higher than listing price" do
-      development = insert(:development)
-      listing = insert(:listing, price: 400_000, development_uuid: development.uuid)
-      new_unit = insert(:unit, @insert_unit_params)
-
-      assert {:ok, listing} = Propagator.update_listing(listing, new_unit)
+      assert {:ok, listing} = Propagator.update_listing(listing, price_list)
       assert listing.price == 400_000
+    end
+
+    test "doesn't update listing price when price_list is empty" do
+      listing = insert(:listing, price: 500_000)
+
+      assert {:ok, listing} = Propagator.update_listing(listing, [])
+      assert listing.price == 500_000
+    end
+
+    test "keep same listing price when price_list is nil" do
+      listing = insert(:listing, price: 500_000)
+
+      assert {:ok, listing} = Propagator.update_listing(listing, nil)
+      assert listing.price == 500_000
     end
   end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -50,4 +50,30 @@ defmodule Re.UnitsTest do
       assert listing.price == 500_000
     end
   end
+
+  describe "update/2" do
+    @update_unit_attrs %{
+      price: 2_000_000,
+      rooms: 3
+    }
+
+    test "should update listing price" do
+      Server.start_link()
+      development = insert(:development)
+      listing = insert(:listing, development_uuid: development.uuid, price: 1_000_000)
+      unit = insert(:unit, development_uuid: development.uuid, price: 500_000)
+
+      params =
+        @update_unit_attrs
+        |> Map.merge(%{development_uuid: development.uuid})
+        |> Map.merge(%{listing_id: listing.id})
+
+      assert {:ok, _updated_unit} = Units.update(unit, params)
+
+      GenServer.call(Server, :inspect)
+
+      listing = Repo.get(Listing, listing.id)
+      assert listing.price == 2_000_000
+    end
+  end
 end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -63,12 +63,7 @@ defmodule Re.UnitsTest do
       listing = insert(:listing, development_uuid: development.uuid, price: 1_000_000)
       unit = insert(:unit, development_uuid: development.uuid, price: 500_000)
 
-      params =
-        @update_unit_attrs
-        |> Map.merge(%{development_uuid: development.uuid})
-        |> Map.merge(%{listing_id: listing.id})
-
-      assert {:ok, _updated_unit} = Units.update(unit, params)
+      assert {:ok, _updated_unit} = Units.update(unit, @update_unit_attrs, development, listing)
 
       GenServer.call(Server, :inspect)
 

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -22,6 +22,18 @@ defmodule ReWeb.Resolvers.Units do
     end
   end
 
+  def update(%{uuid: uuid, input: params}, %{
+        context: %{current_user: current_user}
+      }) do
+    with :ok <- Bodyguard.permit(Units, :update_unit, current_user, params),
+         {:ok, unit} <- Units.get(uuid),
+         {:ok, development} <- get_development(params),
+         {:ok, listing} <- get_listing(params),
+         {:ok, new_unit} <- Units.update(unit, params, development, listing) do
+      {:ok, new_unit}
+    end
+  end
+
   def per_listing(listing, _params, %{context: %{loader: loader}}) do
     loader
     |> Dataloader.load(Units, :units, listing)

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -52,5 +52,13 @@ defmodule ReWeb.Types.Unit do
 
       resolve &Resolvers.Units.insert/2
     end
+
+    @desc "Update unit"
+    field :update_unit, type: :unit do
+      arg :uuid, non_null(:uuid)
+      arg :input, non_null(:unit_input)
+
+      resolve &Resolvers.Units.update/2
+    end
   end
 end

--- a/apps/re_web/test/graphql/developments/query_test.exs
+++ b/apps/re_web/test/graphql/developments/query_test.exs
@@ -52,7 +52,6 @@ defmodule ReWeb.GraphQL.Developments.QueryTest do
   end
 
   describe "development" do
-    @tag dev: true
     test "admin should query development", %{admin_conn: conn} do
       %{filename: image_filename1} = image1 = insert(:image, is_active: true, position: 1)
       %{filename: image_filename2} = image2 = insert(:image, is_active: true, position: 2)

--- a/apps/re_web/test/graphql/units/mutation_test.exs
+++ b/apps/re_web/test/graphql/units/mutation_test.exs
@@ -15,6 +15,7 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
     development = insert(:development)
     listing = insert(:listing, development: development)
 
+    # todo remove setup in favor of: https://github.com/rstacruz/cheatsheets/blob/master/exunit.md#setup-1
     unit_params =
       string_params_for(:unit, %{
         development_uuid: development.uuid,
@@ -23,11 +24,19 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
       })
       |> Map.delete("uuid")
 
+    old_unit =
+      insert(:unit, %{
+        development_uuid: development.uuid,
+        listing_id: listing.id,
+        garage_type: "CONDOMINIUM"
+      })
+
     {
       :ok,
       unauthenticated_conn: conn,
       admin_conn: login_as(conn, admin_user),
       user_conn: login_as(conn, user_user),
+      old_unit: old_unit,
       unit_params: unit_params
     }
   end
@@ -114,5 +123,99 @@ defmodule ReWeb.GraphQL.Units.MutationTest do
 
       assert_unauthorized_response(json_response(conn, 200))
     end
+  end
+
+  describe "updateUnit" do
+    @update_mutation """
+      mutation UpdateUnit ($uuid: UUID!, $input: UnitInput!) {
+        updateUnit(uuid: $uuid, input: $input) {
+          uuid
+          complement
+          price
+          property_tax
+          maintenance_fee
+          floor
+          rooms
+          bathrooms
+          restrooms
+          area
+          garage_spots
+          garage_type
+          suites
+          dependencies
+          balconies
+          status
+          }
+        }
+    """
+
+    test "admin should update a unit", %{
+      admin_conn: conn,
+      old_unit: old_unit,
+      unit_params: unit_params
+    } do
+      variables = update_unit_variables(old_unit.uuid, unit_params)
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@update_mutation, variables))
+
+      assert %{
+               "updateUnit" => updated_unit
+             } = json_response(conn, 200)["data"]
+
+      assert updated_unit["uuid"]
+      assert updated_unit["complement"] == unit_params["complement"]
+      assert updated_unit["price"] == unit_params["price"]
+      assert updated_unit["property_tax"] == unit_params["property_tax"]
+      assert updated_unit["maintenance_fee"] == unit_params["maintenance_fee"]
+      assert updated_unit["floor"] == unit_params["floor"]
+      assert updated_unit["rooms"] == unit_params["rooms"]
+      assert updated_unit["bathrooms"] == unit_params["bathrooms"]
+      assert updated_unit["restrooms"] == unit_params["restrooms"]
+      assert updated_unit["area"] == unit_params["area"]
+      assert updated_unit["garage_spots"] == unit_params["garage_spots"]
+      assert updated_unit["garage_type"] == String.downcase(unit_params["garage_type"])
+      assert updated_unit["suites"] == unit_params["suites"]
+      assert updated_unit["dependencies"] == unit_params["dependencies"]
+      assert updated_unit["balconies"] == unit_params["balconies"]
+      assert updated_unit["status"] == unit_params["status"]
+    end
+
+    test "commom user should not update a unit", %{
+      user_conn: conn,
+      old_unit: old_unit,
+      unit_params: unit_params
+    } do
+      variables = update_unit_variables(old_unit.uuid, unit_params)
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@update_mutation, variables))
+
+      assert %{"updateUnit" => nil} == json_response(conn, 200)["data"]
+
+      assert_forbidden_response(json_response(conn, 200))
+    end
+
+    test "unauthenticated user should not update a unit", %{
+      unauthenticated_conn: conn,
+      old_unit: old_unit,
+      unit_params: unit_params
+    } do
+      variables = update_unit_variables(old_unit.uuid, unit_params)
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@update_mutation, variables))
+
+      assert %{"updateUnit" => nil} == json_response(conn, 200)["data"]
+
+      assert_unauthorized_response(json_response(conn, 200))
+    end
+  end
+
+  def update_unit_variables(uuid, unit) do
+    %{
+      "uuid" => uuid,
+      "input" => unit
+    }
   end
 end


### PR DESCRIPTION
Added GraphQL's mutation to update units. 

Another necessary change is, the lower unit price is being replicated on listing (only by now). I changed the replicator, in the original versions it receives a price and updates the listing if the price is lower than current, now it receives a list with all unit prices and applies the lowest from the list, so we don't need to control all states changes and corner case for unit price changes. 