### PR TITLE
Removing CEP from Zap exporter

### DIFF
--- a/apps/re/lib/exporters/zap.ex
+++ b/apps/re/lib/exporters/zap.ex
@@ -8,7 +8,7 @@ defmodule Re.Exporters.Zap do
   @super_highlight 3
 
   @exported_attributes ~w(id type subtype category address state city neighborhood street_number complement
-                          postal_code price maintenance_fee util_area area_unit rooms bathrooms garage_spots
+                          price maintenance_fee util_area area_unit rooms bathrooms garage_spots
                           property_tax description images highlight)a
 
   @default_options %{attributes: @exported_attributes, highlight_ids: [], super_highlight_ids: []}
@@ -79,10 +79,6 @@ defmodule Re.Exporters.Zap do
 
   defp convert_attribute(:complement, listing, _) do
     {"Complemento", %{}, listing.complement}
-  end
-
-  defp convert_attribute(:postal_code, listing, _) do
-    {"CEP", %{}, String.replace(listing.address.postal_code, "-", "")}
   end
 
   defp convert_attribute(:price, listing, _) do

--- a/apps/re/test/exporters/zap_test.exs
+++ b/apps/re/test/exporters/zap_test.exs
@@ -54,7 +54,6 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
-          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -113,7 +112,6 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
-          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -165,7 +163,6 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
-          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -225,7 +222,6 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
-          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -287,7 +283,6 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
-          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>


### PR DESCRIPTION
Zap Imóveis overrides address information we're currently sending when CEP field is sent