### PR TITLE
Filter listing by tag slug name or uuid on graphql query

### DIFF
--- a/apps/re/lib/listings/queries/queries.ex
+++ b/apps/re/lib/listings/queries/queries.ex
@@ -90,10 +90,11 @@ defmodule Re.Listings.Queries do
     |> exclude(:preload)
     |> exclude(:order_by)
     |> exclude(:limit)
+    |> exclude(:distinct)
     |> count()
   end
 
-  def count(query \\ Listing), do: from(l in query, select: count(l.id))
+  def count(query \\ Listing), do: from(l in query, select: count(l.id, :distinct))
 
   def per_user(query \\ Listing, user_id), do: from(l in query, where: l.user_id == ^user_id)
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -61,7 +61,7 @@ defmodule Re.ListingsTest do
           lng: -43.19675540000001
         )
 
-      {:ok, %{id: id1}} =
+      %{id: id1} =
         insert(
           :listing,
           price: 100,
@@ -72,11 +72,11 @@ defmodule Re.ListingsTest do
           address_id: sao_conrado.id,
           type: "Apartamento",
           garage_spots: 3,
-          garage_type: "contract"
+          garage_type: "contract",
+          tags: [tag_1, tag_2]
         )
-        |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
-      {:ok, %{id: id2}} =
+      %{id: id2} =
         insert(
           :listing,
           price: 110,
@@ -87,11 +87,11 @@ defmodule Re.ListingsTest do
           address_id: leblon.id,
           type: "Apartamento",
           garage_spots: 2,
-          garage_type: "condominium"
+          garage_type: "condominium",
+          tags: [tag_1, tag_2, tag_3]
         )
-        |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid, tag_3.uuid])
 
-      {:ok, %{id: id3}} =
+      %{id: id3} =
         insert(
           :listing,
           price: 90,
@@ -102,9 +102,9 @@ defmodule Re.ListingsTest do
           address_id: botafogo.id,
           type: "Casa",
           garage_spots: 1,
-          garage_type: "contract"
+          garage_type: "contract",
+          tags: [tag_3]
         )
-        |> Re.Listings.upsert_tags([tag_3.uuid])
 
       result = Listings.paginated(%{"max_price" => 105})
       assert [%{id: ^id1}, %{id: ^id3}] = chunk_and_short(result.listings)
@@ -208,17 +208,13 @@ defmodule Re.ListingsTest do
       leblon = insert(:address, street: "anotherstreet", neighborhood: "Leblon")
       botafogo = insert(:address, street: "onemorestreet", neighborhood: "Botafogo")
 
-      {:ok, %{id: id1}} =
-        insert(:listing, score: 4, address_id: laranjeiras.id, type: "Apartamento")
-        |> Listings.upsert_tags([tag_1.uuid])
+      %{id: id1} =
+        insert(:listing, score: 4, address_id: laranjeiras.id, type: "Apartamento", tags: [tag_1])
 
-      {:ok, %{id: id2}} =
-        insert(:listing, score: 3, address_id: leblon.id, type: "Casa")
-        |> Listings.upsert_tags([tag_2.uuid])
+      %{id: id2} = insert(:listing, score: 3, address_id: leblon.id, type: "Casa", tags: [tag_2])
 
-      {:ok, %{id: id3}} =
-        insert(:listing, score: 2, address_id: botafogo.id, type: "Apartamento")
-        |> Listings.upsert_tags([tag_3.uuid])
+      %{id: id3} =
+        insert(:listing, score: 2, address_id: botafogo.id, type: "Apartamento", tags: [tag_3])
 
       result = Listings.paginated(%{"neighborhoods" => []})
       assert [%{id: ^id1}, %{id: ^id2}, %{id: ^id3}] = chunk_and_short(result.listings)

--- a/apps/re/test/listings/queries_test.exs
+++ b/apps/re/test/listings/queries_test.exs
@@ -64,7 +64,7 @@ defmodule Re.Listings.QueriesTest do
   end
 
   describe "remaining_count/2" do
-    test "get remaining count with single tag search" do
+    test "remaining count with single tag search should bring correct number of listings" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       insert(:listing, tags: [tag_1])
       insert(:listing, tags: [tag_1])
@@ -78,7 +78,7 @@ defmodule Re.Listings.QueriesTest do
       assert 2 == result
     end
 
-    test "get remaining count with multi tag search" do
+    test "remaining count with multi tag search should bring correct number of listings, despite many to many relation" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
       insert(:listing, tags: [tag_1, tag_2])

--- a/apps/re/test/listings/queries_test.exs
+++ b/apps/re/test/listings/queries_test.exs
@@ -2,6 +2,8 @@ defmodule Re.Listings.QueriesTest do
   use Re.ModelCase
 
   alias Re.{
+    Filtering,
+    Listing,
     Listings.Queries,
     Repo
   }
@@ -62,7 +64,33 @@ defmodule Re.Listings.QueriesTest do
   end
 
   describe "remaining_count/2" do
-    test "get remaining count with tags" do
+    test "get remaining count with single tag search" do
+      tag_1 = insert(:tag)
+      insert(:listing, tags: [tag_1])
+      insert(:listing, tags: [tag_1])
+
+      result =
+        Listing
+        |> Filtering.apply(%{tags_uuid: [tag_1.uuid]})
+        |> Queries.remaining_count()
+        |> Repo.one()
+
+      assert 2 == result
+    end
+
+    test "get remaining count with multi tag search" do
+      tag_1 = insert(:tag)
+      tag_2 = insert(:tag)
+      insert(:listing, tags: [tag_1, tag_2])
+      insert(:listing, tags: [tag_1, tag_2])
+
+      result =
+        Listing
+        |> Filtering.apply(%{tags_uuid: [tag_1.uuid, tag_2.uuid]})
+        |> Queries.remaining_count()
+        |> Repo.one()
+
+      assert 2 == result
     end
   end
 end

--- a/apps/re/test/listings/queries_test.exs
+++ b/apps/re/test/listings/queries_test.exs
@@ -65,7 +65,7 @@ defmodule Re.Listings.QueriesTest do
 
   describe "remaining_count/2" do
     test "get remaining count with single tag search" do
-      tag_1 = insert(:tag)
+      tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       insert(:listing, tags: [tag_1])
       insert(:listing, tags: [tag_1])
 
@@ -79,8 +79,8 @@ defmodule Re.Listings.QueriesTest do
     end
 
     test "get remaining count with multi tag search" do
-      tag_1 = insert(:tag)
-      tag_2 = insert(:tag)
+      tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
+      tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
       insert(:listing, tags: [tag_1, tag_2])
       insert(:listing, tags: [tag_1, tag_2])
 

--- a/apps/re/test/listings/queries_test.exs
+++ b/apps/re/test/listings/queries_test.exs
@@ -60,4 +60,9 @@ defmodule Re.Listings.QueriesTest do
       assert expected == result
     end
   end
+
+  describe "remaining_count/2" do
+    test "get remaining count with tags" do
+    end
+  end
 end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -203,8 +203,8 @@ defmodule ReWeb.Types.Listing do
     field :garage_types, list_of(:garage_type)
     field :cities, list_of(:string)
     field :cities_slug, list_of(:string)
-    field :tags_slug, list_of(:string)
-    field :tags_uuid, list_of(:uuid)
+    field :tags_slug, list_of(non_null(:string))
+    field :tags_uuid, list_of(non_null(:uuid))
   end
 
   object :listing_filter do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -203,6 +203,8 @@ defmodule ReWeb.Types.Listing do
     field :garage_types, list_of(:garage_type)
     field :cities, list_of(:string)
     field :cities_slug, list_of(:string)
+    field :tags_slug, list_of(:string)
+    field :tags_uuid, list_of(:uuid)
   end
 
   object :listing_filter do
@@ -226,6 +228,8 @@ defmodule ReWeb.Types.Listing do
     field :garage_types, list_of(:garage_type)
     field :cities, list_of(:string)
     field :cities_slug, list_of(:string)
+    field :tags_slug, list_of(:string)
+    field :tags_uuid, list_of(:uuid)
   end
 
   object :price_history do

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -305,6 +305,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
     end
 
     test "should query listing index with filtering", %{user_conn: conn} do
+      tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
+      tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
+
       insert(
         :listing,
         price: 1_100_000,
@@ -323,6 +326,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -342,6 +346,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -361,6 +366,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -380,6 +386,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -399,6 +406,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -418,6 +426,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -437,6 +446,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -456,6 +466,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -475,6 +486,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -494,6 +506,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -513,6 +526,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "contract"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -532,6 +546,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_spots: 2,
         garage_type: "condominium"
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -550,6 +565,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 0
       )
+      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -593,7 +609,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_type: "condominium"
       )
 
-      listing1 =
+      {:ok, listing1} =
         insert(
           :listing,
           price: 900_000,
@@ -616,6 +632,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           garage_spots: 2,
           garage_type: "contract"
         )
+        |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       variables = %{
         "filters" => %{
@@ -638,7 +655,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           "minGarageSpots" => 1,
           "garageTypes" => ["CONTRACT"],
           "cities" => ["Rio de Janeiro"],
-          "citiesSlug" => ["rio-de-janeiro"]
+          "citiesSlug" => ["rio-de-janeiro"],
+          "tagsSlug" => ["tag-1", "tag-2"]
         }
       }
 

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -324,9 +324,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_1]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -344,9 +344,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_1]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -364,9 +364,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_1]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -384,9 +384,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_1]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -404,9 +404,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_1]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid])
 
       insert(
         :listing,
@@ -424,9 +424,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -444,9 +444,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -464,9 +464,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -484,9 +484,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -504,9 +504,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_2.uuid])
 
       insert(
         :listing,
@@ -524,9 +524,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 70.0
           ),
         garage_spots: 2,
-        garage_type: "contract"
+        garage_type: "contract",
+        tags: [tag_1, tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -544,9 +544,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 30.0
           ),
         garage_spots: 2,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        tags: [tag_1, tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -563,9 +563,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lat: 50.0,
             lng: 50.0
           ),
-        garage_spots: 0
+        garage_spots: 0,
+        tags: [tag_1, tag_2]
       )
-      |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       insert(
         :listing,
@@ -609,7 +609,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_type: "condominium"
       )
 
-      {:ok, listing1} =
+      listing1 =
         insert(
           :listing,
           price: 900_000,
@@ -630,9 +630,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
               lng: 50.0
             ),
           garage_spots: 2,
-          garage_type: "contract"
+          garage_type: "contract",
+          tags: [tag_1, tag_2]
         )
-        |> Re.Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
       variables = %{
         "filters" => %{


### PR DESCRIPTION
Add the option to search listings by list of tag slugs name or uuids. Example:

```graphql
query {
  listings(filters: {tagsSlug: ["salao-de-festas"]}) {
    listings {
      id
      address {
        street
        streetNumber
      }
    }
  }
}
```