### PR TITLE
Add infrastructure attributes to developments

### DIFF
--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -15,6 +15,9 @@ defmodule Re.Development do
     field :phase, :string
     field :builder, :string
     field :description, :string
+    field :floor_count, :integer
+    field :units_per_floor, :integer
+    field :elevators, :integer
 
     belongs_to :address, Re.Address
 
@@ -29,9 +32,11 @@ defmodule Re.Development do
 
   @required ~w(name title phase builder description address_id)a
 
+  @optional ~w(floor_count units_per_floor elevators)a
+
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required)
+    |> cast(params, @required ++ @optional)
     |> validate_required(@required)
     |> validate_inclusion(:phase, @phases,
       message: "should be one of: [#{Enum.join(@phases, " ")}]"

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -99,7 +99,10 @@ defmodule Re.Listings do
       development_uuid: development.uuid,
       address_id: address.id,
       user_id: user.id,
-      is_exportable: false
+      is_exportable: false,
+      floor_count: development.floor_count,
+      unit_per_floor: development.units_per_floor,
+      elevators: development.elevators
     })
     |> Listing.development_changeset(params)
     |> Repo.insert()

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -99,14 +99,20 @@ defmodule Re.Listings do
       development_uuid: development.uuid,
       address_id: address.id,
       user_id: user.id,
-      is_exportable: false,
+      is_exportable: false
+    })
+    |> copy_infrastructure(development)
+    |> Listing.development_changeset(params)
+    |> Repo.insert()
+    |> publish_if_admin(user.role)
+  end
+
+  defp copy_infrastructure(changeset, development) do
+    Changeset.change(changeset, %{
       floor_count: development.floor_count,
       unit_per_floor: development.units_per_floor,
       elevators: development.elevators
     })
-    |> Listing.development_changeset(params)
-    |> Repo.insert()
-    |> publish_if_admin(user.role)
   end
 
   defp do_insert(params, address, user) do

--- a/apps/re/priv/repo/migrations/20190425134344_add_infrastructure_attributes_to_development.exs
+++ b/apps/re/priv/repo/migrations/20190425134344_add_infrastructure_attributes_to_development.exs
@@ -1,0 +1,11 @@
+defmodule Re.Repo.Migrations.AddInfrastructureAttributesToDevelopment do
+  use Ecto.Migration
+
+  def change do
+    alter table(:developments) do
+      add :floor_count, :integer
+      add :units_per_floor, :integer
+      add :elevators, :integer
+    end
+  end
+end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -467,6 +467,21 @@ defmodule Re.ListingsTest do
       assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
       assert retrieved_listing.is_exportable == false
     end
+
+    test "should copy infrastructure info from development" do
+      address = insert(:address)
+      development = insert(:development, address_id: address.id)
+      user = insert(:user, role: "admin")
+
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_development_listing_params, address, user, development)
+
+      assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
+      assert retrieved_listing.development_uuid == development.uuid
+      assert retrieved_listing.floor_count == development.floor_count
+      assert retrieved_listing.unit_per_floor == development.units_per_floor
+      assert retrieved_listing.elevators == development.elevators
+    end
   end
 
   describe "update/4" do

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -167,7 +167,10 @@ defmodule Re.Factory do
       title: Name.name(),
       phase: Enum.random(~w(pre-launch planning building delivered)),
       builder: Name.name(),
-      description: Shakespeare.hamlet()
+      description: Shakespeare.hamlet(),
+      floor_count: Enum.random(1..20),
+      units_per_floor: Enum.random(1..20),
+      elevators: Enum.random(1..5)
     }
   end
 

--- a/apps/re_web/lib/graphql/types/development.ex
+++ b/apps/re_web/lib/graphql/types/development.ex
@@ -15,6 +15,9 @@ defmodule ReWeb.Types.Development do
     field :phase, :string
     field :builder, :string
     field :description, :string
+    field :floor_count, :integer
+    field :units_per_floor, :integer
+    field :elevators, :integer
 
     field :address, :address,
       resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_development/3)
@@ -35,6 +38,9 @@ defmodule ReWeb.Types.Development do
     field :phase, :string
     field :builder, :string
     field :description, :string
+    field :floor_count, :integer
+    field :units_per_floor, :integer
+    field :elevators, :integer
 
     field :address_id, :id
   end

--- a/apps/re_web/test/graphql/developments/mutation_test.exs
+++ b/apps/re_web/test/graphql/developments/mutation_test.exs
@@ -34,6 +34,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
           phase
           builder
           description
+          floor_count
+          units_per_floor
+          elevators
           address {
             id
           }
@@ -61,6 +64,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
       assert insert_development["phase"] == development.phase
       assert insert_development["builder"] == development.builder
       assert insert_development["description"] == development.description
+      assert insert_development["floor_count"] == development.floor_count
+      assert insert_development["units_per_floor"] == development.units_per_floor
+      assert insert_development["elevators"] == development.elevators
 
       assert inserted_address["id"] == Integer.to_string(address.id)
     end
@@ -106,6 +112,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
           phase
           builder
           description
+          floor_count
+          units_per_floor
+          elevators
           address {
             id
           }
@@ -133,6 +142,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
       assert updated_development["builder"] == new_development.builder
       assert updated_development["phase"] == new_development.phase
       assert updated_development["description"] == new_development.description
+      assert updated_development["floor_count"] == new_development.floor_count
+      assert updated_development["units_per_floor"] == new_development.units_per_floor
+      assert updated_development["elevators"] == new_development.elevators
 
       assert updated_address["id"] == Integer.to_string(new_address.id)
     end
@@ -178,6 +190,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
         "phase" => development.phase,
         "builder" => development.builder,
         "description" => development.description,
+        "floor_count" => development.floor_count,
+        "units_per_floor" => development.units_per_floor,
+        "elevators" => development.elevators,
         "address_id" => address.id
       }
     }
@@ -192,6 +207,9 @@ defmodule ReWeb.GraphQL.Developments.MutationTest do
         "phase" => development.phase,
         "builder" => development.builder,
         "description" => development.description,
+        "floor_count" => development.floor_count,
+        "units_per_floor" => development.units_per_floor,
+        "elevators" => development.elevators,
         "address_id" => address.id
       }
     }


### PR DESCRIPTION
Add new infrastructure attributes on developments. They're softly duplicated on listings by now duo the filters and exporters.

Made a name type from `unit_per_floor` (listings) to `units_per_floor` on developments, do you think whort it to rename it on listings as well? 

Also add GraphQL entries for it on development cc: @gabiseabra.