### PR TITLE
Grahpql insert images on development

### DIFF
--- a/apps/re/lib/developments/developments.ex
+++ b/apps/re/lib/developments/developments.ex
@@ -8,6 +8,7 @@ defmodule Re.Developments do
 
   alias Re.{
     Development,
+    Developments.Queries,
     Repo
   }
 
@@ -25,6 +26,9 @@ defmodule Re.Developments do
   end
 
   def get(uuid), do: do_get(Development, uuid)
+
+  def get_preloaded(uuid, preload),
+    do: do_get(Queries.preload_relations(Development, preload), uuid)
 
   defp do_get(query, uuid) do
     case Repo.get(query, uuid) do

--- a/apps/re/lib/developments/queries.ex
+++ b/apps/re/lib/developments/queries.ex
@@ -1,0 +1,13 @@
+defmodule Re.Developments.Queries do
+  @moduledoc """
+  Module for grouping develpments queries
+  """
+
+  alias Re.Development
+
+  import Ecto.Query
+
+  def preload_relations(query \\ Development, relations \\ [])
+
+  def preload_relations(query, relations), do: preload(query, ^relations)
+end

--- a/apps/re/lib/developments/queries.ex
+++ b/apps/re/lib/developments/queries.ex
@@ -1,6 +1,6 @@
 defmodule Re.Developments.Queries do
   @moduledoc """
-  Module for grouping develpments queries
+  Module for grouping developments queries
   """
 
   alias Re.Development

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -38,12 +38,23 @@ defmodule Re.Images do
     end
   end
 
-  def insert(image_params, listing) do
+  def insert(image_params, listing, assoc \\ nil)
+
+  def insert(image_params, listing, nil) do
     %Image{}
     |> Image.create_changeset(image_params)
     |> Changeset.change(listing: listing)
     |> Changeset.change(is_active: true)
     |> Changeset.change(position: calculate_position(listing))
+    |> Repo.insert()
+  end
+
+  def insert(image_params, development, :development) do
+    %Image{}
+    |> Image.create_changeset(image_params)
+    |> Changeset.change(development: development)
+    |> Changeset.change(is_active: true)
+    |> Changeset.change(position: calculate_position(development))
     |> Repo.insert()
   end
 

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -38,25 +38,22 @@ defmodule Re.Images do
     end
   end
 
-  def insert(image_params, listing, assoc \\ nil)
-
-  def insert(image_params, listing, nil) do
+  def insert(image_params, association) do
     %Image{}
     |> Image.create_changeset(image_params)
-    |> Changeset.change(listing: listing)
-    |> Changeset.change(is_active: true)
-    |> Changeset.change(position: calculate_position(listing))
+    |> change_association(association)
+    |> Changeset.change(%{
+      is_active: true,
+      position: calculate_position(association)
+    })
     |> Repo.insert()
   end
 
-  def insert(image_params, development, :development) do
-    %Image{}
-    |> Image.create_changeset(image_params)
-    |> Changeset.change(development: development)
-    |> Changeset.change(is_active: true)
-    |> Changeset.change(position: calculate_position(development))
-    |> Repo.insert()
-  end
+  defp change_association(changeset, %Re.Listing{} = listing),
+    do: Changeset.change(changeset, listing: listing)
+
+  defp change_association(changeset, %Re.Development{} = development),
+    do: Changeset.change(changeset, development: development)
 
   defp calculate_position(%{images: []}), do: 1
   defp calculate_position(%{images: [top_image | _]}), do: top_image.position - 1

--- a/apps/re/test/images/images_test.exs
+++ b/apps/re/test/images/images_test.exs
@@ -52,4 +52,28 @@ defmodule Re.ImagesTest do
                ])
     end
   end
+
+  describe "insert/2" do
+    @insert_params %{filename: "test.jpg"}
+
+    test "should insert listing image active" do
+      listing =
+        insert(:listing)
+        |> Re.Repo.preload([:images])
+
+      {:ok, inserted_image} = Images.insert(@insert_params, listing)
+      assert inserted_image.is_active == true
+      assert inserted_image.listing == listing
+    end
+
+    test "should insert development image active" do
+      development =
+        insert(:development)
+        |> Re.Repo.preload([:images])
+
+      {:ok, inserted_image} = Images.insert(@insert_params, development)
+      assert inserted_image.is_active == true
+      assert inserted_image.development == development
+    end
+  end
 end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -63,7 +63,7 @@ defmodule ReWeb.Resolvers.Images do
     with {:ok, development} <- Developments.get_preloaded(parent_uuid, [:images]),
          :ok <- Bodyguard.permit(Images, :create_development_images, current_user, development),
          {:ok, image} <- Images.insert(params, development, :development) do
-      {:ok, %{parent_listing: nil, image: image}}
+      {:ok, %{parent: development, image: image}}
     end
   end
 
@@ -125,8 +125,7 @@ defmodule ReWeb.Resolvers.Images do
   def update_images_trigger(%{parent_listing: %{id: id}}), do: "images_updated:#{id}"
 
   def insert_image_trigger(%{parent_listing: %{id: id}}), do: "images_inserted:#{id}"
-
-  def insert_image_trigger(%{parent_type: %{uuid: uuid}}), do: "images_inserted:#{uuid}"
+  def insert_image_trigger(%{parent: %Re.Development{uuid: uuid}}), do: "images_inserted:#{uuid}"
 
   defp config_subscription(%{listing_id: id}, %{role: "admin"}, topic),
     do: {:ok, topic: "#{topic}:#{id}"}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -60,8 +60,8 @@ defmodule ReWeb.Resolvers.Images do
   def insert_image(%{input: %{parent_type: :development, parent_uuid: parent_uuid} = params}, %{
         context: %{current_user: current_user}
       }) do
-    with {:ok, development} <- Developments.get_preloaded(parent_uuid, [:images]),
-         :ok <- Bodyguard.permit(Images, :create_development_images, current_user, development),
+    with :ok <- Bodyguard.permit(Images, :create_development_images, current_user, nil),
+         {:ok, development} <- Developments.get_preloaded(parent_uuid, [:images]),
          {:ok, image} <- Images.insert(params, development) do
       {:ok, %{parent: development, image: image}}
     end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -62,7 +62,7 @@ defmodule ReWeb.Resolvers.Images do
       }) do
     with {:ok, development} <- Developments.get_preloaded(parent_uuid, [:images]),
          :ok <- Bodyguard.permit(Images, :create_development_images, current_user, development),
-         {:ok, image} <- Images.insert(params, development, :development) do
+         {:ok, image} <- Images.insert(params, development) do
       {:ok, %{parent: development, image: image}}
     end
   end

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -125,7 +125,9 @@ defmodule ReWeb.Resolvers.Images do
   def update_images_trigger(%{parent_listing: %{id: id}}), do: "images_updated:#{id}"
 
   def insert_image_trigger(%{parent_listing: %{id: id}}), do: "images_inserted:#{id}"
-  def insert_image_trigger(%{parent: %Re.Development{uuid: uuid}}), do: "images_inserted:#{uuid}"
+
+  def insert_image_trigger(%{parent: %Re.Development{uuid: uuid}}),
+    do: "development_updated:#{uuid}"
 
   defp config_subscription(%{listing_id: id}, %{role: "admin"}, topic),
     do: {:ok, topic: "#{topic}:#{id}"}

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -45,11 +45,22 @@ defmodule ReWeb.Types.Image do
   object :image_output do
     field :image, :image
     field :parent_listing, :listing
+    field :parent, :image_parent
   end
 
   object :images_output do
     field :images, list_of(:image)
     field :parent_listing, :listing
+    field :parent, :image_parent
+  end
+
+  union :image_parent do
+    types([:development, :listing])
+
+    resolve_type(fn
+      %Re.Development{}, _ -> :development
+      %Re.Listing{}, _ -> :listing
+    end)
   end
 
   object :image_mutations do

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -123,7 +123,8 @@ defmodule ReWeb.Types.Image do
 
     @desc "Subscribe to image insertion"
     field :image_inserted, :image_output do
-      arg :listing_id, non_null(:id)
+      arg :listing_id, :id
+      arg :development_uuid, :uuid
 
       config &Resolvers.Images.image_inserted_config/2
 

--- a/apps/re_web/lib/graphql/types/image.ex
+++ b/apps/re_web/lib/graphql/types/image.ex
@@ -15,8 +15,12 @@ defmodule ReWeb.Types.Image do
     field :category, :string
   end
 
+  enum :image_parent_type, values: ~w(listing development)a
+
   input_object :image_insert_input do
-    field :listing_id, non_null(:id)
+    field :parent_uuid, :uuid
+    field :parent_type, :image_parent_type
+    field :listing_id, :id
     field :filename, non_null(:string)
     field :is_active, :boolean
     field :description, :string

--- a/apps/re_web/test/graphql/images/mutation_test.exs
+++ b/apps/re_web/test/graphql/images/mutation_test.exs
@@ -22,6 +22,20 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
   end
 
   describe "insert" do
+    @insert_mutation """
+      mutation InsertImage ($input: ImageInsertInput!) {
+        insertImage(input: $input) {
+          image {
+            description
+            filename
+            isActive
+            position
+            category
+          }
+        }
+      }
+    """
+
     test "admin should insert image", %{admin_conn: conn} do
       %{id: listing_id} = insert(:listing)
 
@@ -32,21 +46,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert %{
                "image" => %{
@@ -69,21 +70,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert %{
                "image" => %{
@@ -106,21 +94,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert_forbidden_response(json_response(conn, 200))
     end
@@ -135,26 +110,12 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert_unauthorized_response(json_response(conn, 200))
     end
 
-    @tag dev: true
     test "admin should insert image of development type", %{admin_conn: conn} do
       %{uuid: development_uuid} = insert(:development)
 
@@ -166,21 +127,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert %{
                "image" => %{
@@ -193,7 +141,6 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
              } == json_response(conn, 200)["data"]["insertImage"]
     end
 
-    @tag dev: true
     test "commom user should not insert image of development type", %{user_conn: conn} do
       %{uuid: development_uuid} = insert(:development)
 
@@ -205,26 +152,12 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert_forbidden_response(json_response(conn, 200))
     end
 
-    @tag dev: true
     test "unauthenticated user should not insert image of development type", %{
       unauthenticated_conn: conn
     } do
@@ -238,21 +171,8 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
         }
       }
 
-      mutation = """
-        mutation InsertImage ($input: ImageInsertInput!) {
-          insertImage(input: $input) {
-            image {
-              description
-              filename
-              isActive
-              position
-              category
-            }
-          }
-        }
-      """
-
-      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@insert_mutation, variables))
 
       assert_unauthorized_response(json_response(conn, 200))
     end

--- a/apps/re_web/test/graphql/images/mutation_test.exs
+++ b/apps/re_web/test/graphql/images/mutation_test.exs
@@ -153,6 +153,109 @@ defmodule ReWeb.GraphQL.Images.MutationTest do
 
       assert_unauthorized_response(json_response(conn, 200))
     end
+
+    @tag dev: true
+    test "admin should insert image of development type", %{admin_conn: conn} do
+      %{uuid: development_uuid} = insert(:development)
+
+      variables = %{
+        "input" => %{
+          "parentUuid" => development_uuid,
+          "parentType" => "DEVELOPMENT",
+          "filename" => "test.jpg"
+        }
+      }
+
+      mutation = """
+        mutation InsertImage ($input: ImageInsertInput!) {
+          insertImage(input: $input) {
+            image {
+              description
+              filename
+              isActive
+              position
+              category
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert %{
+               "image" => %{
+                 "description" => nil,
+                 "filename" => "test.jpg",
+                 "isActive" => true,
+                 "position" => 1,
+                 "category" => nil
+               }
+             } == json_response(conn, 200)["data"]["insertImage"]
+    end
+
+    @tag dev: true
+    test "commom user should not insert image of development type", %{user_conn: conn} do
+      %{uuid: development_uuid} = insert(:development)
+
+      variables = %{
+        "input" => %{
+          "parentUuid" => development_uuid,
+          "parentType" => "DEVELOPMENT",
+          "filename" => "test.jpg"
+        }
+      }
+
+      mutation = """
+        mutation InsertImage ($input: ImageInsertInput!) {
+          insertImage(input: $input) {
+            image {
+              description
+              filename
+              isActive
+              position
+              category
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert_forbidden_response(json_response(conn, 200))
+    end
+
+    @tag dev: true
+    test "unauthenticated user should not insert image of development type", %{
+      unauthenticated_conn: conn
+    } do
+      %{uuid: development_uuid} = insert(:development)
+
+      variables = %{
+        "input" => %{
+          "parentUuid" => development_uuid,
+          "parentType" => "DEVELOPMENT",
+          "filename" => "test.jpg"
+        }
+      }
+
+      mutation = """
+        mutation InsertImage ($input: ImageInsertInput!) {
+          insertImage(input: $input) {
+            image {
+              description
+              filename
+              isActive
+              position
+              category
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert_unauthorized_response(json_response(conn, 200))
+    end
   end
 
   describe "update" do


### PR DESCRIPTION
Allow insertion of different image types. It required some changes and I took the opportunity to add a more flexible interface for images, main changes are: 
- Now we have a parent_type, to allow be associated with multiple types, we can use pattern match to route the insertion to right resolver function. 
- Using uuid to identify the parent. 
- Now the parent is returned, added a new output param called `parent` by now it can be both `Development` or `Listing` union type, in the future, we can add more image associations (tags, user, etc..) without brake public API. 
- Removed `listing_id` as non-null once development images will not know this param. 

In the sequence I'll: 
- Make the same for image updates, activation and deactivation. 
- Add this same interface to handle listing images and deprecated the old one, so in a nearby future, we can turn both `parentType` and `uuid` non_null. 
- Will change the way we work with image subscription, notifying the association update, so instead of emitting an `images_update:{id}`, we'll emit `development_updated:uuid`, etc. 

Suggestions for other approaches are always welcome. 