### PR TITLE
feature(exporter): mark units' listing on facebook product ads

### DIFF
--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -4,13 +4,19 @@ defmodule Re.Exporters.FacebookAds.Product do
   https://developers.facebook.com/docs/marketing-api/dynamic-product-ads/product-catalog
   """
 
-  @exported_attributes ~w(id url title sell_type condition brand description price
+  @exported_attributes ~w(id url title availability condition brand description price
   listing_type street neighborhood rooms bathrooms area image additional_image)a
   @default_options %{attributes: @exported_attributes}
 
   @frontend_url Application.get_env(:re_integrations, :frontend_url)
   @image_url "https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385"
   @max_additional_images 20
+  @availabilities %{
+    "pre-launch" => "preorder",
+    "planning" => "preorder",
+    "building" => "available for order",
+    "delivered" => "in-stock"
+  }
 
   def export_listings_xml(listings, options \\ %{}) do
     options = merge_default_options(options)
@@ -69,12 +75,12 @@ defmodule Re.Exporters.FacebookAds.Product do
     {"title", %{}, "#{type} a venda em #{city}"}
   end
 
-  defp convert_attribute(:sell_type, _) do
+  defp convert_attribute(:availability, %{units: []}) do
     {"availability", %{}, "in stock"}
   end
 
-  defp convert_attribute(:condition, _) do
-    {"condition", %{}, "new"}
+  defp convert_attribute(:availability, %{units: [_ | _], development: %{phase: phase}}) do
+    {"availability", %{}, Map.get(@availabilities, phase)}
   end
 
   defp convert_attribute(:brand, _) do
@@ -113,6 +119,14 @@ defmodule Re.Exporters.FacebookAds.Product do
 
   defp convert_attribute(:listing_type, %{type: type}) do
     {"product_type", %{}, type}
+  end
+
+  defp convert_attribute(:condition, %{units: []}) do
+    {"condition", %{}, "used"}
+  end
+
+  defp convert_attribute(:condition, %{units: [_ | _]}) do
+    {"condition", %{}, "new"}
   end
 
   defp convert_attribute(:street, %{address: address}) do

--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -15,7 +15,7 @@ defmodule Re.Exporters.FacebookAds.Product do
     "pre-launch" => "preorder",
     "planning" => "preorder",
     "building" => "available for order",
-    "delivered" => "in-stock"
+    "delivered" => "in stock"
   }
 
   def export_listings_xml(listings, options \\ %{}) do

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -1,10 +1,13 @@
 defmodule Re.Exporters.FacebookAds.ProductTest do
   use Re.ModelCase
 
+  import Re.Factory
+
   alias Re.{
+    Address,
+    Development,
     Exporters.FacebookAds,
     Image,
-    Address,
     Listing
   }
 
@@ -48,7 +51,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
             filename: "bath_1.png",
             description: nil
           }
-        ]
+        ],
+        units: []
       }
 
       expected_xml =
@@ -57,7 +61,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
           "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
           "<availability><![CDATA[in stock]]></availability>" <>
-          "<condition><![CDATA[new]]></condition>" <>
+          "<condition><![CDATA[used]]></condition>" <>
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
@@ -70,6 +74,69 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <>
           "<additional_image_link><![CDATA[#{@image_url}/suite_1.png,#{@image_url}/bath_1.png]]></additional_image_link>" <>
           "</entry>"
+
+      generated_xml =
+        listing
+        |> FacebookAds.Product.build_node(FacebookAds.Product.merge_default_options(%{}))
+        |> XmlBuilder.generate(format: :none)
+
+      assert expected_xml == generated_xml
+    end
+
+    test "export XML for new units' listings" do
+      t(
+        listing = %Listing{
+          id: 7_004_578,
+          price: 800,
+          type: "Apartamento",
+          area: 300,
+          price_per_area: 800 / 300,
+          rooms: 4,
+          bathrooms: 4,
+          description:
+            "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+          address: %Address{
+            street: "Rua do Ipiranga",
+            street_number: 20,
+            neighborhood: "Ipiranga",
+            city: "São Paulo",
+            state: "SP",
+            postal_code: "04732-192",
+            lat: 51.496401,
+            lng: -0.179
+          },
+          matterport_code: "mY123",
+          images: [
+            %Image{
+              filename: "living_room.png",
+              description: "Living room"
+            }
+          ],
+          units: build_list(3, :unit),
+          development: %Development{
+            phase: "building"
+          }
+        }
+      )
+
+      expected_xml =
+        "<entry>" <>
+          "<id><![CDATA[7004578]]></id>" <>
+          "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
+          "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
+          "<availability><![CDATA[available for order]]></availability>" <>
+          "<condition><![CDATA[new]]></condition>" <>
+          "<brand><![CDATA[EmCasa]]></brand>" <>
+          "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
+          "<price><![CDATA[800 BRL]]></price>" <>
+          "<product_type><![CDATA[Apartamento]]></product_type>" <>
+          "<custom_label_0><![CDATA[Rua do Ipiranga]]></custom_label_0>" <>
+          "<custom_label_1><![CDATA[Ipiranga]]></custom_label_1>" <>
+          "<custom_label_2><![CDATA[4]]></custom_label_2>" <>
+          "<custom_label_3><![CDATA[4]]></custom_label_3>" <>
+          "<custom_label_4><![CDATA[300]]></custom_label_4>" <>
+          "<image_link><![CDATA[#{@image_url}/living_room.png]]></image_link>" <>
+          "<additional_image_link><![CDATA[]]></additional_image_link>" <> "</entry>"
 
       generated_xml =
         listing
@@ -106,7 +173,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
             filename: "living_room.png",
             description: "Living room"
           }
-        ]
+        ],
+        units: []
       }
 
       expected_xml =
@@ -115,7 +183,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
           "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
           "<availability><![CDATA[in stock]]></availability>" <>
-          "<condition><![CDATA[new]]></condition>" <>
+          "<condition><![CDATA[used]]></condition>" <>
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
@@ -157,7 +225,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           lat: 51.496401,
           lng: -0.179
         },
-        images: []
+        images: [],
+        units: []
       }
 
       expected_xml =
@@ -166,7 +235,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
           "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
           "<availability><![CDATA[in stock]]></availability>" <>
-          "<condition><![CDATA[new]]></condition>" <>
+          "<condition><![CDATA[used]]></condition>" <>
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>
@@ -207,7 +276,8 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           lat: 51.496401,
           lng: -0.179
         },
-        images: []
+        images: [],
+        units: []
       }
 
       expected_xml =
@@ -216,7 +286,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           "<link><![CDATA[#{@frontend_url}/imoveis/7004578]]></link>" <>
           "<title><![CDATA[Apartamento a venda em São Paulo]]></title>" <>
           "<availability><![CDATA[in stock]]></availability>" <>
-          "<condition><![CDATA[new]]></condition>" <>
+          "<condition><![CDATA[used]]></condition>" <>
           "<brand><![CDATA[EmCasa]]></brand>" <>
           "<description><![CDATA[Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço]]></description>" <>
           "<price><![CDATA[800 BRL]]></price>" <>

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -84,40 +84,38 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
     end
 
     test "export XML for new units' listings" do
-      t(
-        listing = %Listing{
-          id: 7_004_578,
-          price: 800,
-          type: "Apartamento",
-          area: 300,
-          price_per_area: 800 / 300,
-          rooms: 4,
-          bathrooms: 4,
-          description:
-            "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
-          address: %Address{
-            street: "Rua do Ipiranga",
-            street_number: 20,
-            neighborhood: "Ipiranga",
-            city: "São Paulo",
-            state: "SP",
-            postal_code: "04732-192",
-            lat: 51.496401,
-            lng: -0.179
-          },
-          matterport_code: "mY123",
-          images: [
-            %Image{
-              filename: "living_room.png",
-              description: "Living room"
-            }
-          ],
-          units: build_list(3, :unit),
-          development: %Development{
-            phase: "building"
+      listing = %Listing{
+        id: 7_004_578,
+        price: 800,
+        type: "Apartamento",
+        area: 300,
+        price_per_area: 800 / 300,
+        rooms: 4,
+        bathrooms: 4,
+        description:
+          "Sobrado, 4 dormitórios, 3 suites, 4 vagas de garagem, 2 salas , 1 lavabo, 1 banheiro, área de serviço",
+        address: %Address{
+          street: "Rua do Ipiranga",
+          street_number: 20,
+          neighborhood: "Ipiranga",
+          city: "São Paulo",
+          state: "SP",
+          postal_code: "04732-192",
+          lat: 51.496401,
+          lng: -0.179
+        },
+        matterport_code: "mY123",
+        images: [
+          %Image{
+            filename: "living_room.png",
+            description: "Living room"
           }
+        ],
+        units: build_list(3, :unit),
+        development: %Development{
+          phase: "building"
         }
-      )
+      }
 
       expected_xml =
         "<entry>" <>


### PR DESCRIPTION
* Use units to infer if the listings are from the primary or secondary
market.
* If they're from primary market map development phases for [facebook
allowed values](https://developers.facebook.com/docs/marketing-api/dynamic-product-ads/product-catalog/#required-fields) for availability, if it's from secondary it keeps the listing as in stock as availability.