### PR TITLE
Change grupozap buyer lead message type to text to fix long message t…

### DIFF
--- a/apps/re/priv/repo/migrations/20190414164942_change_grupoza_lead_message_type.exs
+++ b/apps/re/priv/repo/migrations/20190414164942_change_grupoza_lead_message_type.exs
@@ -1,0 +1,15 @@
+defmodule Re.Repo.Migrations.ChangeGrupozaLeadMessageType do
+  use Ecto.Migration
+
+  def up do
+    alter table(:grupozap_buyer_leads) do
+      modify(:message, :text)
+    end
+  end
+
+  def down do
+    alter table(:grupozap_buyer_leads) do
+      modify(:message, :string)
+    end
+  end
+end

--- a/apps/re_web/test/webhooks/grupozap_plug_test.exs
+++ b/apps/re_web/test/webhooks/grupozap_plug_test.exs
@@ -56,6 +56,28 @@ defmodule ReWeb.Webhooks.GrupozapPlugTest do
       assert gb.client_listing_id
     end
 
+    @long_message_payload %{
+      "leadOrigin" => "VivaReal",
+      "timestamp" => "2019-01-01T00:00:00.000Z",
+      "originLeadId" => "59ee0fc6e4b043e1b2a6d863",
+      "originListingId" => "87027856",
+      "clientListingId" => "a40171",
+      "name" => "mah name",
+      "email" => "mah@email",
+      "ddd" => "11",
+      "phone" => "999999999",
+      "message" => String.duplicate("a", 256)
+    }
+
+    test "should save long message", %{authenticated_conn: conn} do
+      conn = post(conn, "/webhooks/grupozap", @long_message_payload)
+
+      assert text_response(conn, 200) == "ok"
+
+      assert gb = Repo.one(GrupozapBuyer)
+      assert gb.message
+    end
+
     @tag capture_log: true
     test "invalid payload", %{authenticated_conn: conn} do
       conn = post(conn, "/webhooks/grupozap", %{"wat" => "ok"})


### PR DESCRIPTION
Change grupozap buyer lead message type from string to text to fix long message truncate error.