### PR TITLE
Do not autogenerate uuids

### DIFF
--- a/apps/re/lib/leads/facebook_buyer.ex
+++ b/apps/re/lib/leads/facebook_buyer.ex
@@ -6,7 +6,7 @@ defmodule Re.Leads.FacebookBuyer do
 
   import Ecto.Changeset
 
-  @primary_key {:uuid, :binary_id, autogenerate: true}
+  @primary_key {:uuid, :binary_id, autogenerate: false}
 
   schema "facebook_buyer_leads" do
     field :full_name, :string
@@ -32,5 +32,8 @@ defmodule Re.Leads.FacebookBuyer do
     |> validate_inclusion(:location, @locations,
       message: "should be one of: [#{Enum.join(@locations, " ")}]"
     )
+    |> generate_uuid()
   end
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
 end

--- a/apps/re/lib/leads/imovel_web_buyer.ex
+++ b/apps/re/lib/leads/imovel_web_buyer.ex
@@ -6,7 +6,7 @@ defmodule Re.Leads.ImovelWebBuyer do
 
   import Ecto.Changeset
 
-  @primary_key {:uuid, :binary_id, autogenerate: true}
+  @primary_key {:uuid, :binary_id, autogenerate: false}
 
   schema "imovelweb_buyer_leads" do
     field :name, :string
@@ -25,5 +25,8 @@ defmodule Re.Leads.ImovelWebBuyer do
     struct
     |> cast(params, @params)
     |> validate_required(@required)
+    |> generate_uuid()
   end
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
 end


### PR DESCRIPTION
To be able to use `ecto_job` better, I'm refactoring to generate uuid in the changeset so we can create a job with the to-be-inserted uuid.