### PR TITLE
Adjust listing query/mutation to receive an owner contact

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -169,6 +169,9 @@ defmodule Re.Listings do
       {:user, _}, changeset ->
         changeset
 
+      {:owner_contact, nil}, changeset ->
+        changeset
+
       {:owner_contact, owner_contact}, changeset ->
         Changeset.change(changeset, %{owner_contact_uuid: owner_contact.uuid})
     end)

--- a/apps/re/lib/owner_contacts/owner_contacts.ex
+++ b/apps/re/lib/owner_contacts/owner_contacts.ex
@@ -2,10 +2,18 @@ defmodule Re.OwnerContacts do
   @moduledoc """
   Context for owner contacts.
   """
+  @behaviour Bodyguard.Policy
+
   alias Re.{
     OwnerContact,
     Repo
   }
+
+  defdelegate authorize(action, user, params), to: __MODULE__.Policy
+
+  def data(params), do: Dataloader.Ecto.new(Repo, query: &query/2, default_params: params)
+
+  def query(_query, _args), do: OwnerContact
 
   def all, do: Repo.all(OwnerContact)
 

--- a/apps/re/lib/owner_contacts/policy.ex
+++ b/apps/re/lib/owner_contacts/policy.ex
@@ -1,0 +1,11 @@
+defmodule Re.OwnerContacts.Policy do
+  @moduledoc """
+  Policy module for user permission on owner contacts
+  """
+
+  alias Re.User
+
+  def authorize(_, %User{role: "admin"}, _), do: :ok
+  def authorize(_, nil, _), do: {:error, :unauthorized}
+  def authorize(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -373,7 +373,9 @@ defmodule Re.ListingsTest do
       address = insert(:address)
       user = insert(:user, role: "user")
 
-      assert {:ok, inserted_listing} = Listings.insert(@insert_listing_params, address, user)
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_listing_params, address: address, user: user)
+
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.address_id == address.id
       assert retrieved_listing.user_id == user.id
@@ -385,7 +387,7 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "admin")
 
       assert {:ok, inserted_listing} =
-               Listings.insert(@insert_admin_listing_params, address, user)
+               Listings.insert(@insert_admin_listing_params, address: address, user: user)
 
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.status == "inactive"
@@ -398,7 +400,9 @@ defmodule Re.ListingsTest do
       address = insert(:address)
       user = insert(:user, role: "user")
 
-      assert {:ok, inserted_listing} = Listings.insert(@insert_listing_params, address, user)
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_listing_params, address: address, user: user)
+
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.status == "inactive"
 
@@ -411,7 +415,10 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "user", phone: nil)
 
       assert {:ok, inserted_listing} =
-               Listings.insert(Map.put(@insert_listing_params, "phone", "123321"), address, user)
+               Listings.insert(Map.put(@insert_listing_params, "phone", "123321"),
+                 address: address,
+                 user: user
+               )
 
       assert inserted_listing = Repo.get(Listing, inserted_listing.id)
       assert inserted_listing.status == "inactive"
@@ -422,14 +429,16 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "user", phone: nil)
 
       assert {:error, :phone_number_required} =
-               Listings.insert(@insert_listing_params, address, user)
+               Listings.insert(@insert_listing_params, address: address, user: user)
     end
 
     test "should insert if user doesn't have phone but is admin" do
       address = insert(:address)
       user = insert(:user, role: "admin", phone: nil)
 
-      assert {:ok, listing} = Listings.insert(@insert_listing_params, address, user)
+      assert {:ok, listing} =
+               Listings.insert(@insert_listing_params, address: address, user: user)
+
       assert Repo.get(Listing, listing.id)
     end
   end
@@ -447,7 +456,11 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "admin")
 
       assert {:ok, inserted_listing} =
-               Listings.insert(@insert_development_listing_params, address, user, development)
+               Listings.insert(@insert_development_listing_params,
+                 address: address,
+                 user: user,
+                 development: development
+               )
 
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.development_uuid == development.uuid
@@ -462,7 +475,11 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "admin")
 
       assert {:ok, inserted_listing} =
-               Listings.insert(@insert_development_listing_params, address, user, development)
+               Listings.insert(@insert_development_listing_params,
+                 address: address,
+                 user: user,
+                 development: development
+               )
 
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.is_exportable == false
@@ -477,7 +494,7 @@ defmodule Re.ListingsTest do
       address = insert(:address)
       listing = insert(:listing, user: user, price: 1_000_000)
 
-      Listings.update(listing, %{price: listing.price + 50_000}, address, user)
+      Listings.update(listing, %{price: listing.price + 50_000}, address: address, user: user)
 
       GenServer.call(Server, :inspect)
 
@@ -492,7 +509,7 @@ defmodule Re.ListingsTest do
       address = insert(:address)
       listing = insert(:listing, user: user, rooms: 3)
 
-      Listings.update(listing, %{rooms: 4}, address, user)
+      Listings.update(listing, %{rooms: 4}, address: address, user: user)
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.status == "inactive"
@@ -507,7 +524,11 @@ defmodule Re.ListingsTest do
       development = insert(:development, address: address)
       listing = insert(:listing, user: user)
 
-      Listings.update(listing, %{is_exportable: true}, address, user, development)
+      Listings.update(listing, %{is_exportable: true},
+        address: address,
+        user: user,
+        development: development
+      )
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.is_exportable == false

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -514,7 +514,11 @@ defmodule Re.ListingsTest do
       user = insert(:user, role: "admin")
 
       assert {:ok, inserted_listing} =
-               Listings.insert(@insert_development_listing_params, address, user, development)
+               Listings.insert(@insert_development_listing_params,
+                 address: address,
+                 user: user,
+                 development: development
+               )
 
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.development_uuid == development.uuid

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -421,6 +421,18 @@ defmodule Re.ListingsTest do
                @insert_listing_params["price"] / @insert_listing_params["area"]
     end
 
+    test "should insert if owner contact is nil" do
+      address = insert(:address)
+      user = insert(:user, role: "admin")
+
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_admin_listing_params,
+                 address: address,
+                 user: user,
+                 owner_contact: nil
+               )
+    end
+
     test "should insert if user provides a phone" do
       address = insert(:address)
       user = insert(:user, role: "user", phone: nil)
@@ -543,6 +555,22 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.owner_contact_uuid == updated_owner_contact.uuid
+    end
+
+    test "should update if owner contact is nil" do
+      user = insert(:user)
+      address = insert(:address)
+      original_owner_contact = insert(:owner_contact)
+      listing = insert(:listing, user: user, owner_contact: original_owner_contact)
+
+      Listings.update(listing, %{},
+        address: address,
+        user: user,
+        owner_contact: nil
+      )
+
+      updated_listing = Repo.get(Listing, listing.id)
+      assert updated_listing.owner_contact_uuid == original_owner_contact.uuid
     end
 
     test "should not change user who created listing" do

--- a/apps/re/test/owner_contacts/owner_contacts_test.exs
+++ b/apps/re/test/owner_contacts/owner_contacts_test.exs
@@ -1,7 +1,10 @@
 defmodule Re.OwnerContactsTest do
   use Re.ModelCase
 
-  alias Re.OwnerContacts
+  alias Re.{
+    OwnerContact,
+    OwnerContacts
+  }
 
   import Re.Factory
 
@@ -156,6 +159,33 @@ defmodule Re.OwnerContactsTest do
       assert inserted_owner_contact.name == owner_contact.name
       assert inserted_owner_contact.name_slug == owner_contact.name_slug
       assert inserted_owner_contact.phone == params.phone
+    end
+  end
+
+  describe "data/1" do
+    test "should fetch owner contact through dataloader" do
+      owner_contact = insert(:owner_contact)
+
+      loader =
+        Dataloader.add_source(
+          Dataloader.new(),
+          :owner_contacts,
+          OwnerContacts.data(%{})
+        )
+
+      loader =
+        loader
+        |> Dataloader.load(
+          :owner_contacts,
+          OwnerContact,
+          owner_contact.uuid
+        )
+        |> Dataloader.run()
+
+      owner_contact_fetched =
+        Dataloader.get(loader, :owner_contacts, OwnerContact, owner_contact.uuid)
+
+      assert owner_contact == owner_contact_fetched
     end
   end
 end

--- a/apps/re_web/lib/controllers/listing_controller.ex
+++ b/apps/re_web/lib/controllers/listing_controller.ex
@@ -26,7 +26,7 @@ defmodule ReWeb.ListingController do
   def create(conn, %{"listing" => listing_params, "address" => address_params} = params, user) do
     with :ok <- Bodyguard.permit(Listings, :create_listing, user, params),
          {:ok, address} <- Addresses.insert_or_update(address_params),
-         {:ok, listing} <- Listings.insert(listing_params, address, user) do
+         {:ok, listing} <- Listings.insert(listing_params, address: address, user: user) do
       send_email_if_not_admin(listing, user)
 
       conn
@@ -60,7 +60,7 @@ defmodule ReWeb.ListingController do
     with {:ok, listing} <- Listings.get_preloaded(id),
          :ok <- Bodyguard.permit(Listings, :update_listing, user, listing),
          {:ok, address} <- Addresses.insert_or_update(address_params),
-         {:ok, listing} <- Listings.update(listing, listing_params, address, user) do
+         {:ok, listing} <- Listings.update(listing, listing_params, address: address, user: user) do
       conn
       |> put_view(get_view(user))
       |> render("edit.json", listing: listing)

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -112,8 +112,13 @@ defmodule ReWeb.Resolvers.Listings do
     with {:ok, listing} <- Listings.get(id),
          :ok <- Bodyguard.permit(Listings, :update_listing, current_user, listing),
          {:ok, address} <- get_address(listing_params),
+         {:ok, owner_contact} <- upsert_owner_contact(listing_params),
          {:ok, listing} <-
-           Listings.update(listing, listing_params, address: address, user: current_user),
+           Listings.update(listing, listing_params,
+             address: address,
+             user: current_user,
+             owner_contact: owner_contact
+           ),
          {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     end

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -48,7 +48,12 @@ defmodule ReWeb.Resolvers.Listings do
            Bodyguard.permit(Listings, :create_development_listing, current_user, listing_params),
          {:ok, address} <- get_address(listing_params),
          {:ok, development} <- get_development(listing_params),
-         {:ok, listing} <- Listings.insert(listing_params, address, current_user, development),
+         {:ok, listing} <-
+           Listings.insert(listing_params,
+             address: address,
+             user: current_user,
+             development: development
+           ),
          {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     else
@@ -60,7 +65,7 @@ defmodule ReWeb.Resolvers.Listings do
   def insert(%{input: listing_params}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Listings, :create_listing, current_user, listing_params),
          {:ok, address} <- get_address(listing_params),
-         {:ok, listing} <- Listings.insert(listing_params, address, current_user),
+         {:ok, listing} <- Listings.insert(listing_params, address: address, user: current_user),
          {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     else
@@ -84,7 +89,11 @@ defmodule ReWeb.Resolvers.Listings do
          address <- listing.address,
          development <- listing.development,
          {:ok, listing} <-
-           Listings.update(listing, listing_params, address, current_user, development),
+           Listings.update(listing, listing_params,
+             address: address,
+             user: current_user,
+             development: development
+           ),
          {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     end
@@ -96,7 +105,8 @@ defmodule ReWeb.Resolvers.Listings do
     with {:ok, listing} <- Listings.get(id),
          :ok <- Bodyguard.permit(Listings, :update_listing, current_user, listing),
          {:ok, address} <- get_address(listing_params),
-         {:ok, listing} <- Listings.update(listing, listing_params, address, current_user),
+         {:ok, listing} <-
+           Listings.update(listing, listing_params, address: address, user: current_user),
          {:ok, listing} <- Listings.upsert_tags(listing, Map.get(listing_params, :tags)) do
       {:ok, listing}
     end

--- a/apps/re_web/lib/graphql/resolvers/owner_contacts.ex
+++ b/apps/re_web/lib/graphql/resolvers/owner_contacts.ex
@@ -1,0 +1,19 @@
+defmodule ReWeb.Resolvers.OwnerContacts do
+  @moduledoc """
+  Resolver module for owner contact queries and mutations
+  """
+  import Absinthe.Resolution.Helpers, only: [on_load: 2]
+
+  def per_listing(listing, _params, %{context: %{loader: loader, current_user: current_user}}) do
+    with :ok <-
+           Bodyguard.permit(Re.OwnerContacts, :fetch_owner_contact, current_user, current_user) do
+      loader
+      |> Dataloader.load(Re.OwnerContacts, :owner_contact, listing)
+      |> on_load(fn loader ->
+        {:ok, Dataloader.get(loader, Re.OwnerContacts, :owner_contact, listing)}
+      end)
+    else
+      _ -> {:ok, nil}
+    end
+  end
+end

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -13,6 +13,7 @@ defmodule ReWeb.Schema do
   import_types ReWeb.Types.Development
   import_types ReWeb.Types.Unit
   import_types ReWeb.Types.Tag
+  import_types ReWeb.Types.OwnerContact
   import_types ReWeb.Types.Custom.UUID
   import_types Absinthe.Type.Custom
 
@@ -80,6 +81,7 @@ defmodule ReWeb.Schema do
       Re.Interests,
       Re.Interests.Types,
       Re.Favorites,
+      Re.OwnerContacts,
       Re.Statistics.ListingVisualizations,
       Re.Statistics.TourVisualizations,
       Re.Statistics.InPersonVisits,

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -127,6 +127,8 @@ defmodule ReWeb.Types.Listing do
     field :development_uuid, :uuid
 
     field :tags, list_of(non_null(:uuid))
+
+    field :owner_contact, :owner_contact_input
   end
 
   enum :garage_type, values: ~w(contract condominium)

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -85,6 +85,8 @@ defmodule ReWeb.Types.Listing do
     field :development, :development, resolve: &Resolvers.Developments.per_listing/3
 
     field :tags, list_of(:tag), resolve: &Resolvers.Tags.per_listing/3
+
+    field :owner_contact, :owner_contact, resolve: &Resolvers.OwnerContacts.per_listing/3
   end
 
   input_object :listing_input do

--- a/apps/re_web/lib/graphql/types/owner_contact.ex
+++ b/apps/re_web/lib/graphql/types/owner_contact.ex
@@ -1,0 +1,15 @@
+defmodule ReWeb.Types.OwnerContact do
+  @moduledoc """
+  Graphql type for owner contact.
+  """
+  use Absinthe.Schema.Notation
+
+  object :owner_contact do
+    field :uuid, :uuid
+    field :name, :string
+    field :phone, :string
+    field :email, :string
+    field :additional_phones, list_of(:string)
+    field :additional_emails, list_of(:string)
+  end
+end

--- a/apps/re_web/lib/graphql/types/owner_contact.ex
+++ b/apps/re_web/lib/graphql/types/owner_contact.ex
@@ -12,4 +12,12 @@ defmodule ReWeb.Types.OwnerContact do
     field :additional_phones, list_of(:string)
     field :additional_emails, list_of(:string)
   end
+
+  input_object :owner_contact_input do
+    field :name, non_null(:string)
+    field :phone, non_null(:string)
+    field :email, :string
+    field :additional_phones, list_of(non_null(:string))
+    field :additional_emails, list_of(non_null(:string))
+  end
 end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -773,6 +773,77 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert expected == json_response(conn, 200)["data"]["updateListing"]
     end
 
+    test "admin should update owner contact from listing", %{
+      admin_conn: conn,
+      old_address: address
+    } do
+      listing =
+        insert(
+          :listing,
+          address_id: address.id,
+          owner_contact:
+            build(
+              :owner_contact,
+              name: "Jon Snow",
+              name_slug: "jon-snow",
+              phone: "+5511987654321",
+              email: nil,
+              additional_phones: nil,
+              additional_emails: nil
+            )
+        )
+
+      variables = %{
+        "id" => listing.id,
+        "input" => %{
+          "type" => "Apartamento",
+          "addressId" => address.id,
+          "ownerContact" => %{
+            "name" => "Jon Snow",
+            "phone" => "+5511987654321",
+            "email" => "jon@snow.com",
+            "additionalPhones" => ["+5511876543210"],
+            "additionalEmails" => ["jonsnow@gmail.com"]
+          }
+        }
+      }
+
+      mutation = """
+        mutation UpdateListing (
+          $id: ID!,
+          $input: ListingInput!
+        ) {
+          updateListing(id: $id, input: $input) {
+            type
+            ownerContact {
+              name
+              phone
+              email
+              additionalPhones
+              additionalEmails
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{
+        "updateListing" => %{
+          "type" => "Apartamento",
+          "ownerContact" => %{
+            "name" => "Jon Snow",
+            "phone" => "+5511987654321",
+            "email" => "jon@snow.com",
+            "additionalPhones" => ["+5511876543210"],
+            "additionalEmails" => ["jonsnow@gmail.com"]
+          }
+        }
+      }
+
+      assert expected == json_response(conn, 200)["data"]
+    end
+
     @update_development_listing_mutation """
       mutation UpdateListing ($id: ID!, $input: ListingInput!) {
         updateListing(id: $id, input: $input) {

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -329,6 +329,57 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert expected == json_response(conn, 200)["data"]
     end
 
+    test "admin should insert listing with owner contact", %{
+      admin_conn: conn,
+      old_address: address
+    } do
+      variables = %{
+        "input" => %{
+          "type" => "Apartamento",
+          "addressId" => address.id,
+          "ownerContact" => %{
+            "name" => "Jon Snow",
+            "phone" => "+5511987654321",
+            "email" => "jon@snow.com",
+            "additionalPhones" => ["+5511876543210"],
+            "additionalEmails" => ["jonsnow@gmail.com"]
+          }
+        }
+      }
+
+      mutation = """
+        mutation InsertListing ($input: ListingInput!) {
+          insertListing(input: $input) {
+            type
+            ownerContact {
+              name
+              phone
+              email
+              additionalPhones
+              additionalEmails
+            }
+          }
+        }
+      """
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      expected = %{
+        "insertListing" => %{
+          "type" => "Apartamento",
+          "ownerContact" => %{
+            "name" => "Jon Snow",
+            "phone" => "+5511987654321",
+            "email" => "jon@snow.com",
+            "additionalPhones" => ["+5511876543210"],
+            "additionalEmails" => ["jonsnow@gmail.com"]
+          }
+        }
+      }
+
+      assert expected == json_response(conn, 200)["data"]
+    end
+
     test "anonymous should not insert listing", %{
       unauthenticated_conn: conn,
       listing: listing,

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -984,6 +984,107 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
 
       assert expected == json_response(conn, 200)["data"]["listings"]
     end
+
+    test "admin should query listing with owner contact", %{admin_conn: conn} do
+      insert(
+        :listing,
+        owner_contact:
+          build(:owner_contact, name: "Jon Snow", name_slug: "jon-snow", phone: "+5511987654321")
+      )
+
+      query = """
+        query Listings {
+          listings {
+            listings {
+              ownerContact {
+                name
+                phone
+              }
+            }
+          }
+        }
+      """
+
+      expected = %{
+        "listings" => [
+          %{
+            "ownerContact" => %{"name" => "Jon Snow", "phone" => "+5511987654321"}
+          }
+        ]
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query))
+
+      assert expected == json_response(conn, 200)["data"]["listings"]
+    end
+
+    test "user should not query listing with owner contact", %{user_conn: conn} do
+      insert(
+        :listing,
+        owner_contact:
+          build(:owner_contact, name: "Jon Snow", name_slug: "jon-snow", phone: "+5511987654321")
+      )
+
+      query = """
+        query Listings {
+          listings {
+            listings {
+              ownerContact {
+                name
+                phone
+              }
+            }
+          }
+        }
+      """
+
+      expected = %{
+        "listings" => [
+          %{
+            "ownerContact" => nil
+          }
+        ]
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query))
+
+      assert expected == json_response(conn, 200)["data"]["listings"]
+    end
+
+    test "anonymous user should not query listing with owner contact", %{
+      unauthenticated_conn: conn
+    } do
+      insert(
+        :listing,
+        owner_contact:
+          build(:owner_contact, name: "Jon Snow", name_slug: "jon-snow", phone: "+5511987654321")
+      )
+
+      query = """
+        query Listings {
+          listings {
+            listings {
+              ownerContact {
+                name
+                phone
+              }
+            }
+          }
+        }
+      """
+
+      expected = %{
+        "listings" => [
+          %{
+            "ownerContact" => nil
+          }
+        ]
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query))
+
+      assert expected == json_response(conn, 200)["data"]["listings"]
+    end
   end
 
   describe "listing" do


### PR DESCRIPTION
Allow any administrative user to add and fetch owner contact information in `graphql`.

To fetch an owner contact:

```graphql
query {
  listing(id: 3211) {
    id
    ownerContact {
      name
      phone
      email
      additionalPhones
      additionalEmails
    }
  }
}
```

To insert an owner contact:

```graphql
mutation {
  insertListing(input: {
    type: "Apartamento",
    addressId: 1,
    ownerContact: {
      name: "João Paulo Dubas",
      phone: "+5511999999999"
    }
  }) {
    id
    type
    ownerContact {
      name
      phone
    }
  }
}
```

To update a contact:

```graphql
mutation {
  updateListing(
    id: 3281,
    input: {
      type: "Apartamento",
      addressId: 1,
      ownerContact: {
        name: "João Paulo Dubas",
        phone: "+5511999999999",
        email: "joao@email.com",
        additionalPhones: ["+5511888888888"],
        additionalEmails: ["joao@outro.email.com"]
      }
    }
  ) {
    id
    type
    ownerContact {
      name
      phone
    }
  }
}
```

Besides that, refactor `Re.Listings.insert/2` and `Re.Listings.update/3` to receive any number of keyword arguments. This should make easier to extend both methods.