### PR TITLE
Allow to export development listings

### DIFF
--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -167,7 +167,7 @@ defmodule Re.Listings do
   defp changeset_for_opts(%{user_id: user_id} = listing, opts) do
     Enum.reduce(opts, Changeset.change(listing), fn
       {:development, development}, changeset ->
-        Changeset.change(changeset, %{development_uuid: development.uuid, is_exportable: false})
+        Changeset.change(changeset, %{development_uuid: development.uuid})
 
       {:address, address}, changeset ->
         Changeset.change(changeset, %{address_id: address.id})

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -148,7 +148,7 @@ defmodule Re.Listing do
 
   @development_required ~w(type description has_elevator address_id user_id development_uuid)a
 
-  @development_optional ~w(matterport_code is_exclusive status is_release)a
+  @development_optional ~w(matterport_code is_exclusive status is_release is_exportable)a
 
   @development_attributes @development_required ++ @development_optional
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -337,7 +337,7 @@ defmodule Re.ListingsTest do
     end
   end
 
-  describe "insert/3" do
+  describe "insert/2" do
     @insert_listing_params %{
       "type" => "Apartamento",
       "complement" => "100",
@@ -464,13 +464,12 @@ defmodule Re.ListingsTest do
 
       assert Repo.get(Listing, listing.id)
     end
-  end
 
-  describe "insert/4" do
     @insert_development_listing_params %{
       "type" => "Apartamento",
       "has_elevator" => true,
-      "description" => "Awesome new brand building"
+      "description" => "Awesome new brand building",
+      "is_exportable" => true
     }
 
     test "should insert development listing" do
@@ -489,23 +488,8 @@ defmodule Re.ListingsTest do
       assert retrieved_listing.development_uuid == development.uuid
       assert retrieved_listing.address_id == address.id
       assert retrieved_listing.user_id == user.id
+      assert retrieved_listing.is_exportable == true
       assert retrieved_listing.uuid
-    end
-
-    test "should set is_exportable to false" do
-      address = insert(:address)
-      development = insert(:development, address_id: address.id)
-      user = insert(:user, role: "admin")
-
-      assert {:ok, inserted_listing} =
-               Listings.insert(@insert_development_listing_params,
-                 address: address,
-                 user: user,
-                 development: development
-               )
-
-      assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
-      assert retrieved_listing.is_exportable == false
     end
 
     test "should copy infrastructure info from development" do

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -591,24 +591,6 @@ defmodule Re.ListingsTest do
     end
   end
 
-  describe "update/5" do
-    test "should set is exportable as false" do
-      user = insert(:user)
-      address = insert(:address)
-      development = insert(:development, address: address)
-      listing = insert(:listing, user: user)
-
-      Listings.update(listing, %{is_exportable: true},
-        address: address,
-        user: user,
-        development: development
-      )
-
-      updated_listing = Repo.get(Listing, listing.id)
-      assert updated_listing.is_exportable == false
-    end
-  end
-
   describe "upsert_tags/2" do
     test "should insert tags" do
       tag_1 = insert(:tag, name: "tag 1", name_slug: "tag-1")

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -497,8 +497,8 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert inserted_listing["description"] == listing.description
       assert inserted_listing["hasElevator"] == listing.has_elevator
       assert inserted_listing["matterportCode"] == listing.matterport_code
+      assert inserted_listing["isExportable"] == listing.is_exportable
 
-      refute inserted_listing["isExportable"]
       refute inserted_listing["isActive"]
 
       assert associated_address["city"] == address.city
@@ -895,7 +895,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       assert updated_listing["description"] == new_listing.description
       assert updated_listing["hasElevator"] == new_listing.has_elevator
       assert updated_listing["matterportCode"] == new_listing.matterport_code
-      refute updated_listing["isExportable"]
+      assert updated_listing["isExportable"] == new_listing.is_exportable
 
       assert updated_address["id"] == to_string(new_address.id)
       assert updated_development["uuid"] == development.uuid
@@ -977,6 +977,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       "description" => listing.description,
       "hasElevator" => listing.has_elevator,
       "matterportCode" => listing.matterport_code,
+      "isExportable" => listing.is_exportable,
       "address_id" => address_id,
       "development_uuid" => development_uuid
     }


### PR DESCRIPTION
At first, we shouldn't export these listings, so I used to not consider user input(:grimacing:). We changed this rule, so I'm allowing the user to set this value. 

Also unified the describes once they're testing the same function now.  