### PR TITLE
Allow to show and edit tags in listings queries/mutations

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -234,6 +234,8 @@ defmodule Re.Listings do
     |> Repo.all()
   end
 
+  def upsert_tags(listing, nil), do: {:ok, listing}
+
   def upsert_tags(listing, tag_uuids) do
     tags = Tags.list_by_uuids(tag_uuids)
 

--- a/apps/re/lib/tags/dataloader_queries.ex
+++ b/apps/re/lib/tags/dataloader_queries.ex
@@ -1,0 +1,10 @@
+defmodule Re.Tags.DataloaderQueries do
+  @moduledoc """
+  Module for grouping tags queries
+  """
+  import Ecto.Query
+
+  def build(query, %{user: %{role: "admin"}}), do: query
+
+  def build(query, _), do: where(query, [t], t.visibility == "public")
+end

--- a/apps/re/lib/tags/tags.ex
+++ b/apps/re/lib/tags/tags.ex
@@ -8,6 +8,7 @@ defmodule Re.Tags do
 
   alias Re.{
     Tag,
+    Tags.DataloaderQueries,
     Tags.Queries,
     Repo,
     Slugs
@@ -17,7 +18,7 @@ defmodule Re.Tags do
 
   def data(params), do: Dataloader.Ecto.new(Repo, query: &query/2, default_params: params)
 
-  def query(_query, _args), do: Tag
+  def query(query, args), do: DataloaderQueries.build(query, args)
 
   def all(user) do
     %{}

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -488,7 +488,7 @@ defmodule Re.ListingsTest do
     end
   end
 
-  describe "upsert_tags/3" do
+  describe "upsert_tags/2" do
     test "should insert tags" do
       tag_1 = insert(:tag, name: "tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "tag 2", name_slug: "tag-2")
@@ -517,10 +517,7 @@ defmodule Re.ListingsTest do
 
       user = insert(:user)
 
-      {:ok, listing} =
-        insert(:listing, user: user)
-        |> Repo.preload([:tags])
-        |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
+      listing = insert(:listing, user: user, tags: [tag_1, tag_2])
 
       {:ok, updated_listing} = Listings.upsert_tags(listing, [tag_3.uuid])
 
@@ -536,16 +533,28 @@ defmodule Re.ListingsTest do
 
       user = insert(:user)
 
-      {:ok, listing} =
-        insert(:listing, user: user)
-        |> Repo.preload([:tags])
-        |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
+      listing = insert(:listing, user: user, tags: [tag_1, tag_2])
 
       {:ok, updated_listing} = Listings.upsert_tags(listing, [])
 
       assert Enum.count(updated_listing.tags) == 0
       refute Enum.member?(updated_listing.tags, tag_1)
       refute Enum.member?(updated_listing.tags, tag_2)
+    end
+
+    test "noop when no tags is nil" do
+      tag_1 = insert(:tag, name: "tag 1", name_slug: "tag-1")
+      tag_2 = insert(:tag, name: "tag 2", name_slug: "tag-2")
+
+      user = insert(:user)
+
+      listing = insert(:listing, user: user, tags: [tag_1, tag_2])
+
+      {:ok, updated_listing} = Listings.upsert_tags(listing, nil)
+
+      assert Enum.count(updated_listing.tags) == 2
+      assert Enum.member?(updated_listing.tags, tag_1)
+      assert Enum.member?(updated_listing.tags, tag_2)
     end
   end
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -542,7 +542,7 @@ defmodule Re.ListingsTest do
       refute Enum.member?(updated_listing.tags, tag_2)
     end
 
-    test "noop when no tags is nil" do
+    test "should not upsert when tags is nil" do
       tag_1 = insert(:tag, name: "tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "tag 2", name_slug: "tag-2")
 

--- a/apps/re/test/tags/dataloader_test.exs
+++ b/apps/re/test/tags/dataloader_test.exs
@@ -1,0 +1,74 @@
+defmodule Re.Tags.DataloaderTest do
+  use Re.ModelCase
+
+  alias Re.{
+    Tag,
+    Tags
+  }
+
+  test "admin user should fetch tags with private visibility" do
+    loader =
+      Dataloader.add_source(
+        Dataloader.new(),
+        :tags,
+        Tags.data(%{user: %{role: "admin"}})
+      )
+
+    loader =
+      loader
+      |> Dataloader.load(
+        :tags,
+        {:many, Tag},
+        visibility: "private"
+      )
+      |> Dataloader.run()
+
+    tags = Dataloader.get(loader, :tags, {:many, Tag}, visibility: "private")
+
+    assert 3 == Enum.count(tags)
+  end
+
+  test "regular user should not fetch tags with private visibility" do
+    loader =
+      Dataloader.add_source(
+        Dataloader.new(),
+        :tags,
+        Tags.data(%{user: %{role: "user"}})
+      )
+
+    loader =
+      loader
+      |> Dataloader.load(
+        :tags,
+        {:many, Tag},
+        visibility: "private"
+      )
+      |> Dataloader.run()
+
+    tags = Dataloader.get(loader, :tags, {:many, Tag}, visibility: "private")
+
+    assert 0 == Enum.count(tags)
+  end
+
+  test "anonymous user should not fetch tags with private visibility" do
+    loader =
+      Dataloader.add_source(
+        Dataloader.new(),
+        :tags,
+        Tags.data(%{user: nil})
+      )
+
+    loader =
+      loader
+      |> Dataloader.load(
+        :tags,
+        {:many, Tag},
+        visibility: "private"
+      )
+      |> Dataloader.run()
+
+    tags = Dataloader.get(loader, :tags, {:many, Tag}, visibility: "private")
+
+    assert 0 == Enum.count(tags)
+  end
+end

--- a/apps/re/test/tags/dataloader_test.exs
+++ b/apps/re/test/tags/dataloader_test.exs
@@ -47,7 +47,7 @@ defmodule Re.Tags.DataloaderTest do
 
     tags = Dataloader.get(loader, :tags, {:many, Tag}, visibility: "private")
 
-    assert 0 == Enum.count(tags)
+    assert [] == tags
   end
 
   test "anonymous user should not fetch tags with private visibility" do
@@ -69,6 +69,6 @@ defmodule Re.Tags.DataloaderTest do
 
     tags = Dataloader.get(loader, :tags, {:many, Tag}, visibility: "private")
 
-    assert 0 == Enum.count(tags)
+    assert [] == tags
   end
 end

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -84,7 +84,8 @@ defmodule ReWeb.Resolvers.Listings do
          address <- listing.address,
          development <- listing.development,
          {:ok, listing} <-
-           Listings.update(listing, listing_params, address, current_user, development) do
+           Listings.update(listing, listing_params, address, current_user, development),
+         {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     end
   end
@@ -95,7 +96,8 @@ defmodule ReWeb.Resolvers.Listings do
     with {:ok, listing} <- Listings.get(id),
          :ok <- Bodyguard.permit(Listings, :update_listing, current_user, listing),
          {:ok, address} <- get_address(listing_params),
-         {:ok, listing} <- Listings.update(listing, listing_params, address, current_user) do
+         {:ok, listing} <- Listings.update(listing, listing_params, address, current_user),
+         {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     end
   end

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -48,7 +48,8 @@ defmodule ReWeb.Resolvers.Listings do
            Bodyguard.permit(Listings, :create_development_listing, current_user, listing_params),
          {:ok, address} <- get_address(listing_params),
          {:ok, development} <- get_development(listing_params),
-         {:ok, listing} <- Listings.insert(listing_params, address, current_user, development) do
+         {:ok, listing} <- Listings.insert(listing_params, address, current_user, development),
+         {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     else
       {:error, _, error, _} -> {:error, error}
@@ -59,7 +60,8 @@ defmodule ReWeb.Resolvers.Listings do
   def insert(%{input: listing_params}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Listings, :create_listing, current_user, listing_params),
          {:ok, address} <- get_address(listing_params),
-         {:ok, listing} <- Listings.insert(listing_params, address, current_user) do
+         {:ok, listing} <- Listings.insert(listing_params, address, current_user),
+         {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     else
       {:error, _, error, _} -> {:error, error}

--- a/apps/re_web/lib/graphql/resolvers/tags.ex
+++ b/apps/re_web/lib/graphql/resolvers/tags.ex
@@ -2,6 +2,8 @@ defmodule ReWeb.Resolvers.Tags do
   @moduledoc """
   Resolvers for tags.
   """
+  import Absinthe.Resolution.Helpers, only: [on_load: 2]
+
   alias Re.Tags
 
   def index(params, %{context: %{current_user: current_user}}) do
@@ -13,14 +15,20 @@ defmodule ReWeb.Resolvers.Tags do
     {:ok, tags}
   end
 
+  def show(%{uuid: uuid}, %{context: %{current_user: current_user}}) do
+    Tags.get(uuid, current_user)
+  end
+
   def search(%{name: name}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Tags, :search, current_user, %{name: name}) do
       {:ok, Tags.search(name)}
     end
   end
 
-  def show(%{uuid: uuid}, %{context: %{current_user: current_user}}) do
-    Tags.get(uuid, current_user)
+  def per_listing(listing, _params, %{context: %{loader: loader}}) do
+    loader
+    |> Dataloader.load(Tags, :tags, listing)
+    |> on_load(fn loader -> {:ok, Dataloader.get(loader, Tags, :tags, listing)} end)
   end
 
   def insert(%{input: params}, %{context: %{current_user: current_user}}) do

--- a/apps/re_web/lib/graphql/resolvers/tags.ex
+++ b/apps/re_web/lib/graphql/resolvers/tags.ex
@@ -25,10 +25,12 @@ defmodule ReWeb.Resolvers.Tags do
     end
   end
 
-  def per_listing(listing, _params, %{context: %{loader: loader}}) do
+  def per_listing(listing, _params, %{context: %{loader: loader, current_user: current_user}}) do
     loader
-    |> Dataloader.load(Tags, :tags, listing)
-    |> on_load(fn loader -> {:ok, Dataloader.get(loader, Tags, :tags, listing)} end)
+    |> Dataloader.load(Tags, {:tags, %{user: current_user}}, listing)
+    |> on_load(fn loader ->
+      {:ok, Dataloader.get(loader, Tags, {:tags, %{user: current_user}}, listing)}
+    end)
   end
 
   def insert(%{input: params}, %{context: %{current_user: current_user}}) do

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -83,6 +83,7 @@ defmodule ReWeb.Schema do
       Re.Statistics.ListingVisualizations,
       Re.Statistics.TourVisualizations,
       Re.Statistics.InPersonVisits,
+      Re.Tags,
       Re.Units
     ]
   end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -111,7 +111,7 @@ defmodule ReWeb.Types.Listing do
 
     field :development_uuid, :uuid
 
-    field :tags, list_of(:uuid)
+    field :tags, list_of(non_null(:uuid))
   end
 
   enum :garage_type, values: ~w(contract condominium)

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -76,6 +76,8 @@ defmodule ReWeb.Types.Listing do
     field :units, list_of(:unit), resolve: &Resolvers.Units.per_listing/3
 
     field :development, :development, resolve: &Resolvers.Developments.per_listing/3
+
+    field :tags, list_of(:tag), resolve: &Resolvers.Tags.per_listing/3
   end
 
   input_object :listing_input do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -110,6 +110,8 @@ defmodule ReWeb.Types.Listing do
     field :address_id, :id
 
     field :development_uuid, :uuid
+
+    field :tags, list_of(:uuid)
   end
 
   enum :garage_type, values: ~w(contract condominium)

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -638,6 +638,80 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert [%{"message" => "Unauthorized", "code" => 401}] = json_response(conn, 200)["errors"]
     end
 
+    test "admin should update tags from listing", %{
+      admin_conn: conn,
+      old_address: address,
+      old_listing: listing
+    } do
+      tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
+
+      mutation = """
+        mutation UpdateListing (
+          $id: ID!,
+          $input: ListingInput!
+        ) {
+          updateListing(id: $id, input: $input) {
+            id
+            tags {
+              nameSlug
+            }
+          }
+        }
+      """
+
+      variables = %{
+        "id" => listing.id,
+        "input" => %{
+          "type" => listing.type,
+          "addressId" => address.id,
+          "tags" => [tag_1.uuid]
+        }
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{"id" => "#{listing.id}", "tags" => [%{"nameSlug" => "tag-1"}]}
+
+      assert expected == json_response(conn, 200)["data"]["updateListing"]
+    end
+
+    test "owner should update tags from listing", %{
+      user_conn: conn,
+      old_address: address,
+      old_listing: listing
+    } do
+      tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
+
+      mutation = """
+        mutation UpdateListing (
+          $id: ID!,
+          $input: ListingInput!
+        ) {
+          updateListing(id: $id, input: $input) {
+            id
+            tags {
+              nameSlug
+            }
+          }
+        }
+      """
+
+      variables = %{
+        "id" => listing.id,
+        "input" => %{
+          "type" => listing.type,
+          "addressId" => address.id,
+          "tags" => [tag_1.uuid]
+        }
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{"id" => "#{listing.id}", "tags" => [%{"nameSlug" => "tag-1"}]}
+
+      assert expected == json_response(conn, 200)["data"]["updateListing"]
+    end
+
     @update_development_listing_mutation """
       mutation UpdateListing ($id: ID!, $input: ListingInput!) {
         updateListing(id: $id, input: $input) {

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -262,6 +262,68 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert [%{"message" => "Bad request", "code" => 400}] = json_response(conn, 200)["errors"]
     end
 
+    test "admin should insert listing with tags", %{admin_conn: conn, old_address: address} do
+      tag = insert(:tag)
+
+      variables = %{
+        "input" => %{
+          "type" => "Apartamento",
+          "addressId" => address.id,
+          "tags" => [tag.uuid]
+        }
+      }
+
+      mutation = """
+        mutation InsertListing ($input: ListingInput!) {
+          insertListing(input: $input) {
+            type
+            tags {
+              nameSlug
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{
+        "insertListing" => %{"type" => "Apartamento", "tags" => [%{"nameSlug" => tag.name_slug}]}
+      }
+
+      assert expected == json_response(conn, 200)["data"]
+    end
+
+    test "user should insert listing with tags", %{user_conn: conn, old_address: address} do
+      tag = insert(:tag)
+
+      variables = %{
+        "input" => %{
+          "type" => "Apartamento",
+          "addressId" => address.id,
+          "tags" => [tag.uuid]
+        }
+      }
+
+      mutation = """
+        mutation InsertListing ($input: ListingInput!) {
+          insertListing(input: $input) {
+            type
+            tags {
+              nameSlug
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{
+        "insertListing" => %{"type" => "Apartamento", "tags" => [%{"nameSlug" => tag.name_slug}]}
+      }
+
+      assert expected == json_response(conn, 200)["data"]
+    end
+
     test "anonymous should not insert listing", %{
       unauthenticated_conn: conn,
       listing: listing,

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -849,6 +849,45 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                ]
              } == json_response(conn, 200)["data"]["listings"]
     end
+
+    test "should query listing with tags", %{unauthenticated_conn: conn} do
+      insert(
+        :listing,
+        tags: [
+          build(:tag, name: "Tag 1", name_slug: "tag-1"),
+          build(:tag, name: "Tag 2", name_slug: "tag-2"),
+          build(:tag, name: "Tag 3", name_slug: "tag-3")
+        ]
+      )
+
+      query = """
+        query Listings {
+          listings {
+            listings {
+              tags {
+                nameSlug
+              }
+            }
+          }
+        }
+      """
+
+      expected = %{
+        "listings" => [
+          %{
+            "tags" => [
+              %{"nameSlug" => "tag-1"},
+              %{"nameSlug" => "tag-2"},
+              %{"nameSlug" => "tag-3"}
+            ]
+          }
+        ]
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query))
+
+      assert expected == json_response(conn, 200)["data"]["listings"]
+    end
   end
 
   describe "listing" do


### PR DESCRIPTION
The last step of the tagging system is to be available in listings, so the following changes were made:

1. Listing type has a `tags` node:
   ```graphql
   query {
     listings {
       listings {
         id
         tags {
           nameSlug
           category
           visibility
         }
       }
     }
   }
   ```
2. Listing input type has a `tags` uuid list:
   ```graphql
   mutation {
     insertListing(input: {
       type: "Apartamento",
       address: {
         state: "SP",
         city: "São Paulo",
         neighborhood: "Vila Pompéia",
         postalCode: "05027-000",
         street: "Rua Doutor Miranda de Azevedo",
         streetNumber: "189",
         lat: -23.5308362,
         lng: -46.6909294
       },
       tags: [
         "3157962a-deac-46e1-a74f-9c9c45e50baf",
         "bc7317e6-480d-4ae4-a16a-ff94e4461499",
         "31ab8cd1-cfe7-4517-af26-7f693141c32d"
       ]
     }) {
       id
       tags {
         nameSlug
       }
     }
   }
   ```
