### PR TITLE
Add missing attributes to listing

### DIFF
--- a/apps/re/lib/filtering/filtering.ex
+++ b/apps/re/lib/filtering/filtering.ex
@@ -41,8 +41,8 @@ defmodule Re.Filtering do
     field :max_floor_count, :integer
     field :min_unit_per_floor, :integer
     field :max_unit_per_floor, :integer
-    field :orientation, :string
-    field :sun_period, :string
+    field :orientations, {:array, :string}
+    field :sun_periods, {:array, :string}
     field :min_age, :integer
     field :max_age, :integer
     field :min_price_per_area, :float
@@ -53,7 +53,7 @@ defmodule Re.Filtering do
               neighborhoods types max_lat min_lat max_lng min_lng neighborhoods_slugs
               max_garage_spots min_garage_spots garage_types cities cities_slug states_slug
               exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
-              min_unit_per_floor max_unit_per_floor orientation sun_period min_age max_age
+              min_unit_per_floor max_unit_per_floor orientations sun_periods min_age max_age
               min_price_per_area max_price_per_area)a
 
   def changeset(struct, params \\ %{}), do: cast(struct, params, @filters)
@@ -277,17 +277,21 @@ defmodule Re.Filtering do
     )
   end
 
-  defp attr_filter({:orientation, orientation}, query) do
+  defp attr_filter({:orientations, []}, query), do: query
+
+  defp attr_filter({:orientations, orientations}, query) do
     from(
       l in query,
-      where: l.orientation == ^orientation
+      where: l.orientation in ^orientations
     )
   end
 
-  defp attr_filter({:sun_period, sun_period}, query) do
+  defp attr_filter({:sun_periods, []}, query), do: query
+
+  defp attr_filter({:sun_periods, sun_periods}, query) do
     from(
       l in query,
-      where: l.sun_period == ^sun_period
+      where: l.sun_period in ^sun_periods
     )
   end
 

--- a/apps/re/lib/filtering/filtering.ex
+++ b/apps/re/lib/filtering/filtering.ex
@@ -37,12 +37,24 @@ defmodule Re.Filtering do
     field :tags_slug, {:array, :string}
     field :tags_uuid, {:array, :string}
     field :statuses, {:array, :string}
+    field :min_floor_count, :integer
+    field :max_floor_count, :integer
+    field :min_unit_per_floor, :integer
+    field :max_unit_per_floor, :integer
+    field :orientation, :string
+    field :sun_period, :string
+    field :min_age, :integer
+    field :max_age, :integer
+    field :min_price_per_area, :float
+    field :max_price_per_area, :float
   end
 
   @filters ~w(max_price min_price max_rooms min_rooms max_suites min_suites min_area max_area
               neighborhoods types max_lat min_lat max_lng min_lng neighborhoods_slugs
               max_garage_spots min_garage_spots garage_types cities cities_slug states_slug
-              exportable tags_slug tags_uuid statuses)a
+              exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
+              min_unit_per_floor max_unit_per_floor orientation sun_period min_age max_age
+              min_price_per_area max_price_per_area)a
 
   def changeset(struct, params \\ %{}), do: cast(struct, params, @filters)
 
@@ -237,5 +249,80 @@ defmodule Re.Filtering do
     )
   end
 
+  defp attr_filter({:min_floor_count, floor_count}, query) do
+    from(
+      l in query,
+      where: l.floor_count >= ^floor_count
+    )
+  end
+
+  defp attr_filter({:max_floor_count, floor_count}, query) do
+    from(
+      l in query,
+      where: l.floor_count <= ^floor_count
+    )
+  end
+
+  defp attr_filter({:min_unit_per_floor, unit_per_floor}, query) do
+    from(
+      l in query,
+      where: l.unit_per_floor >= ^unit_per_floor
+    )
+  end
+
+  defp attr_filter({:max_unit_per_floor, unit_per_floor}, query) do
+    from(
+      l in query,
+      where: l.unit_per_floor <= ^unit_per_floor
+    )
+  end
+
+  defp attr_filter({:orientation, orientation}, query) do
+    from(
+      l in query,
+      where: l.orientation == ^orientation
+    )
+  end
+
+  defp attr_filter({:sun_period, sun_period}, query) do
+    from(
+      l in query,
+      where: l.sun_period == ^sun_period
+    )
+  end
+
+  defp attr_filter({:min_age, age}, query) do
+    from(
+      l in query,
+      where: l.construction_year <= ^age_to_year(age)
+    )
+  end
+
+  defp attr_filter({:max_age, age}, query) do
+    from(
+      l in query,
+      where: l.construction_year >= ^age_to_year(age)
+    )
+  end
+
+  defp attr_filter({:min_price_per_area, price_per_area}, query) do
+    from(
+      l in query,
+      where: l.price_per_area >= ^price_per_area
+    )
+  end
+
+  defp attr_filter({:max_price_per_area, price_per_area}, query) do
+    from(
+      l in query,
+      where: l.price_per_area <= ^price_per_area
+    )
+  end
+
   defp attr_filter(_, query), do: query
+
+  defp age_to_year(age) do
+    today = Date.utc_today()
+    today.year - age
+  end
 end

--- a/apps/re/lib/listings/queries/queries.ex
+++ b/apps/re/lib/listings/queries/queries.ex
@@ -22,7 +22,7 @@ defmodule Re.Listings.Queries do
     images: Images.Queries.listing_preload()
   ]
 
-  @orderable_fields ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies updated_at)a
+  @orderable_fields ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies updated_at price_per_area)a
 
   def active(query \\ Listing), do: where(query, [l], l.status == "active")
 

--- a/apps/re/priv/repo/migrations/20190411184202_add_listing_extra_details.exs
+++ b/apps/re/priv/repo/migrations/20190411184202_add_listing_extra_details.exs
@@ -1,0 +1,27 @@
+defmodule Re.Repo.Migrations.AddListingExtraDetails do
+  use Ecto.Migration
+
+  def up do
+    alter table(:listings) do
+      add :orientation, :string
+      add :floor_count, :integer
+      add :unit_per_floor, :integer
+      add :sun_period, :string
+      add :elevators, :integer
+      add :construction_year, :integer
+      add :price_per_area, :float
+    end
+  end
+
+  def down do
+    alter table(:listings) do
+      remove :orientation
+      remove :floor_count
+      remove :unit_per_floor
+      remove :sun_period
+      remove :elevators
+      remove :construction_year
+      remove :price_per_area
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190415131727_set_price_per_area_in_listing.exs
+++ b/apps/re/priv/repo/migrations/20190415131727_set_price_per_area_in_listing.exs
@@ -1,0 +1,20 @@
+defmodule Re.Repo.Migrations.SetPricePerAreaInListing do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  def up do
+    query =
+      from(
+        l in Re.Listing,
+        update: [set: [price_per_area: l.price / l.area]],
+        where: l.price > 0 and l.area > 0
+      )
+
+    Re.Repo.update_all(query, [])
+  end
+
+  def down do
+    Re.Repo.update_all(Re.Listing, set: [price_per_area: nil])
+  end
+end

--- a/apps/re/priv/repo/migrations/20190415131727_set_price_per_area_in_listing.exs
+++ b/apps/re/priv/repo/migrations/20190415131727_set_price_per_area_in_listing.exs
@@ -6,7 +6,7 @@ defmodule Re.Repo.Migrations.SetPricePerAreaInListing do
   def up do
     query =
       from(
-        l in Re.Listing,
+        l in "listings",
         update: [set: [price_per_area: l.price / l.area]],
         where: l.price > 0 and l.area > 0
       )
@@ -15,6 +15,6 @@ defmodule Re.Repo.Migrations.SetPricePerAreaInListing do
   end
 
   def down do
-    Re.Repo.update_all(Re.Listing, set: [price_per_area: nil])
+    Re.Repo.update_all("listings", set: [price_per_area: nil])
   end
 end

--- a/apps/re/test/filtering/filtering_test.exs
+++ b/apps/re/test/filtering/filtering_test.exs
@@ -5,6 +5,7 @@ defmodule Re.FilteringTest do
     Filtering,
     Listing,
     Listings,
+    Listings.Queries,
     Repo
   }
 
@@ -193,6 +194,22 @@ defmodule Re.FilteringTest do
       assert [listing_1, listing_2] == result
     end
 
+    test "filter listing with empty orientation fetch all instances" do
+      %{id: listing_1} = insert(:listing, orientation: "frente")
+      %{id: listing_2} = insert(:listing, orientation: "fundos")
+      %{id: listing_3} = insert(:listing, orientation: "lateral")
+      %{id: listing_4} = insert(:listing, orientation: "meio")
+
+      result =
+        Listing
+        |> Filtering.apply(%{orientations: []})
+        |> Queries.order_by_id()
+        |> Repo.all()
+        |> Enum.map(& &1.id)
+
+      assert [listing_1, listing_2, listing_3, listing_4] == result
+    end
+
     test "filter listing by orientation" do
       listing = insert(:listing, orientation: "frente")
       insert(:listing, orientation: "fundos")
@@ -205,6 +222,20 @@ defmodule Re.FilteringTest do
         |> Repo.all()
 
       assert [listing] == result
+    end
+
+    test "filter listing with empty sun period fetch all instances" do
+      %{id: listing_1} = insert(:listing, sun_period: "morning")
+      %{id: listing_2} = insert(:listing, sun_period: "evening")
+
+      result =
+        Listing
+        |> Filtering.apply(%{sun_periods: []})
+        |> Queries.order_by_id()
+        |> Repo.all()
+        |> Enum.map(& &1.id)
+
+      assert [listing_1, listing_2] == result
     end
 
     test "filter listing by sun period" do

--- a/apps/re/test/filtering/filtering_test.exs
+++ b/apps/re/test/filtering/filtering_test.exs
@@ -189,5 +189,86 @@ defmodule Re.FilteringTest do
 
       assert [listing_1, listing_2] == result
     end
+
+    test "filter listing by orientation" do
+      listing = insert(:listing, orientation: "frente")
+      insert(:listing, orientation: "fundos")
+      insert(:listing, orientation: "lateral")
+      insert(:listing, orientation: "meio")
+
+      result = Filtering.apply(Listing, %{orientation: "frente"}) |> Repo.all()
+
+      assert [listing] == result
+    end
+
+    test "filter listing by sun period" do
+      listing = insert(:listing, sun_period: "morning")
+      insert(:listing, sun_period: "evening")
+
+      result = Filtering.apply(Listing, %{sun_period: "morning"}) |> Repo.all()
+
+      assert [listing] == result
+    end
+
+    test "filter listing by floor count" do
+      listing_1 = insert(:listing, floor_count: 1)
+      listing_2 = insert(:listing, floor_count: 2)
+      listing_3 = insert(:listing, floor_count: 3)
+      listing_4 = insert(:listing, floor_count: 4)
+
+      result = Filtering.apply(Listing, %{min_floor_count: 3}) |> Repo.all()
+
+      assert [listing_3, listing_4] == result
+
+      result = Filtering.apply(Listing, %{max_floor_count: 2}) |> Repo.all()
+
+      assert [listing_1, listing_2] == result
+    end
+
+    test "filter listing by unit per floor" do
+      listing_1 = insert(:listing, unit_per_floor: 1)
+      listing_2 = insert(:listing, unit_per_floor: 2)
+      listing_3 = insert(:listing, unit_per_floor: 3)
+      listing_4 = insert(:listing, unit_per_floor: 4)
+
+      result = Filtering.apply(Listing, %{min_unit_per_floor: 3}) |> Repo.all()
+
+      assert [listing_3, listing_4] == result
+
+      result = Filtering.apply(Listing, %{max_unit_per_floor: 2}) |> Repo.all()
+
+      assert [listing_1, listing_2] == result
+    end
+
+    test "filter listing by age" do
+      base_year = Date.utc_today().year
+      listing_1 = insert(:listing, construction_year: base_year - 5)
+      listing_2 = insert(:listing, construction_year: base_year - 10)
+      listing_3 = insert(:listing, construction_year: base_year - 15)
+      listing_4 = insert(:listing, construction_year: base_year - 20)
+
+      result = Filtering.apply(Listing, %{max_age: 10}) |> Repo.all()
+
+      assert [listing_1, listing_2] == result
+
+      result = Filtering.apply(Listing, %{min_age: 15}) |> Repo.all()
+
+      assert [listing_3, listing_4] == result
+    end
+
+    test "filter listing by price per area" do
+      listing_1 = insert(:listing, price: 10, area: 1, price_per_area: 10)
+      listing_2 = insert(:listing, price: 15, area: 1, price_per_area: 15)
+      listing_3 = insert(:listing, price: 20, area: 1, price_per_area: 20)
+      listing_4 = insert(:listing, price: 25, area: 1, price_per_area: 25)
+
+      result = Filtering.apply(Listing, %{min_price_per_area: 20}) |> Repo.all()
+
+      assert [listing_3, listing_4] == result
+
+      result = Filtering.apply(Listing, %{max_price_per_area: 15}) |> Repo.all()
+
+      assert [listing_1, listing_2] == result
+    end
   end
 end

--- a/apps/re/test/filtering/filtering_test.exs
+++ b/apps/re/test/filtering/filtering_test.exs
@@ -201,7 +201,7 @@ defmodule Re.FilteringTest do
 
       result =
         Listing
-        |> Filtering.apply(%{orientation: "frente"})
+        |> Filtering.apply(%{orientations: ["frente"]})
         |> Repo.all()
 
       assert [listing] == result
@@ -213,7 +213,7 @@ defmodule Re.FilteringTest do
 
       result =
         Listing
-        |> Filtering.apply(%{sun_period: "morning"})
+        |> Filtering.apply(%{sun_periods: ["morning"]})
         |> Repo.all()
 
       assert [listing] == result

--- a/apps/re/test/filtering/filtering_test.exs
+++ b/apps/re/test/filtering/filtering_test.exs
@@ -161,7 +161,8 @@ defmodule Re.FilteringTest do
       listing = insert(:listing)
 
       result =
-        Filtering.apply(Listing, %{statuses: []})
+        Listing
+        |> Filtering.apply(%{statuses: []})
         |> Repo.all()
 
       assert [listing] == result
@@ -172,7 +173,8 @@ defmodule Re.FilteringTest do
       insert(:listing, status: "inactive")
 
       result =
-        Filtering.apply(Listing, %{statuses: ["active"]})
+        Listing
+        |> Filtering.apply(%{statuses: ["active"]})
         |> Repo.all()
 
       assert [listing] == result
@@ -184,7 +186,8 @@ defmodule Re.FilteringTest do
       insert(:listing, status: "sold")
 
       result =
-        Filtering.apply(Listing, %{statuses: ["active", "inactive"]})
+        Listing
+        |> Filtering.apply(%{statuses: ["active", "inactive"]})
         |> Repo.all()
 
       assert [listing_1, listing_2] == result
@@ -196,7 +199,10 @@ defmodule Re.FilteringTest do
       insert(:listing, orientation: "lateral")
       insert(:listing, orientation: "meio")
 
-      result = Filtering.apply(Listing, %{orientation: "frente"}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{orientation: "frente"})
+        |> Repo.all()
 
       assert [listing] == result
     end
@@ -205,7 +211,10 @@ defmodule Re.FilteringTest do
       listing = insert(:listing, sun_period: "morning")
       insert(:listing, sun_period: "evening")
 
-      result = Filtering.apply(Listing, %{sun_period: "morning"}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{sun_period: "morning"})
+        |> Repo.all()
 
       assert [listing] == result
     end
@@ -216,11 +225,17 @@ defmodule Re.FilteringTest do
       listing_3 = insert(:listing, floor_count: 3)
       listing_4 = insert(:listing, floor_count: 4)
 
-      result = Filtering.apply(Listing, %{min_floor_count: 3}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{min_floor_count: 3})
+        |> Repo.all()
 
       assert [listing_3, listing_4] == result
 
-      result = Filtering.apply(Listing, %{max_floor_count: 2}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{max_floor_count: 2})
+        |> Repo.all()
 
       assert [listing_1, listing_2] == result
     end
@@ -231,11 +246,17 @@ defmodule Re.FilteringTest do
       listing_3 = insert(:listing, unit_per_floor: 3)
       listing_4 = insert(:listing, unit_per_floor: 4)
 
-      result = Filtering.apply(Listing, %{min_unit_per_floor: 3}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{min_unit_per_floor: 3})
+        |> Repo.all()
 
       assert [listing_3, listing_4] == result
 
-      result = Filtering.apply(Listing, %{max_unit_per_floor: 2}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{max_unit_per_floor: 2})
+        |> Repo.all()
 
       assert [listing_1, listing_2] == result
     end
@@ -247,11 +268,17 @@ defmodule Re.FilteringTest do
       listing_3 = insert(:listing, construction_year: base_year - 15)
       listing_4 = insert(:listing, construction_year: base_year - 20)
 
-      result = Filtering.apply(Listing, %{max_age: 10}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{max_age: 10})
+        |> Repo.all()
 
       assert [listing_1, listing_2] == result
 
-      result = Filtering.apply(Listing, %{min_age: 15}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{min_age: 15})
+        |> Repo.all()
 
       assert [listing_3, listing_4] == result
     end
@@ -262,11 +289,17 @@ defmodule Re.FilteringTest do
       listing_3 = insert(:listing, price: 20, area: 1, price_per_area: 20)
       listing_4 = insert(:listing, price: 25, area: 1, price_per_area: 25)
 
-      result = Filtering.apply(Listing, %{min_price_per_area: 20}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{min_price_per_area: 20})
+        |> Repo.all()
 
       assert [listing_3, listing_4] == result
 
-      result = Filtering.apply(Listing, %{max_price_per_area: 15}) |> Repo.all()
+      result =
+        Listing
+        |> Filtering.apply(%{max_price_per_area: 15})
+        |> Repo.all()
 
       assert [listing_1, listing_2] == result
     end

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -266,7 +266,7 @@ defmodule Re.ListingTest do
       assert changeset.changes.price_per_area == @valid_attrs.price / @valid_attrs.area
     end
 
-    test "set to nil when price or area are nil" do
+    test "set to nil when price is nil" do
       attrs = Map.merge(@valid_attrs, %{addres_id: 1, user_id: 1})
 
       nil_price_attrs = %{attrs | price: nil}
@@ -275,6 +275,10 @@ defmodule Re.ListingTest do
 
       assert changeset.valid?
       refute Map.get(changeset.changes, :price_per_area)
+    end
+
+    test "set to nil when area is nil" do
+      attrs = Map.merge(@valid_attrs, %{addres_id: 1, user_id: 1})
 
       nil_area_attrs = %{attrs | area: nil}
 
@@ -284,7 +288,7 @@ defmodule Re.ListingTest do
       refute Map.get(changeset.changes, :price_per_area)
     end
 
-    test "set to nil when price or area are zero" do
+    test "set to nil when price is zero" do
       attrs = Map.merge(@valid_attrs, %{address_id: 1, user_id: 1})
 
       zero_price_attrs = %{attrs | price: 0}
@@ -293,6 +297,10 @@ defmodule Re.ListingTest do
 
       assert changeset.valid?
       refute Map.get(changeset.changes, :price_per_area)
+    end
+
+    test "set to nil when area is zero" do
+      attrs = Map.merge(@valid_attrs, %{address_id: 1, user_id: 1})
 
       zero_area_attrs = %{attrs | area: 0}
 

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -256,4 +256,50 @@ defmodule Re.ListingTest do
                {"is invalid", [type: :boolean, validation: :cast]}
     end
   end
+
+  describe "price per area" do
+    test "calculate when price and area set to proper value" do
+      attrs = Map.merge(@valid_attrs, %{address_id: 1, user_id: 1})
+      changeset = Listing.changeset(%Listing{}, attrs, "admin")
+
+      assert changeset.valid?
+      assert changeset.changes.price_per_area == @valid_attrs.price / @valid_attrs.area
+    end
+
+    test "set to nil when price or area are nil" do
+      attrs = Map.merge(@valid_attrs, %{addres_id: 1, user_id: 1})
+
+      nil_price_attrs = %{attrs | price: nil}
+
+      changeset = Listing.changeset(%Listing{}, nil_price_attrs, "user")
+
+      assert changeset.valid?
+      refute Map.get(changeset.changes, :price_per_area)
+
+      nil_area_attrs = %{attrs | area: nil}
+
+      changeset = Listing.changeset(%Listing{}, nil_area_attrs, "admin")
+
+      assert changeset.valid?
+      refute Map.get(changeset.changes, :price_per_area)
+    end
+
+    test "set to nil when price or area are zero" do
+      attrs = Map.merge(@valid_attrs, %{address_id: 1, user_id: 1})
+
+      zero_price_attrs = %{attrs | price: 0}
+
+      changeset = Listing.changeset(%Listing{}, zero_price_attrs, "user")
+
+      assert changeset.valid?
+      refute Map.get(changeset.changes, :price_per_area)
+
+      zero_area_attrs = %{attrs | area: 0}
+
+      changeset = Listing.changeset(%Listing{}, zero_area_attrs, "user")
+
+      assert changeset.valid?
+      refute Map.get(changeset.changes, :price_per_area)
+    end
+  end
 end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -406,6 +406,34 @@ defmodule Re.ListingsTest do
       assert {:ok, listing} = Listings.insert(@insert_listing_params, address, user)
       assert Repo.get(Listing, listing.id)
     end
+
+    test "should insert extra info for admin user" do
+      address = insert(:address)
+      user = insert(:user, role: "admin")
+
+      params =
+        Map.merge(
+          @insert_listing_params,
+          %{
+            "orientation" => "frente",
+            "sun_period" => "morning",
+            "floor_count" => 10,
+            "unit_per_floor" => 4,
+            "elevators" => 2,
+            "construction_year" => 2005
+          }
+        )
+
+      assert {:ok, listing} = Listings.insert(params, address, user)
+
+      assert listing.orientation == "frente"
+      assert listing.sun_period == "morning"
+      assert listing.floor_count == 10
+      assert listing.unit_per_floor == 4
+      assert listing.elevators == 2
+      assert listing.construction_year == 2005
+      assert listing.price_per_area == params["price"] / params["area"]
+    end
   end
 
   describe "insert/4" do

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -347,8 +347,26 @@ defmodule Re.ListingsTest do
       "rooms" => 3,
       "bathrooms" => 2,
       "garage_spots" => 1,
+      "area" => 100
+    }
+
+    @insert_admin_listing_params %{
+      "type" => "Apartamento",
+      "complement" => "100",
+      "description" => String.duplicate("a", 256),
+      "price" => 1_000_000,
+      "floor" => "3",
+      "rooms" => 3,
+      "bathrooms" => 2,
+      "garage_spots" => 1,
       "area" => 100,
-      "score" => 3
+      "score" => 3,
+      "orientation" => "frente",
+      "sun_period" => "morning",
+      "floor_count" => 10,
+      "unit_per_floor" => 4,
+      "elevators" => 2,
+      "construction_year" => 2005
     }
 
     test "should insert with description size bigger than 255" do
@@ -366,9 +384,14 @@ defmodule Re.ListingsTest do
       address = insert(:address)
       user = insert(:user, role: "admin")
 
-      assert {:ok, inserted_listing} = Listings.insert(@insert_listing_params, address, user)
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_admin_listing_params, address, user)
+
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.status == "inactive"
+
+      assert retrieved_listing.price_per_area ==
+               @insert_admin_listing_params["price"] / @insert_admin_listing_params["area"]
     end
 
     test "should insert inactive for normal user" do
@@ -378,6 +401,9 @@ defmodule Re.ListingsTest do
       assert {:ok, inserted_listing} = Listings.insert(@insert_listing_params, address, user)
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.status == "inactive"
+
+      assert retrieved_listing.price_per_area ==
+               @insert_listing_params["price"] / @insert_listing_params["area"]
     end
 
     test "should insert if user provides a phone" do
@@ -405,34 +431,6 @@ defmodule Re.ListingsTest do
 
       assert {:ok, listing} = Listings.insert(@insert_listing_params, address, user)
       assert Repo.get(Listing, listing.id)
-    end
-
-    test "should insert extra info for admin user" do
-      address = insert(:address)
-      user = insert(:user, role: "admin")
-
-      params =
-        Map.merge(
-          @insert_listing_params,
-          %{
-            "orientation" => "frente",
-            "sun_period" => "morning",
-            "floor_count" => 10,
-            "unit_per_floor" => 4,
-            "elevators" => 2,
-            "construction_year" => 2005
-          }
-        )
-
-      assert {:ok, listing} = Listings.insert(params, address, user)
-
-      assert listing.orientation == "frente"
-      assert listing.sun_period == "morning"
-      assert listing.floor_count == 10
-      assert listing.unit_per_floor == 4
-      assert listing.elevators == 2
-      assert listing.construction_year == 2005
-      assert listing.price_per_area == params["price"] / params["area"]
     end
   end
 

--- a/apps/re/test/listings/queries_test.exs
+++ b/apps/re/test/listings/queries_test.exs
@@ -93,4 +93,25 @@ defmodule Re.Listings.QueriesTest do
       assert 2 == result
     end
   end
+
+  describe "order_by/2" do
+    test "order listings by price per area" do
+      %{id: listing_id_1} =
+        insert(:listing, price: 20, area: 1, price_per_area: 20, status: "active")
+
+      %{id: listing_id_2} =
+        insert(:listing, price: 15, area: 1, price_per_area: 15, status: "active")
+
+      %{id: listing_id_3} =
+        insert(:listing, price: 10, area: 1, price_per_area: 10, status: "active")
+
+      result =
+        Queries.active()
+        |> Queries.order_by(%{order_by: [%{field: :price_per_area, type: :asc}]})
+        |> Repo.all()
+        |> Enum.map(& &1.id)
+
+      assert [listing_id_3, listing_id_2, listing_id_1] == result
+    end
+  end
 end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -22,15 +22,20 @@ defmodule Re.Factory do
   end
 
   def listing_factory do
+    price = random(:price)
+    area = Enum.random(1..500)
+    floor = random(:floor)
+    floor_count = random(:floor_count, floor)
+
     %Re.Listing{
       uuid: UUID.uuid4(),
       type: random(:listing_type),
       complement: Address.secondary_address(),
       description: Shakespeare.hamlet(),
-      price: random(:price),
+      price: price,
       property_tax: random(:price_float),
       maintenance_fee: random(:price_float),
-      floor: random(:floor),
+      floor: floor,
       rooms: Enum.random(1..10),
       bathrooms: Enum.random(1..10),
       restrooms: Enum.random(1..10),
@@ -40,13 +45,20 @@ defmodule Re.Factory do
       dependencies: Enum.random(0..10),
       balconies: Enum.random(0..10),
       has_elevator: Enum.random([true, false]),
-      area: Enum.random(1..500),
+      area: area,
       score: Enum.random(1..4),
       matterport_code: Faker.String.base64(),
       status: "active",
       is_exclusive: Enum.random([true, false]),
       is_release: Enum.random([true, false]),
-      is_exportable: Enum.random([true, false])
+      is_exportable: Enum.random([true, false]),
+      orientation: Enum.random(~w(frente fundos lateral meio)),
+      floor_count: floor_count,
+      unit_per_floor: Enum.random(1..10),
+      sun_period: Enum.random(~w(morning evening)),
+      elevators: Enum.random(0..10),
+      construction_year: Enum.random(1950..Date.utc_today().year),
+      price_per_area: price / area
     }
   end
 
@@ -217,5 +229,11 @@ defmodule Re.Factory do
     1..50
     |> Enum.random()
     |> Integer.to_string()
+  end
+
+  defp random(:floor_count, base_floor) do
+    base = String.to_integer(base_floor)
+    top = base * 2
+    Enum.random(base..top)
   end
 end


### PR DESCRIPTION
Add the following attributes to a listing:

* `orientation`
* `sun period`
* `floor count`
* `unit per floor`
* `construction year`
* `price per area`

For each field a new filter was added:

* `orientation`
* `sun_period`
* `mix_floor_count` and `max_floor_count`
* `min_unit_per_floor` and `max_unit_per_floor`
* `min_age` and `max_age`
* `min_price_per_area` and `max_price_per_area`

GraphQL queries and mutations were adjusted in PR #484.