### PR TITLE
Refactor zapier integration to validate payload through changeset

### DIFF
--- a/apps/re/lib/leads/facebook_buyer.ex
+++ b/apps/re/lib/leads/facebook_buyer.ex
@@ -20,7 +20,17 @@ defmodule Re.Leads.FacebookBuyer do
     timestamps()
   end
 
-  @params ~w(full_name email phone_number neighborhoods timestamp lead_id location)a
+  @required ~w(full_name email phone_number timestamp lead_id location)a
+  @optional ~w(neighborhoods)a
+  @params @required ++ @optional
+  @locations ~w(RJ SP)
 
-  def changeset(struct, params \\ %{}), do: cast(struct, params, @params)
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @params)
+    |> validate_required(@required)
+    |> validate_inclusion(:location, @locations,
+      message: "should be one of: [#{Enum.join(@locations, " ")}]"
+    )
+  end
 end

--- a/apps/re_web/lib/webhooks/zapier_plug.ex
+++ b/apps/re_web/lib/webhooks/zapier_plug.ex
@@ -15,7 +15,6 @@ defmodule ReWeb.Webhooks.ZapierPlug do
 
   def call(%{method: "POST", params: params} = conn, _args) do
     with :ok <- validate_credentials(conn),
-         :ok <- Zapier.validate_payload(params),
          {:ok, _} <- Zapier.new_buyer_lead(params) do
       conn
       |> put_resp_content_type("text/plain")


### PR DESCRIPTION
Zapier's integration warned that `neighborhoods` is optional, so I'm adding a proper changeset validation rather than a poorly-written pattern match.