### PR TITLE
Add option to filter multiple tags by name slug

### DIFF
--- a/apps/re_web/lib/graphql/types/tag.ex
+++ b/apps/re_web/lib/graphql/types/tag.ex
@@ -21,6 +21,7 @@ defmodule ReWeb.Types.Tag do
   end
 
   input_object :tag_filter_input do
+    field :name_slugs, list_of(non_null(:string))
     field :category, :string
     field :visibility, :string
   end

--- a/apps/re_web/test/graphql/tags/query_test.exs
+++ b/apps/re_web/test/graphql/tags/query_test.exs
@@ -191,6 +191,27 @@ defmodule ReWeb.GraphQL.Tags.QueryTest do
 
       assert json_response(conn, 200)["data"] == %{"tags" => expected_tags}
     end
+
+    test "filter multiple tags by name slug", %{unauthenticated_conn: conn} do
+      query = """
+        query Tags (
+          $filters: TagFilterInput!
+        ) {
+          tags(filters: $filters) {
+            nameSlug
+          }
+        }
+      """
+
+      variables = %{filters: %{nameSlugs: ["salao-de-festas", "academia"]}}
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+      assert data = json_response(conn, 200)["data"]["tags"]
+      assert 2 == Enum.count(data)
+      assert Enum.member?(data, %{"nameSlug" => "academia"})
+      assert Enum.member?(data, %{"nameSlug" => "salao-de-festas"})
+    end
   end
 
   describe "tag" do


### PR DESCRIPTION
Add `nameSlugs` to `TagFilterInput`, so we can filter multiple tags by their `nameSlug`

```graphql
query {
  tags(filters: {nameSlugs: ["salao-de-festas", "academia"]}) {
    uuid
    nameSlug
  }
}
```