### PR TITLE
Allow edit development listings

### DIFF
--- a/apps/re/lib/listings/policy.ex
+++ b/apps/re/lib/listings/policy.ex
@@ -10,7 +10,6 @@ defmodule Re.Listings.Policy do
 
   def authorize(_, %User{role: "admin"}, _), do: :ok
   def authorize(:create_listing, %User{role: "user"}, _), do: :ok
-  def authorize(:create_development_listing, %User{role: "admin"}, _), do: :ok
   def authorize(:show_listing, _, %{status: "active"}), do: :ok
   def authorize(:show_listing, %User{id: id}, %{user_id: id}), do: :ok
   def authorize(:show_listing, _, _), do: {:error, :not_found}

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -445,6 +445,20 @@ defmodule Re.ListingsTest do
     end
   end
 
+  describe "update/5" do
+    test "should set is exportable as false" do
+      user = insert(:user)
+      address = insert(:address)
+      development = insert(:development, address: address)
+      listing = insert(:listing, user: user)
+
+      Listings.update(listing, %{is_exportable: true}, address, user, development)
+
+      updated_listing = Repo.get(Listing, listing.id)
+      assert updated_listing.is_exportable == false
+    end
+  end
+
   describe "upsert_tags/3" do
     test "should insert tags" do
       tag_1 = insert(:tag, name: "tag 1", name_slug: "tag-1")

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -74,6 +74,19 @@ defmodule ReWeb.Resolvers.Listings do
   defp get_development(%{development_uuid: uuid}), do: Developments.get(uuid)
   defp get_development(_), do: {:error, :bad_request}
 
+  def update(%{id: id, input: %{development_uuid: _} = listing_params}, %{
+        context: %{current_user: current_user}
+      }) do
+    with {:ok, listing} <- Listings.get(id),
+         :ok <- Bodyguard.permit(Listings, :update_development_listing, current_user, listing),
+         {:ok, address} <- get_address(listing_params),
+         {:ok, development} <- get_development(listing_params),
+         {:ok, listing} <-
+           Listings.update(listing, listing_params, address, current_user, development) do
+      {:ok, listing}
+    end
+  end
+
   def update(%{id: id, input: listing_params}, %{
         context: %{current_user: current_user}
       }) do

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -77,10 +77,10 @@ defmodule ReWeb.Resolvers.Listings do
   def update(%{id: id, input: %{development_uuid: _} = listing_params}, %{
         context: %{current_user: current_user}
       }) do
-    with {:ok, listing} <- Listings.get(id),
+    with {:ok, listing} <- Listings.get_partial_preloaded(id, [:address, :development]),
          :ok <- Bodyguard.permit(Listings, :update_development_listing, current_user, listing),
-         {:ok, address} <- get_address(listing_params),
-         {:ok, development} <- get_development(listing_params),
+         address <- listing.address,
+         development <- listing.development,
          {:ok, listing} <-
            Listings.update(listing, listing_params, address, current_user, development) do
       {:ok, listing}

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -596,7 +596,6 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       }
     """
 
-    @tag dev: true
     test "admin should update development listing", %{
       admin_conn: conn,
       listing: new_listing

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -575,18 +575,144 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
 
       assert [%{"message" => "Unauthorized", "code" => 401}] = json_response(conn, 200)["errors"]
     end
+
+    @update_development_listing_mutation """
+      mutation UpdateListing ($id: ID!, $input: ListingInput!) {
+        updateListing(id: $id, input: $input) {
+          id
+          type
+          address {
+            id
+          }
+          development {
+            uuid
+          }
+          description
+          hasElevator
+          matterportCode
+          isActive
+          isExportable
+        }
+      }
+    """
+
+    test "admin should update development listing", %{
+      admin_conn: conn,
+      old_listing: old_listing,
+      listing: new_listing
+    } do
+      development = insert(:development)
+      new_address = insert(:address)
+
+      variables =
+        update_development_listing_variables(
+          old_listing.id,
+          new_listing,
+          new_address.id,
+          development.uuid
+        )
+
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@update_development_listing_mutation, variables)
+        )
+
+      assert %{
+               "updateListing" =>
+                 %{"address" => updated_address, "development" => updated_development} =
+                   updated_listing
+             } = json_response(conn, 200)["data"]
+
+      assert updated_listing["type"] == new_listing.type
+      assert updated_listing["description"] == new_listing.description
+      assert updated_listing["hasElevator"] == new_listing.has_elevator
+      assert updated_listing["matterportCode"] == new_listing.matterport_code
+      refute updated_listing["isExportable"]
+
+      assert updated_address["id"] == to_string(new_address.id)
+      assert updated_development["uuid"] == development.uuid
+    end
+
+    test "commom user should not update development listing", %{
+      user_conn: conn,
+      old_listing: old_listing,
+      listing: new_listing
+    } do
+      development = insert(:development)
+      new_address = insert(:address)
+
+      variables =
+        update_development_listing_variables(
+          old_listing.id,
+          new_listing,
+          new_address.id,
+          development.uuid
+        )
+
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@update_development_listing_mutation, variables)
+        )
+
+      assert %{"updateListing" => nil} = json_response(conn, 200)["data"]
+
+      assert_forbidden_response(json_response(conn, 200))
+    end
+
+    test "unauthenticated user should not update development listing", %{
+      unauthenticated_conn: conn,
+      old_listing: old_listing,
+      listing: new_listing
+    } do
+      development = insert(:development)
+      new_address = insert(:address)
+
+      variables =
+        update_development_listing_variables(
+          old_listing.id,
+          new_listing,
+          new_address.id,
+          development.uuid
+        )
+
+      conn =
+        post(
+          conn,
+          "/graphql_api",
+          AbsintheHelpers.mutation_wrapper(@update_development_listing_mutation, variables)
+        )
+
+      assert %{"updateListing" => nil} = json_response(conn, 200)["data"]
+
+      assert_unauthorized_response(json_response(conn, 200))
+    end
   end
 
   def insert_development_listing_variables(listing, address_id, development_uuid) do
     %{
-      "input" => %{
-        "type" => listing.type,
-        "description" => listing.description,
-        "hasElevator" => listing.has_elevator,
-        "matterportCode" => listing.matterport_code,
-        "address_id" => address_id,
-        "development_uuid" => development_uuid
-      }
+      "input" => development_listing_input(listing, address_id, development_uuid)
+    }
+  end
+
+  def update_development_listing_variables(id, listing, address_id, development_uuid) do
+    %{
+      "id" => id,
+      "input" => development_listing_input(listing, address_id, development_uuid)
+    }
+  end
+
+  defp development_listing_input(listing, address_id, development_uuid) do
+    %{
+      "type" => listing.type,
+      "description" => listing.description,
+      "hasElevator" => listing.has_elevator,
+      "matterportCode" => listing.matterport_code,
+      "address_id" => address_id,
+      "development_uuid" => development_uuid
     }
   end
 end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -596,13 +596,14 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       }
     """
 
+    @tag dev: true
     test "admin should update development listing", %{
       admin_conn: conn,
-      old_listing: old_listing,
       listing: new_listing
     } do
       development = insert(:development)
       new_address = insert(:address)
+      old_listing = insert(:listing, development: development, address: new_address)
 
       variables =
         update_development_listing_variables(


### PR DESCRIPTION
	* Add GraphQL queries to edit development listings with
	right validations when updateListing mutation receives
	development_uuid params.
	* Remove create policy once the match will occur always at first
	 policy function.
	* Extract development listing input.
--- 

Also, add a new param for each association for both insert and update functions doesn't seem to be a good pattern, it tends to increase the params number as well to lead to not so flexible public APIs. My next step is to open a new PR refactoring those cases to use a map as the third param with associations and matching it against the right insert/update function, i.e., `def update(listing, params, %{user: user, address: address} = associations)`

Have you any other suggestions/options for this topic? 