### PR TITLE
Imovelweb buyer leads

### DIFF
--- a/apps/re/lib/leads/imovel_web_buyer.ex
+++ b/apps/re/lib/leads/imovel_web_buyer.ex
@@ -1,0 +1,29 @@
+defmodule Re.Leads.ImovelWebBuyer do
+  @moduledoc """
+  Schema for ImovelWeb buyer leads
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:uuid, :binary_id, autogenerate: true}
+
+  schema "imovelweb_buyer_leads" do
+    field :name, :string
+    field :email, :string
+    field :phone, :string
+    field :listing_id, :string
+
+    timestamps()
+  end
+
+  @required ~w(name email phone listing_id)a
+  @optional ~w()a
+  @params @required ++ @optional
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @params)
+    |> validate_required(@required)
+  end
+end

--- a/apps/re/priv/repo/migrations/20190415131527_create_imovelweb_buyer_leads.exs
+++ b/apps/re/priv/repo/migrations/20190415131527_create_imovelweb_buyer_leads.exs
@@ -1,0 +1,15 @@
+defmodule Re.Repo.Migrations.CreateImovelwebBuyerLeads do
+  use Ecto.Migration
+
+  def change do
+    create table(:imovelweb_buyer_leads, primary_key: false) do
+      add(:uuid, :uuid, primary_key: true)
+      add :phone, :string
+      add :name, :string
+      add :listing_id, :string
+      add :email, :string
+
+      timestamps()
+    end
+  end
+end

--- a/apps/re_integrations/lib/zapier/zapier.ex
+++ b/apps/re_integrations/lib/zapier/zapier.ex
@@ -9,7 +9,7 @@ defmodule ReIntegrations.Zapier do
     Repo
   }
 
-  def new_buyer_lead(payload) do
+  def new_buyer_lead(%{"source" => "facebook_buyer"} = payload) do
     %FacebookBuyer{}
     |> FacebookBuyer.changeset(payload)
     |> case do
@@ -23,5 +23,17 @@ defmodule ReIntegrations.Zapier do
 
         {:error, :unexpected_payload, errors}
     end
+  end
+
+  def new_buyer_lead(%{"source" => _source} = payload) do
+    Logger.warn("Invalid payload source. Payload: #{Kernel.inspect(payload)}")
+
+    {:error, :unexpected_payload, payload}
+  end
+
+  def new_buyer_lead(payload) do
+    Logger.warn("No payload source. Payload: #{Kernel.inspect(payload)}")
+
+    {:error, :unexpected_payload, payload}
   end
 end

--- a/apps/re_integrations/lib/zapier/zapier.ex
+++ b/apps/re_integrations/lib/zapier/zapier.ex
@@ -6,6 +6,7 @@ defmodule ReIntegrations.Zapier do
 
   alias Re.{
     Leads.FacebookBuyer,
+    Leads.ImovelWebBuyer,
     Repo
   }
 
@@ -19,6 +20,22 @@ defmodule ReIntegrations.Zapier do
       %{errors: errors} ->
         Logger.warn(
           "Invalid payload from zapier's facebook buyer. Errors: #{Kernel.inspect(errors)}"
+        )
+
+        {:error, :unexpected_payload, errors}
+    end
+  end
+
+  def new_buyer_lead(%{"source" => "imovelweb_buyer"} = payload) do
+    %ImovelWebBuyer{}
+    |> ImovelWebBuyer.changeset(payload)
+    |> case do
+      %{valid?: true} = changeset ->
+        Repo.insert(changeset)
+
+      %{errors: errors} ->
+        Logger.warn(
+          "Invalid payload from zapier's imovelweb buyer. Errors: #{Kernel.inspect(errors)}"
         )
 
         {:error, :unexpected_payload, errors}

--- a/apps/re_web/test/webhooks/zapier_plug_test.exs
+++ b/apps/re_web/test/webhooks/zapier_plug_test.exs
@@ -98,18 +98,12 @@ defmodule ReWeb.Webhooks.ZapierPlugTest do
     "name" => "mah full naem",
     "email" => "mah@email",
     "phone" => "11999999999",
-    "listingId" => "manhattan brooklyn harlem",
+    "listingId" => "2000",
     "source" => "imovelweb_buyer"
   }
 
   @imovelweb_buyer_invalid_payload %{
-    "full_name" => "mah full naem",
-    "timestamp" => "2019-01-01T00:00:00.000Z",
-    "lead_id" => "193846287346183764187",
-    "email" => "mah@email",
-    "phone_number" => "11999999999",
-    "neighborhoods" => "manhattan brooklyn harlem",
-    "location" => "asdasda",
+    "name" => "mah full naem",
     "source" => "imovelweb_buyer"
   }
 

--- a/apps/re_web/test/webhooks/zapier_plug_test.exs
+++ b/apps/re_web/test/webhooks/zapier_plug_test.exs
@@ -143,7 +143,7 @@ defmodule ReWeb.Webhooks.ZapierPlugTest do
     end
 
     @tag capture_log: true
-    test "invalid location request", %{authenticated_conn: conn} do
+    test "missing attributes request", %{authenticated_conn: conn} do
       conn = post(conn, "/webhooks/zapier", @imovelweb_buyer_invalid_payload)
 
       assert text_response(conn, 422) == "Unprocessable Entity"

--- a/apps/re_web/test/webhooks/zapier_plug_test.exs
+++ b/apps/re_web/test/webhooks/zapier_plug_test.exs
@@ -169,4 +169,14 @@ defmodule ReWeb.Webhooks.ZapierPlugTest do
     refute Repo.one(FacebookBuyer)
     refute Repo.one(ImovelWebBuyer)
   end
+
+  @tag capture_log: true
+  test "inexisting source", %{authenticated_conn: conn} do
+    conn = post(conn, "/webhooks/zapier", %{})
+
+    assert text_response(conn, 422) == "Unprocessable Entity"
+
+    refute Repo.one(FacebookBuyer)
+    refute Repo.one(ImovelWebBuyer)
+  end
 end


### PR DESCRIPTION
Since ImovelWeb's buyer leads comes from zapier, I refactored the integration to come with a `source` field so we can reuse the integration itself.