### PR TITLE
Update development image

### DIFF
--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -8,6 +8,7 @@ defmodule Re.Images do
     Image,
     Images.DataloaderQueries,
     Images.Queries,
+    Listings,
     Repo
   }
 

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -7,6 +7,7 @@ defmodule Re.Images do
   alias Re.{
     Image,
     Images.DataloaderQueries,
+    Images.Parents,
     Images.Queries,
     Listings,
     Repo
@@ -146,6 +147,15 @@ defmodule Re.Images do
     |> Image.deactivate_changeset(%{is_active: false})
     |> Repo.update()
   end
+
+  def get_parent_from_image_list(images) do
+    images
+    |> extract_image_list()
+    |> Parents.get_parent_from_image_list()
+  end
+
+  defp extract_image_list(images_and_inputs),
+    do: Enum.map(images_and_inputs, fn {_, image, _} -> image end)
 
   def zip(listing) do
     dir_name = "./temp/listing-#{listing.id}/"

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -148,7 +148,7 @@ defmodule Re.Images do
     |> Repo.update()
   end
 
-  def get_parent_from_image_list(images) do
+  def get_parent(images) do
     images
     |> extract_image_list()
     |> Parents.get_parent_from_image_list()

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -5,7 +5,6 @@ defmodule Re.Images do
   @behaviour Bodyguard.Policy
 
   alias Re.{
-    Developments,
     Image,
     Images.DataloaderQueries,
     Images.Queries,
@@ -98,39 +97,6 @@ defmodule Re.Images do
       image -> {:ok, image, input}
     end
   end
-
-  def check_same_parent(images_and_inputs) do
-    cond do
-      unique_listing_parent?(images_and_inputs) -> get_listing_parent(images_and_inputs)
-      unique_development_parent?(images_and_inputs) -> get_development_parent(images_and_inputs)
-      true -> {:error, :distinct_parents}
-    end
-  end
-
-  defp unique_listing_parent?([{:ok, %{listing_id: first_id}, _params} | images]) do
-    parent_is_unique =
-      Enum.all?(images, fn {:ok, %{listing_id: listing_id}, _} -> listing_id == first_id end)
-
-    not is_nil(first_id) && parent_is_unique
-  end
-
-  defp unique_listing_parent?(_), do: false
-
-  defp unique_development_parent?([{:ok, %{development_uuid: first_id}, _params} | images]) do
-    parent_is_unique =
-      Enum.all?(images, fn {:ok, %{development_uuid: development_uuid}, _} ->
-        development_uuid == first_id
-      end)
-
-    not is_nil(first_id) && parent_is_unique
-  end
-
-  defp unique_development_parent?(_), do: false
-
-  defp get_listing_parent([{:ok, %{listing_id: listing_id}, _} | _]), do: Listings.get(listing_id)
-
-  defp get_development_parent([{:ok, %{development_uuid: development_uuid}, _} | _]),
-    do: Developments.get(development_uuid)
 
   def fetch_listing(images) do
     case Enum.uniq_by(images, fn %{listing_id: id} -> id end) do

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -5,6 +5,7 @@ defmodule Re.Images do
   @behaviour Bodyguard.Policy
 
   alias Re.{
+    Developments,
     Image,
     Images.DataloaderQueries,
     Images.Queries,
@@ -98,12 +99,38 @@ defmodule Re.Images do
     end
   end
 
-  def check_same_listing(images_and_inputs) do
-    case Enum.uniq_by(images_and_inputs, fn {:ok, %{listing_id: listing_id}, _} -> listing_id end) do
-      [{:ok, %{listing_id: listing_id}, _}] -> Listings.get(listing_id)
-      _ -> {:error, :distinct_listings}
+  def check_same_parent(images_and_inputs) do
+    cond do
+      unique_listing_parent?(images_and_inputs) -> get_listing_parent(images_and_inputs)
+      unique_development_parent?(images_and_inputs) -> get_development_parent(images_and_inputs)
+      true -> {:error, :distinct_parents}
     end
   end
+
+  defp unique_listing_parent?([{:ok, %{listing_id: first_id}, _params} | images]) do
+    parent_is_unique =
+      Enum.all?(images, fn {:ok, %{listing_id: listing_id}, _} -> listing_id == first_id end)
+
+    not is_nil(first_id) && parent_is_unique
+  end
+
+  defp unique_listing_parent?(_), do: false
+
+  defp unique_development_parent?([{:ok, %{development_uuid: first_id}, _params} | images]) do
+    parent_is_unique =
+      Enum.all?(images, fn {:ok, %{development_uuid: development_uuid}, _} ->
+        development_uuid == first_id
+      end)
+
+    not is_nil(first_id) && parent_is_unique
+  end
+
+  defp unique_development_parent?(_), do: false
+
+  defp get_listing_parent([{:ok, %{listing_id: listing_id}, _} | _]), do: Listings.get(listing_id)
+
+  defp get_development_parent([{:ok, %{development_uuid: development_uuid}, _} | _]),
+    do: Developments.get(development_uuid)
 
   def fetch_listing(images) do
     case Enum.uniq_by(images, fn %{listing_id: id} -> id end) do

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -8,7 +8,6 @@ defmodule Re.Images do
     Image,
     Images.DataloaderQueries,
     Images.Queries,
-    Listings,
     Repo
   }
 

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -8,11 +8,19 @@ defmodule Re.Images.Parents do
     Listings
   }
 
-  def get_parent_from_image_list(images) do
-    cond do
-      unique_listing_parent?(images) -> get_listing_parent(images)
-      unique_development_parent?(images) -> get_development_parent(images)
-      true -> {:error, :distinct_parents}
+  def get_parent_from_image_list([%{listing_id: listing_id} | _] = images)
+      when not is_nil(listing_id) do
+    case unique_listing_parent?(images) do
+      true -> get_listing_parent(images)
+      false -> {:error, :distinct_parents}
+    end
+  end
+
+  def get_parent_from_image_list([%{development_uuid: development_uuid} | _] = images)
+      when not is_nil(development_uuid) do
+    case unique_development_parent?(images) do
+      true -> get_development_parent(images)
+      false -> {:error, :distinct_parents}
     end
   end
 
@@ -21,7 +29,6 @@ defmodule Re.Images.Parents do
       Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end)
 
     case unique_images_by_listing_id do
-      [%{listing_id: nil}] -> false
       [%{listing_id: _}] -> true
       _ -> false
     end
@@ -32,7 +39,6 @@ defmodule Re.Images.Parents do
       Enum.uniq_by(images, fn image -> Map.get(image, :development_uuid) end)
 
     case unique_images_by_development_uuid do
-      [%{development_uuid: nil}] -> false
       [%{development_uuid: _}] -> true
       _ -> false
     end

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -25,20 +25,14 @@ defmodule Re.Images.Parents do
   end
 
   defp unique_listing_parent?(images) do
-    unique_images_by_listing_id =
-      Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end)
-
-    case unique_images_by_listing_id do
+    case Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end) do
       [%{listing_id: _}] -> true
       _ -> false
     end
   end
 
   defp unique_development_parent?(images) do
-    unique_images_by_development_uuid =
-      Enum.uniq_by(images, fn image -> Map.get(image, :development_uuid) end)
-
-    case unique_images_by_development_uuid do
+    case Enum.uniq_by(images, fn image -> Map.get(image, :development_uuid) end) do
       [%{development_uuid: _}] -> true
       _ -> false
     end

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -1,0 +1,43 @@
+defmodule Re.Images.Parents do
+  @moduledoc """
+  This module know how to to fetch and interact with image parents.
+  """
+
+  alias Re.{
+    Developments,
+    Listings,
+  }
+
+  def get_image_parent(images_and_inputs) do
+    cond do
+      unique_listing_parent?(images_and_inputs) -> get_listing_parent(images_and_inputs)
+      unique_development_parent?(images_and_inputs) -> get_development_parent(images_and_inputs)
+      true -> {:error, :distinct_parents}
+    end
+  end
+
+  defp unique_listing_parent?([{:ok, %{listing_id: first_id}, _params} | images]) do
+    parent_is_unique =
+      Enum.all?(images, fn {:ok, %{listing_id: listing_id}, _} -> listing_id == first_id end)
+
+    not is_nil(first_id) && parent_is_unique
+  end
+
+  defp unique_listing_parent?(_), do: false
+
+  defp unique_development_parent?([{:ok, %{development_uuid: first_id}, _params} | images]) do
+    parent_is_unique =
+      Enum.all?(images, fn {:ok, %{development_uuid: development_uuid}, _} ->
+        development_uuid == first_id
+      end)
+
+    not is_nil(first_id) && parent_is_unique
+  end
+
+  defp unique_development_parent?(_), do: false
+
+  defp get_listing_parent([{:ok, %{listing_id: listing_id}, _} | _]), do: Listings.get(listing_id)
+
+  defp get_development_parent([{:ok, %{development_uuid: development_uuid}, _} | _]),
+    do: Developments.get(development_uuid)
+end

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -1,33 +1,33 @@
 defmodule Re.Images.Parents do
   @moduledoc """
-  This module know how to to fetch and interact with image parents.
+  This module know how to fetch and interact with image parents.
   """
 
   alias Re.{
     Developments,
-    Listings,
+    Listings
   }
 
-  def get_image_parent(images_and_inputs) do
+  def get_image_parent(images) do
     cond do
-      unique_listing_parent?(images_and_inputs) -> get_listing_parent(images_and_inputs)
-      unique_development_parent?(images_and_inputs) -> get_development_parent(images_and_inputs)
+      unique_listing_parent?(images) -> get_listing_parent(images)
+      unique_development_parent?(images) -> get_development_parent(images)
       true -> {:error, :distinct_parents}
     end
   end
 
-  defp unique_listing_parent?([{:ok, %{listing_id: first_id}, _params} | images]) do
+  defp unique_listing_parent?([%{listing_id: first_id} | images]) do
     parent_is_unique =
-      Enum.all?(images, fn {:ok, %{listing_id: listing_id}, _} -> listing_id == first_id end)
+      Enum.all?(images, fn %{listing_id: listing_id} -> listing_id == first_id end)
 
     not is_nil(first_id) && parent_is_unique
   end
 
   defp unique_listing_parent?(_), do: false
 
-  defp unique_development_parent?([{:ok, %{development_uuid: first_id}, _params} | images]) do
+  defp unique_development_parent?([%{development_uuid: first_id} | images]) do
     parent_is_unique =
-      Enum.all?(images, fn {:ok, %{development_uuid: development_uuid}, _} ->
+      Enum.all?(images, fn %{development_uuid: development_uuid} ->
         development_uuid == first_id
       end)
 
@@ -36,8 +36,8 @@ defmodule Re.Images.Parents do
 
   defp unique_development_parent?(_), do: false
 
-  defp get_listing_parent([{:ok, %{listing_id: listing_id}, _} | _]), do: Listings.get(listing_id)
+  defp get_listing_parent([%{listing_id: listing_id} | _]), do: Listings.get(listing_id)
 
-  defp get_development_parent([{:ok, %{development_uuid: development_uuid}, _} | _]),
+  defp get_development_parent([%{development_uuid: development_uuid} | _]),
     do: Developments.get(development_uuid)
 end

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -8,7 +8,7 @@ defmodule Re.Images.Parents do
     Listings
   }
 
-  def get_image_parent(images) do
+  def get_parent_from_image_list(images) do
     cond do
       unique_listing_parent?(images) -> get_listing_parent(images)
       unique_development_parent?(images) -> get_development_parent(images)
@@ -16,25 +16,27 @@ defmodule Re.Images.Parents do
     end
   end
 
-  defp unique_listing_parent?([%{listing_id: first_id} | images]) do
-    parent_is_unique =
-      Enum.all?(images, fn %{listing_id: listing_id} -> listing_id == first_id end)
+  defp unique_listing_parent?(images) do
+    unique_images_by_listing_id =
+      Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end)
 
-    not is_nil(first_id) && parent_is_unique
+    case unique_images_by_listing_id do
+      [%{listing_id: nil}] -> false
+      [%{listing_id: _}] -> true
+      _ -> false
+    end
   end
 
-  defp unique_listing_parent?(_), do: false
+  defp unique_development_parent?(images) do
+    unique_images_by_development_uuid =
+      Enum.uniq_by(images, fn image -> Map.get(image, :development_uuid) end)
 
-  defp unique_development_parent?([%{development_uuid: first_id} | images]) do
-    parent_is_unique =
-      Enum.all?(images, fn %{development_uuid: development_uuid} ->
-        development_uuid == first_id
-      end)
-
-    not is_nil(first_id) && parent_is_unique
+    case unique_images_by_development_uuid do
+      [%{development_uuid: nil}] -> false
+      [%{development_uuid: _}] -> true
+      _ -> false
+    end
   end
-
-  defp unique_development_parent?(_), do: false
 
   defp get_listing_parent([%{listing_id: listing_id} | _]), do: Listings.get(listing_id)
 

--- a/apps/re/lib/images/parents.ex
+++ b/apps/re/lib/images/parents.ex
@@ -10,36 +10,17 @@ defmodule Re.Images.Parents do
 
   def get_parent_from_image_list([%{listing_id: listing_id} | _] = images)
       when not is_nil(listing_id) do
-    case unique_listing_parent?(images) do
-      true -> get_listing_parent(images)
-      false -> {:error, :distinct_parents}
+    case Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end) do
+      [%{listing_id: _}] -> Listings.get(listing_id)
+      _ -> {:error, :distinct_parents}
     end
   end
 
   def get_parent_from_image_list([%{development_uuid: development_uuid} | _] = images)
       when not is_nil(development_uuid) do
-    case unique_development_parent?(images) do
-      true -> get_development_parent(images)
-      false -> {:error, :distinct_parents}
-    end
-  end
-
-  defp unique_listing_parent?(images) do
-    case Enum.uniq_by(images, fn image -> Map.get(image, :listing_id) end) do
-      [%{listing_id: _}] -> true
-      _ -> false
-    end
-  end
-
-  defp unique_development_parent?(images) do
     case Enum.uniq_by(images, fn image -> Map.get(image, :development_uuid) end) do
-      [%{development_uuid: _}] -> true
-      _ -> false
+      [%{development_uuid: _}] -> Developments.get(development_uuid)
+      _ -> {:error, :distinct_parents}
     end
   end
-
-  defp get_listing_parent([%{listing_id: listing_id} | _]), do: Listings.get(listing_id)
-
-  defp get_development_parent([%{development_uuid: development_uuid} | _]),
-    do: Developments.get(development_uuid)
 end

--- a/apps/re/test/images/images_test.exs
+++ b/apps/re/test/images/images_test.exs
@@ -30,42 +30,6 @@ defmodule Re.ImagesTest do
     end
   end
 
-  describe "check_same_parent/1" do
-    test "should return parent when images are from same listing" do
-      listing = insert(:listing)
-      assert {:ok, listing} ==
-               Images.check_same_parent([
-                 {:ok, %{listing_id: listing.id}, %{}},
-                 {:ok, %{listing_id: listing.id}, %{}}
-               ])
-    end
-
-    test "should return parent when images are from same development" do
-      development = insert(:development)
-      assert {:ok, development} ==
-                Images.check_same_parent([
-                  {:ok, %{development_uuid: development.uuid}, %{}},
-                  {:ok, %{development_uuid: development.uuid}, %{}}
-                ])
-    end
-
-    test "should return error when images are from distinct listing" do
-      assert {:error, :distinct_parents} ==
-                Images.check_same_parent([
-                  {:ok, %{listing_id: 1}, %{}},
-                  {:ok, %{listing_id: 2}, %{}}
-                ])
-    end
-
-    test "should return error when images are from distinct development" do
-      assert {:error, :distinct_parents} ==
-                Images.check_same_parent([
-                  {:ok, %{development_uuid: "aa"}, %{}},
-                  {:ok, %{development_uuid: "bb"}, %{}}
-                ])
-    end
-  end
-
   describe "update_images/1" do
     test "should error when input is invalid" do
       [image1, image2, image3] = insert_list(3, :image)

--- a/apps/re/test/images/images_test.exs
+++ b/apps/re/test/images/images_test.exs
@@ -30,13 +30,39 @@ defmodule Re.ImagesTest do
     end
   end
 
-  describe "check_same_listing/1" do
-    test "should return error when images are from distinct listings" do
-      assert {:error, :distinct_listings} ==
-               Images.check_same_listing([
-                 {:ok, %{listing_id: 1}, %{position: 1}},
-                 {:ok, %{listing_id: 2}, %{position: 2}}
+  describe "check_same_parent/1" do
+    test "should return parent when images are from same listing" do
+      listing = insert(:listing)
+      assert {:ok, listing} ==
+               Images.check_same_parent([
+                 {:ok, %{listing_id: listing.id}, %{}},
+                 {:ok, %{listing_id: listing.id}, %{}}
                ])
+    end
+
+    test "should return parent when images are from same development" do
+      development = insert(:development)
+      assert {:ok, development} ==
+                Images.check_same_parent([
+                  {:ok, %{development_uuid: development.uuid}, %{}},
+                  {:ok, %{development_uuid: development.uuid}, %{}}
+                ])
+    end
+
+    test "should return error when images are from distinct listing" do
+      assert {:error, :distinct_parents} ==
+                Images.check_same_parent([
+                  {:ok, %{listing_id: 1}, %{}},
+                  {:ok, %{listing_id: 2}, %{}}
+                ])
+    end
+
+    test "should return error when images are from distinct development" do
+      assert {:error, :distinct_parents} ==
+                Images.check_same_parent([
+                  {:ok, %{development_uuid: "aa"}, %{}},
+                  {:ok, %{development_uuid: "bb"}, %{}}
+                ])
     end
   end
 

--- a/apps/re/test/images/parents_test.exs
+++ b/apps/re/test/images/parents_test.exs
@@ -1,0 +1,44 @@
+defmodule Re.Images.ParentsTest do
+  use Re.ModelCase
+
+  alias Re.Images.Parents
+
+  import Re.Factory
+
+  describe "check_same_parent/1" do
+    test "should return parent when images are from same listing" do
+      listing = insert(:listing)
+      assert {:ok, listing} ==
+               Parents.get_image_parent([
+                 {:ok, %{listing_id: listing.id}, %{}},
+                 {:ok, %{listing_id: listing.id}, %{}}
+               ])
+    end
+
+    test "should return parent when images are from same development" do
+      development = insert(:development)
+      assert {:ok, development} ==
+                Parents.get_image_parent([
+                  {:ok, %{development_uuid: development.uuid}, %{}},
+                  {:ok, %{development_uuid: development.uuid}, %{}}
+                ])
+    end
+
+    test "should return error when images are from distinct listing" do
+      assert {:error, :distinct_parents} ==
+                Parents.get_image_parent([
+                  {:ok, %{listing_id: 1}, %{}},
+                  {:ok, %{listing_id: 2}, %{}}
+                ])
+    end
+
+    test "should return error when images are from distinct development" do
+      assert {:error, :distinct_parents} ==
+                Parents.get_image_parent([
+                  {:ok, %{development_uuid: "aa"}, %{}},
+                  {:ok, %{development_uuid: "bb"}, %{}}
+                ])
+    end
+  end
+end
+

--- a/apps/re/test/images/parents_test.exs
+++ b/apps/re/test/images/parents_test.exs
@@ -10,8 +10,8 @@ defmodule Re.Images.ParentsTest do
       listing = insert(:listing)
       assert {:ok, listing} ==
                Parents.get_image_parent([
-                 {:ok, %{listing_id: listing.id}, %{}},
-                 {:ok, %{listing_id: listing.id}, %{}}
+                 %{listing_id: listing.id},
+                 %{listing_id: listing.id}
                ])
     end
 
@@ -19,24 +19,24 @@ defmodule Re.Images.ParentsTest do
       development = insert(:development)
       assert {:ok, development} ==
                 Parents.get_image_parent([
-                  {:ok, %{development_uuid: development.uuid}, %{}},
-                  {:ok, %{development_uuid: development.uuid}, %{}}
+                  %{development_uuid: development.uuid},
+                  %{development_uuid: development.uuid}
                 ])
     end
 
     test "should return error when images are from distinct listing" do
       assert {:error, :distinct_parents} ==
                 Parents.get_image_parent([
-                  {:ok, %{listing_id: 1}, %{}},
-                  {:ok, %{listing_id: 2}, %{}}
+                  %{listing_id: 1},
+                  %{listing_id: 2}
                 ])
     end
 
     test "should return error when images are from distinct development" do
       assert {:error, :distinct_parents} ==
                 Parents.get_image_parent([
-                  {:ok, %{development_uuid: "aa"}, %{}},
-                  {:ok, %{development_uuid: "bb"}, %{}}
+                  %{development_uuid: "aa"},
+                  %{development_uuid: "bb"}
                 ])
     end
   end

--- a/apps/re/test/images/parents_test.exs
+++ b/apps/re/test/images/parents_test.exs
@@ -8,8 +8,9 @@ defmodule Re.Images.ParentsTest do
   describe "check_same_parent/1" do
     test "should return parent when images are from same listing" do
       listing = insert(:listing)
+
       assert {:ok, listing} ==
-               Parents.get_image_parent([
+               Parents.get_parent_from_image_list([
                  %{listing_id: listing.id},
                  %{listing_id: listing.id}
                ])
@@ -17,28 +18,28 @@ defmodule Re.Images.ParentsTest do
 
     test "should return parent when images are from same development" do
       development = insert(:development)
+
       assert {:ok, development} ==
-                Parents.get_image_parent([
-                  %{development_uuid: development.uuid},
-                  %{development_uuid: development.uuid}
-                ])
+               Parents.get_parent_from_image_list([
+                 %{development_uuid: development.uuid},
+                 %{development_uuid: development.uuid}
+               ])
     end
 
     test "should return error when images are from distinct listing" do
       assert {:error, :distinct_parents} ==
-                Parents.get_image_parent([
-                  %{listing_id: 1},
-                  %{listing_id: 2}
-                ])
+               Parents.get_parent_from_image_list([
+                 %{listing_id: 1},
+                 %{listing_id: 2}
+               ])
     end
 
     test "should return error when images are from distinct development" do
       assert {:error, :distinct_parents} ==
-                Parents.get_image_parent([
-                  %{development_uuid: "aa"},
-                  %{development_uuid: "bb"}
-                ])
+               Parents.get_parent_from_image_list([
+                 %{development_uuid: "aa"},
+                 %{development_uuid: "bb"}
+               ])
     end
   end
 end
-

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -79,7 +79,9 @@ defmodule ReWeb.Resolvers.Images do
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
          {:ok, parent} <-
-           extract_image_list(images_and_inputs) |> Images.Parents.get_parent_from_image_list(),
+           images_and_inputs
+           |> extract_image_list()
+           |> Images.Parents.get_parent_from_image_list(),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,7 +78,7 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, parent} <- Images.get_parent_from_image_list(images_and_inputs),
+         {:ok, parent} <- Images.get_parent(images_and_inputs),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,10 +78,10 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, listing} <- Images.check_same_parent(images_and_inputs),
-         :ok <- Bodyguard.permit(Images, :update_images, current_user, listing),
+         {:ok, parent} <- Images.check_same_parent(images_and_inputs),
+         :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
-         do: {:ok, %{images: images, parent_listing: listing}}
+         do: {:ok, %{images: images, parent_listing: parent, parent: parent}}
   end
 
   def deactivate_images(%{input: %{image_ids: image_ids}}, %{
@@ -123,6 +123,9 @@ defmodule ReWeb.Resolvers.Images do
   def images_activate_trigger(%{parent_listing: %{id: id}}), do: "images_activated:#{id}"
 
   def update_images_trigger(%{parent_listing: %{id: id}}), do: "images_updated:#{id}"
+
+  def update_images_trigger(%{parent: %Re.Development{uuid: uuid}}),
+    do: "development_updated:#{uuid}"
 
   def insert_image_trigger(%{parent_listing: %{id: id}}), do: "images_inserted:#{id}"
 

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,7 +78,7 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, listing} <- Images.check_same_listing(images_and_inputs),
+         {:ok, listing} <- Images.check_same_parent(images_and_inputs),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, listing),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: listing}}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,17 +78,11 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, parent} <-
-           images_and_inputs
-           |> extract_image_list()
-           |> Images.Parents.get_parent_from_image_list(),
+         {:ok, parent} <- Images.get_parent_from_image_list(images_and_inputs),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}
   end
-
-  defp extract_image_list(images_and_inputs),
-    do: Enum.map(images_and_inputs, fn {_, image, _} -> image end)
 
   def deactivate_images(%{input: %{image_ids: image_ids}}, %{
         context: %{current_user: current_user}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,11 +78,15 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, parent} <- Images.Parents.get_image_parent(images_and_inputs),
+         {:ok, parent} <-
+           extract_image_list(images_and_inputs) |> Images.Parents.get_image_parent(),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}
   end
+
+  defp extract_image_list(images_and_inputs),
+    do: Enum.map(images_and_inputs, fn {_, image, _} -> image end)
 
   def deactivate_images(%{input: %{image_ids: image_ids}}, %{
         context: %{current_user: current_user}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -78,7 +78,7 @@ defmodule ReWeb.Resolvers.Images do
 
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
-         {:ok, parent} <- Images.check_same_parent(images_and_inputs),
+         {:ok, parent} <- Images.Parents.get_image_parent(images_and_inputs),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}

--- a/apps/re_web/lib/graphql/resolvers/images.ex
+++ b/apps/re_web/lib/graphql/resolvers/images.ex
@@ -79,7 +79,7 @@ defmodule ReWeb.Resolvers.Images do
   def update_images(%{input: inputs}, %{context: %{current_user: current_user}}) do
     with {:ok, images_and_inputs} <- Images.get_list(inputs),
          {:ok, parent} <-
-           extract_image_list(images_and_inputs) |> Images.Parents.get_image_parent(),
+           extract_image_list(images_and_inputs) |> Images.Parents.get_parent_from_image_list(),
          :ok <- Bodyguard.permit(Images, :update_images, current_user, parent),
          {:ok, images} <- Images.update_images(images_and_inputs),
          do: {:ok, %{images: images, parent_listing: parent, parent: parent}}

--- a/apps/re_web/test/webhooks/grupozap_plug_test.exs
+++ b/apps/re_web/test/webhooks/grupozap_plug_test.exs
@@ -35,8 +35,8 @@ defmodule ReWeb.Webhooks.GrupozapPlugTest do
   setup %{conn: conn} do
     conn = put_req_header(conn, "accept", "application/json")
 
-    encoded_secret = Base.encode64("vivareal|testsecret")
-    wrong_secret = Base.encode64("vivareal|wrongsecret")
+    encoded_secret = Base.encode64("vivareal:testsecret")
+    wrong_secret = Base.encode64("vivareal:wrongsecret")
 
     {:ok,
      unauthenticated_conn: conn,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -65,7 +65,9 @@ config :re_integrations,
   reply_to: System.get_env("REPORT_REPLY_EMAIL"),
   credipronto_simulator_url: System.get_env("CREDIPRONTO_SIMULATOR_URL"),
   credipronto_account_id: System.get_env("CREDIPRONTO_ACCOUNT_ID"),
-  grupozap_webhook_secret: System.get_env("GRUPOZAP_WEBHOOK_SECRET")
+  grupozap_webhook_secret: System.get_env("GRUPOZAP_WEBHOOK_SECRET"),
+  zapier_webhook_user: System.get_env("ZAPIER_WEBHOOK_USER"),
+  zapier_webhook_pass: System.get_env("ZAPIER_WEBHOOK_PASS")
 
 config :re_integrations, ReIntegrations.Search.Cluster,
   url: System.get_env("ELASTICSEARCH_URL"),


### PR DESCRIPTION
It allows to updated images associated with developments. The major work here was in `check_same_listing` old version only used to look to associated listings. After alter this I extract the logic to a module. I got the "Parents" name from the original GraphQL field `parent_listing` who become only `parent`. 

I also changed the interface from the `check_same_listing` who used to received `[{:ok, images, params}]`, once only images are important to say if they're from the same parent I've extracted only the images from this structure. It'll also enable us to remove duplicated code between [`check_same_listing`](https://github.com/emcasa/backend/blob/master/apps/re/lib/images/images.ex#L101) and  [`fetch_listing`](https://github.com/emcasa/backend/blob/master/apps/re/lib/images/images.ex#L108) which use to contain the same logic for different structures. This deduplication will come in other PR to make the review for this one easier. 

Last but not least, also made a minor change on the public interface: The `distinct_listings` error string is now `distinct_parents`. If the front end use to throw this error, it should be updated in the client. cc: @gabiseabra 