### PR TITLE
Remove tour appointment from site seller lead

### DIFF
--- a/apps/re/lib/seller_leads/site_lead.ex
+++ b/apps/re/lib/seller_leads/site_lead.ex
@@ -16,14 +16,13 @@ defmodule Re.SellerLeads.SiteLead do
     field :price, :integer
 
     belongs_to :price_request, Re.PriceSuggestions.Request
-    belongs_to :tour_appointment, Re.Calendars.TourAppointment
 
     timestamps(type: :utc_datetime)
   end
 
   @types ~w(Apartamento Casa Cobertura)
 
-  @required ~w(price_request_id tour_appointment_id)a
+  @required ~w(price_request_id)a
   @optional ~w(complement type maintenance_fee suites price)a
   @params @required ++ @optional
 

--- a/apps/re/priv/repo/migrations/20190430152454_remove_tour_appointment_site_seller_lead.exs
+++ b/apps/re/priv/repo/migrations/20190430152454_remove_tour_appointment_site_seller_lead.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.RemoveTourAppointmentSiteSellerLead do
+  use Ecto.Migration
+
+  def change do
+    alter table(:site_seller_leads) do
+      remove :tour_appointment_id
+    end
+  end
+end

--- a/apps/re/test/seller_leads/site_lead_test.exs
+++ b/apps/re/test/seller_leads/site_lead_test.exs
@@ -23,12 +23,8 @@ defmodule Re.SellerLeads.SiteLeadTest do
   describe "changeset" do
     test "should be valid" do
       price_suggestion_request = insert(:price_suggestion_request)
-      tour_appointment = insert(:tour_appointment)
 
-      attrs =
-        @valid_attributes
-        |> Map.put(:price_request_id, price_suggestion_request.id)
-        |> Map.put(:tour_appointment_id, tour_appointment.id)
+      attrs = Map.put(@valid_attributes, :price_request_id, price_suggestion_request.id)
 
       changeset = SiteLead.changeset(%SiteLead{}, attrs)
       assert changeset.valid?
@@ -54,9 +50,6 @@ defmodule Re.SellerLeads.SiteLeadTest do
                 [validation: :number, kind: :greater_than_or_equal_to, number: 0]}
 
       assert Keyword.get(changeset.errors, :price_request_id) ==
-               {"can't be blank", [validation: :required]}
-
-      assert Keyword.get(changeset.errors, :tour_appointment_id) ==
                {"can't be blank", [validation: :required]}
     end
   end

--- a/apps/re_web/lib/graphql/types/seller_lead.ex
+++ b/apps/re_web/lib/graphql/types/seller_lead.ex
@@ -22,7 +22,6 @@ defmodule ReWeb.Types.SellerLead do
     field :maintenance_fee, :float
     field :suites, :integer
     field :price_request_id, non_null(:id)
-    field :tour_appointment_id, non_null(:id)
   end
 
   object :seller_lead_mutations do

--- a/apps/re_web/test/graphql/seller_leads/mutation_test.exs
+++ b/apps/re_web/test/graphql/seller_leads/mutation_test.exs
@@ -11,15 +11,13 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
     user_user = insert(:user, email: "user@email.com", role: "user")
 
     price_request = insert(:price_suggestion_request)
-    tour_appointment = insert(:tour_appointment)
 
     {
       :ok,
       unauthenticated_conn: conn,
       admin_conn: login_as(conn, admin_user),
       user_conn: login_as(conn, user_user),
-      price_request: price_request,
-      tour_appointment: tour_appointment
+      price_request: price_request
     }
   end
 
@@ -39,8 +37,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
 
     test "admin should add seller lead", %{
       admin_conn: conn,
-      price_request: price_request,
-      tour_appointment: tour_appointment
+      price_request: price_request
     } do
       variables = %{
         "input" => %{
@@ -49,8 +46,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
           "maintenance_fee" => 100.00,
           "suites" => 2,
           "price" => 800_000,
-          "priceRequestId" => price_request.id,
-          "tourAppointmentId" => tour_appointment.id
+          "priceRequestId" => price_request.id
         }
       }
 
@@ -69,8 +65,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
 
     test "user should add seller lead", %{
       user_conn: conn,
-      price_request: price_request,
-      tour_appointment: tour_appointment
+      price_request: price_request
     } do
       variables = %{
         "input" => %{
@@ -79,8 +74,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
           "maintenance_fee" => 100.00,
           "suites" => 2,
           "price" => 800_000,
-          "priceRequestId" => price_request.id,
-          "tourAppointmentId" => tour_appointment.id
+          "priceRequestId" => price_request.id
         }
       }
 
@@ -99,8 +93,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
 
     test "anonymous should not add seller lead", %{
       unauthenticated_conn: conn,
-      price_request: price_request,
-      tour_appointment: tour_appointment
+      price_request: price_request
     } do
       variables = %{
         "input" => %{
@@ -109,8 +102,7 @@ defmodule ReWeb.GraphQL.SellerLeads.MutationTest do
           "maintenance_fee" => 100.00,
           "suites" => 2,
           "price" => 800_000,
-          "priceRequestId" => price_request.id,
-          "tourAppointmentId" => tour_appointment.id
+          "priceRequestId" => price_request.id
         }
       }
 


### PR DESCRIPTION
The `tourSchedule` mutation is called after the lead is submitted, so removing it from the site seller lead.
In the future when we switch from the listing reference to a seller lead reference, we will add a field in `tourSchedule` to add a reference to the lead.