### PR TITLE
Enable listing extra info in graphql

### DIFF
--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -78,7 +78,7 @@ defmodule Re.Listing do
 
   @garage_types ~w(contract condominium)
 
-  @orientation_types ~w(frente lateral fundo meio)
+  @orientation_types ~w(frontside backside lateral inside)
 
   @sun_period_types ~w(morning evening)
 

--- a/apps/re/test/filtering/filtering_test.exs
+++ b/apps/re/test/filtering/filtering_test.exs
@@ -195,10 +195,10 @@ defmodule Re.FilteringTest do
     end
 
     test "filter listing with empty orientation fetch all instances" do
-      %{id: listing_1} = insert(:listing, orientation: "frente")
-      %{id: listing_2} = insert(:listing, orientation: "fundos")
+      %{id: listing_1} = insert(:listing, orientation: "frontside")
+      %{id: listing_2} = insert(:listing, orientation: "backside")
       %{id: listing_3} = insert(:listing, orientation: "lateral")
-      %{id: listing_4} = insert(:listing, orientation: "meio")
+      %{id: listing_4} = insert(:listing, orientation: "inside")
 
       result =
         Listing
@@ -211,14 +211,14 @@ defmodule Re.FilteringTest do
     end
 
     test "filter listing by orientation" do
-      listing = insert(:listing, orientation: "frente")
-      insert(:listing, orientation: "fundos")
+      listing = insert(:listing, orientation: "frontside")
+      insert(:listing, orientation: "backside")
       insert(:listing, orientation: "lateral")
-      insert(:listing, orientation: "meio")
+      insert(:listing, orientation: "inside")
 
       result =
         Listing
-        |> Filtering.apply(%{orientations: ["frente"]})
+        |> Filtering.apply(%{orientations: ["frontside"]})
         |> Repo.all()
 
       assert [listing] == result

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -361,7 +361,7 @@ defmodule Re.ListingsTest do
       "garage_spots" => 1,
       "area" => 100,
       "score" => 3,
-      "orientation" => "frente",
+      "orientation" => "frontside",
       "sun_period" => "morning",
       "floor_count" => 10,
       "unit_per_floor" => 4,

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -52,7 +52,7 @@ defmodule Re.Factory do
       is_exclusive: Enum.random([true, false]),
       is_release: Enum.random([true, false]),
       is_exportable: Enum.random([true, false]),
-      orientation: Enum.random(~w(frente fundos lateral meio)),
+      orientation: Enum.random(~w(frontside backside lateral inside)),
       floor_count: floor_count,
       unit_per_floor: Enum.random(1..10),
       sun_period: Enum.random(~w(morning evening)),

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -199,7 +199,8 @@ defmodule ReWeb.Types.Listing do
 
   enum :orderable_field,
     values:
-      ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies price_per_area)a
+      ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies
+      price_per_area)a
 
   enum :order_type, values: ~w(desc asc)a
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -35,10 +35,10 @@ defmodule ReWeb.Types.Listing do
     field :is_exclusive, :boolean
     field :is_release, :boolean
     field :is_exportable, :boolean
-    field :orientation, :string
+    field :orientation, :orientation_type
     field :floor_count, :integer
     field :unit_per_floor, :integer
-    field :sun_period, :string
+    field :sun_period, :sun_period_type
     field :elevators, :integer
     field :construction_year, :integer
     field :price_per_area, :float
@@ -110,10 +110,10 @@ defmodule ReWeb.Types.Listing do
     field :is_release, :boolean
     field :is_exportable, :boolean
     field :score, :integer
-    field :orientation, :string
+    field :orientation, :orientation_type
     field :floor_count, :integer
     field :unit_per_floor, :integer
-    field :sun_period, :string
+    field :sun_period, :sun_period_type
     field :elevators, :integer
     field :construction_year, :integer
 
@@ -128,6 +128,10 @@ defmodule ReWeb.Types.Listing do
   end
 
   enum :garage_type, values: ~w(contract condominium)
+
+  enum :orientation_type, values: ~w(frontside backside lateral inside)
+
+  enum :sun_period_type, values: ~w(morning evening)
 
   object :address do
     field :id, :id

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -232,8 +232,8 @@ defmodule ReWeb.Types.Listing do
     field :max_floor_count, :integer
     field :min_unit_per_floor, :integer
     field :max_unit_per_floor, :integer
-    field :orientation, :string
-    field :sun_period, :string
+    field :orientations, list_of(non_null(:orientation_type))
+    field :sun_periods, list_of(non_null(:sun_period_type))
     field :min_age, :integer
     field :max_age, :integer
     field :min_price_per_area, :float
@@ -264,6 +264,16 @@ defmodule ReWeb.Types.Listing do
     field :statuses, list_of(:string)
     field :tags_slug, list_of(:string)
     field :tags_uuid, list_of(:uuid)
+    field :min_floor_count, :integer
+    field :max_floor_count, :integer
+    field :min_unit_per_floor, :integer
+    field :max_unit_per_floor, :integer
+    field :orientations, list_of(non_null(:orientation_type))
+    field :sun_periods, list_of(non_null(:sun_period_type))
+    field :min_age, :integer
+    field :max_age, :integer
+    field :min_price_per_area, :float
+    field :max_price_per_area, :float
   end
 
   object :price_history do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -35,6 +35,13 @@ defmodule ReWeb.Types.Listing do
     field :is_exclusive, :boolean
     field :is_release, :boolean
     field :is_exportable, :boolean
+    field :orientation, :string
+    field :floor_count, :integer
+    field :unit_per_floor, :integer
+    field :sun_period, :string
+    field :elevators, :integer
+    field :construction_year, :integer
+    field :price_per_area, :float
     field :inserted_at, :naive_datetime
     field :score, :integer, resolve: &Resolvers.Listings.score/3
 
@@ -101,6 +108,12 @@ defmodule ReWeb.Types.Listing do
     field :is_release, :boolean
     field :is_exportable, :boolean
     field :score, :integer
+    field :orientation, :string
+    field :floor_count, :integer
+    field :unit_per_floor, :integer
+    field :sun_period, :string
+    field :elevators, :integer
+    field :construction_year, :integer
 
     field :phone, :string
 
@@ -206,6 +219,16 @@ defmodule ReWeb.Types.Listing do
     field :statuses, list_of(non_null(:string))
     field :tags_slug, list_of(non_null(:string))
     field :tags_uuid, list_of(non_null(:uuid))
+    field :min_floor_count, :integer
+    field :max_floor_count, :integer
+    field :min_unit_per_floor, :integer
+    field :max_unit_per_floor, :integer
+    field :orientation, :string
+    field :sun_period, :string
+    field :min_age, :integer
+    field :max_age, :integer
+    field :min_price_per_area, :float
+    field :max_price_per_area, :float
   end
 
   object :listing_filter do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -199,7 +199,7 @@ defmodule ReWeb.Types.Listing do
 
   enum :orderable_field,
     values:
-      ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies)a
+      ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies price_per_area)a
 
   enum :order_type, values: ~w(desc asc)a
 

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -74,6 +74,11 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["isRelease"] == listing.is_release
       assert inserted_listing["isExportable"] == listing.is_exportable
       assert inserted_listing["score"] == listing.score
+      assert inserted_listing["orientation"] == String.upcase(listing.orientation)
+      assert inserted_listing["sunPeriod"] == String.upcase(listing.sun_period)
+      assert inserted_listing["floorCount"] == listing.floor_count
+      assert inserted_listing["unitPerFloor"] == listing.unit_per_floor
+      assert inserted_listing["elevators"] == listing.elevators
 
       refute inserted_listing["isActive"]
 
@@ -545,6 +550,11 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["isRelease"] == new_listing.is_release
       assert updated_listing["isExportable"] == new_listing.is_exportable
       assert updated_listing["score"] == new_listing.score
+      assert updated_listing["orientation"] == String.upcase(new_listing.orientation)
+      assert updated_listing["sunPeriod"] == String.upcase(new_listing.sun_period)
+      assert updated_listing["floorCount"] == new_listing.floor_count
+      assert updated_listing["unitPerFloor"] == new_listing.unit_per_floor
+      assert updated_listing["elevators"] == new_listing.elevators
 
       assert inserted_address["city"] == new_address.city
       assert inserted_address["state"] == new_address.state

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -325,7 +325,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_1]
+        tags: [tag_1],
+        price_per_area: 12_222.22
       )
 
       insert(
@@ -345,7 +346,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_1]
+        tags: [tag_1],
+        price_per_area: 8_777.78
       )
 
       insert(
@@ -365,7 +367,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_1]
+        tags: [tag_1],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -385,7 +388,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_1]
+        tags: [tag_1],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -405,7 +409,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_1]
+        tags: [tag_1],
+        price_per_area: 8181.82
       )
 
       insert(
@@ -425,7 +430,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_2]
+        tags: [tag_2],
+        price_per_area: 12_857.14
       )
 
       insert(
@@ -445,7 +451,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_2]
+        tags: [tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -465,7 +472,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_2]
+        tags: [tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -485,7 +493,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_2]
+        tags: [tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -505,7 +514,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_2]
+        tags: [tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -525,7 +535,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "contract",
-        tags: [tag_1, tag_2]
+        tags: [tag_1, tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -545,7 +556,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           ),
         garage_spots: 2,
         garage_type: "condominium",
-        tags: [tag_1, tag_2]
+        tags: [tag_1, tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -564,7 +576,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 0,
-        tags: [tag_1, tag_2]
+        tags: [tag_1, tag_2],
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -583,7 +596,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 4,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        price_per_area: 10_000.00
       )
 
       insert(
@@ -606,7 +620,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             lng: 50.0
           ),
         garage_spots: 4,
-        garage_type: "condominium"
+        garage_type: "condominium",
+        price_per_area: 10_000.00
       )
 
       listing1 =
@@ -631,13 +646,16 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
             ),
           garage_spots: 2,
           garage_type: "contract",
-          tags: [tag_1, tag_2]
+          tags: [tag_1, tag_2],
+          price_per_area: 10_000.00
         )
 
       variables = %{
         "filters" => %{
           "maxPrice" => 1_000_000,
           "minPrice" => 800_000,
+          "maxPricePerArea" => 10_500,
+          "minPricePerArea" => 9_500,
           "maxRooms" => 4,
           "minRooms" => 2,
           "maxSuites" => 2,

--- a/apps/re_web/test/support/mutation_helpers.ex
+++ b/apps/re_web/test/support/mutation_helpers.ex
@@ -37,7 +37,12 @@ defmodule ReWeb.Listing.MutationHelpers do
         "isExclusive" => listing.is_exclusive,
         "isRelease" => listing.is_release,
         "isExportable" => listing.is_exportable,
-        "score" => listing.score
+        "score" => listing.score,
+        "orientation" => String.upcase(listing.orientation),
+        "sunPeriod" => String.upcase(listing.sun_period),
+        "floorCount" => listing.floor_count,
+        "unitPerFloor" => listing.unit_per_floor,
+        "elevators" => listing.elevators
       }
     }
   end
@@ -77,7 +82,12 @@ defmodule ReWeb.Listing.MutationHelpers do
         "isExclusive" => listing.is_exclusive,
         "isRelease" => listing.is_release,
         "isExportable" => listing.is_exportable,
-        "score" => listing.score
+        "score" => listing.score,
+        "orientation" => String.upcase(listing.orientation),
+        "sunPeriod" => String.upcase(listing.sun_period),
+        "floorCount" => listing.floor_count,
+        "unitPerFloor" => listing.unit_per_floor,
+        "elevators" => listing.elevators
       }
     }
   end
@@ -123,6 +133,11 @@ defmodule ReWeb.Listing.MutationHelpers do
           isRelease
           isExportable
           score
+          orientation
+          sunPeriod
+          floorCount
+          unitPerFloor
+          elevators
         }
       }
     """
@@ -169,6 +184,11 @@ defmodule ReWeb.Listing.MutationHelpers do
           isRelease
           isExportable
           score
+          orientation
+          sunPeriod
+          floorCount
+          unitPerFloor
+          elevators
         }
       }
     """


### PR DESCRIPTION
Enable new fields and filters for listing mutations and query.

For querying these are the new filters, and ordering:

```graphql
query {
  listings(
    filters: {
      minPricePerArea: 6000,
      maxPricePerArea: 8000,
      minFloorCount: 6,
      maxFloorCount: 10,
      minUnitPerFloor: 2,
      maxUnitPerFloor: 4,
      orientations: [FRONTSIDE, INSIDE],
      sunPeriods: [MORNING],
      minAge: 5,
      maxAge: 10
    },
    orderBy: [{
      field: PRICE_PER_AREA,
      type: DESC
    }],
    pagination: {pageSize: 10}
  ) {
    listings {
      id
      price
      area
      pricePerArea
      orientation
      sunPeriod
      floorCount
      unitPerFloor
      constructionYear
    }
    remainingCount
  }
}
```

To mutate a listing these are the new inputs:

```graphql
mutation {
  insertListing(input: {
    type: "Apartamento",
    addressId: 1,
    price: 1000000,
    area: 100,
    orientation: FRONTSIDE,
    sunPeriod: MORNING,
    floor: "5",
    floorCount: 17,
    unitPerFloor: 6,
    constructionYear: 2000
  }) {
    price
    area
    pricePerArea
    orientation
    sunPeriod
    floorCount
    unitPerFloor
    constructionYear
  }
}
```