### PR TITLE
Send notification e-mail for new site seller lead

### DIFF
--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -4,6 +4,7 @@ defmodule Re.SellerLeads do
   """
 
   alias Re.{
+    PubSub,
     Repo,
     SellerLeads.SiteLead
   }
@@ -14,5 +15,6 @@ defmodule Re.SellerLeads do
     %SiteLead{}
     |> SiteLead.changeset(params)
     |> Repo.insert()
+    |> PubSub.publish_new("new_site_seller_lead")
   end
 end

--- a/apps/re/test/seller_leads/seller_leads_test.exs
+++ b/apps/re/test/seller_leads/seller_leads_test.exs
@@ -1,0 +1,28 @@
+defmodule Re.SellerLeadsTest do
+  use Re.ModelCase
+
+  import Re.Factory
+
+  alias Re.{
+    PubSub,
+    SellerLeads,
+    SellerLeads.SiteLead
+  }
+
+  describe "create_site" do
+    test "should create a seller lead and notify by email" do
+      user = insert(:user)
+      address = insert(:address)
+      price_suggestion_request = insert(:price_suggestion_request, user: user, address: address)
+      params = params_for(:site_seller_lead, price_request: price_suggestion_request)
+
+      PubSub.subscribe("new_site_seller_lead")
+
+      {:ok, _site_lead} = SellerLeads.create_site(params)
+
+      assert %{uuid: uuid} = Repo.one(SiteLead)
+
+      assert_received %{topic: "new_site_seller_lead", new: %{uuid: ^uuid}}
+    end
+  end
+end

--- a/apps/re_integrations/lib/notifications/emails/server.ex
+++ b/apps/re_integrations/lib/notifications/emails/server.ex
@@ -30,6 +30,7 @@ defmodule ReIntegrations.Notifications.Emails.Server do
     PubSub.subscribe("tour_appointment")
     PubSub.subscribe("new_interest")
     PubSub.subscribe("update_listing")
+    PubSub.subscribe("new_site_seller_lead")
 
     {:ok, args}
   end
@@ -118,6 +119,12 @@ defmodule ReIntegrations.Notifications.Emails.Server do
     listing = Repo.preload(listing, :user)
 
     handle_cast({Emails.User, :listing_added_admin, [listing.user, listing]}, state)
+  end
+
+  def handle_info(%{topic: "new_site_seller_lead", type: :new, new: site_lead}, state) do
+    site_lead = Repo.preload(site_lead, price_request: [:address, :user])
+
+    handle_cast({Emails.User, :new_site_seller_lead, [site_lead]}, state)
   end
 
   def handle_info(

--- a/apps/re_integrations/lib/notifications/emails/user.ex
+++ b/apps/re_integrations/lib/notifications/emails/user.ex
@@ -108,6 +108,37 @@ defmodule ReIntegrations.Notifications.Emails.User do
                   #{changes_txt}")
   end
 
+  def new_site_seller_lead(
+        %{price_request: %{user: user, address: address} = price_request} = site_lead
+      ) do
+    new()
+    |> to(@to)
+    |> from(@admin_email)
+    |> subject("Novo seller lead")
+    |> html_body("Nome: #{user.name}<br>
+                  Email: #{user.email}<br>
+                  Telefone: #{user.phone}<br>
+                  Área: #{price_request.area}<br>
+                  Quartos: #{price_request.rooms}<br>
+                  Banheiros: #{price_request.bathrooms}<br>
+                  Vagas: #{price_request.garage_spots}<br>
+                  Rua: #{address.street}<br>
+                  Número: #{address.street_number}<br>
+                  Preço: #{site_lead.price}<br>
+                  ")
+    |> text_body("Nome: #{user.name}
+                  Email: #{user.email}
+                  Telefone: #{user.phone}
+                  Área: #{price_request.area}
+                  Quartos: #{price_request.rooms}
+                  Banheiros: #{price_request.bathrooms}
+                  Vagas: #{price_request.garage_spots}
+                  Rua: #{address.street}
+                  Número: #{address.street_number}
+                  Preço: #{site_lead.price}
+                  ")
+  end
+
   defp build_changes(changes) do
     {Enum.map(changes, fn {attr, value} -> "Atributo: #{attr}, novo valor: #{value}<br>" end),
      Enum.map(changes, fn {attr, value} -> "Atributo: #{attr}, novo valor: #{value}" end)}

--- a/apps/re_integrations/lib/notifications/emails/user.ex
+++ b/apps/re_integrations/lib/notifications/emails/user.ex
@@ -124,6 +124,10 @@ defmodule ReIntegrations.Notifications.Emails.User do
                   Vagas: #{price_request.garage_spots}<br>
                   Rua: #{address.street}<br>
                   Número: #{address.street_number}<br>
+                  Bairro: #{address.neighborhood}<br>
+                  Cidade: #{address.city}<br>
+                  Estado: #{address.state}<br>
+                  CEP: #{address.postal_code}<br>
                   Preço: #{site_lead.price}<br>
                   ")
     |> text_body("Nome: #{user.name}
@@ -135,6 +139,10 @@ defmodule ReIntegrations.Notifications.Emails.User do
                   Vagas: #{price_request.garage_spots}
                   Rua: #{address.street}
                   Número: #{address.street_number}
+                  Bairro: #{address.neighborhood}
+                  Cidade: #{address.city}
+                  Estado: #{address.state}
+                  CEP: #{address.postal_code}
                   Preço: #{site_lead.price}
                   ")
   end

--- a/apps/re_integrations/test/emails/server_test.exs
+++ b/apps/re_integrations/test/emails/server_test.exs
@@ -308,5 +308,23 @@ defmodule ReIntegrations.Notifications.Emails.ServerTest do
 
       assert_email_sent(Emails.User.listing_added_admin(user, listing))
     end
+
+    test "should send e-mail when a new site seller lead is added" do
+      user = insert(:user)
+      address = insert(:address)
+      price_suggestion_request = insert(:price_suggestion_request, user: user, address: address)
+      site_seller_lead = insert(:site_seller_lead, price_request: price_suggestion_request)
+
+      Emails.Server.handle_info(
+        %{
+          topic: "new_site_seller_lead",
+          type: :new,
+          new: site_seller_lead
+        },
+        []
+      )
+
+      assert_email_sent(Emails.User.new_site_seller_lead(site_seller_lead))
+    end
   end
 end


### PR DESCRIPTION
Send e-mail in the old `pubsub` format since we'll remove all at once when we don't need the e-mails anymore