### PR TITLE
Create a copy field for tour appointment's datetime option

### DIFF
--- a/apps/re/lib/calendars/calendars.ex
+++ b/apps/re/lib/calendars/calendars.ex
@@ -12,12 +12,18 @@ defmodule Re.Calendars do
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def schedule_tour(params) do
+    option = get_one_datetimte(params)
+
     %TourAppointment{}
-    |> TourAppointment.changeset(params)
+    |> TourAppointment.changeset(Map.merge(%{option: option}, params))
     |> add_listing_id(params)
     |> Repo.insert()
     |> PubSub.publish_new("tour_appointment")
   end
+
+  defp get_one_datetimte(%{options: [%{datetime: datetime} | _rest]}), do: datetime
+
+  defp get_one_datetimte(_), do: nil
 
   defp add_listing_id(changeset, %{listing_id: listing_id}) do
     case Repo.get(Listing, listing_id) do

--- a/apps/re/lib/calendars/calendars.ex
+++ b/apps/re/lib/calendars/calendars.ex
@@ -9,13 +9,16 @@ defmodule Re.Calendars do
     Repo
   }
 
+  alias Ecto.Changeset
+
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def schedule_tour(params) do
     option = get_one_datetime(params)
 
     %TourAppointment{}
-    |> TourAppointment.changeset(Map.merge(%{option: option}, params))
+    |> TourAppointment.changeset(params)
+    |> Changeset.change(%{option: option})
     |> add_listing_id(params)
     |> Repo.insert()
     |> PubSub.publish_new("tour_appointment")

--- a/apps/re/lib/calendars/calendars.ex
+++ b/apps/re/lib/calendars/calendars.ex
@@ -12,7 +12,7 @@ defmodule Re.Calendars do
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def schedule_tour(params) do
-    option = get_one_datetimte(params)
+    option = get_one_datetime(params)
 
     %TourAppointment{}
     |> TourAppointment.changeset(Map.merge(%{option: option}, params))
@@ -21,9 +21,9 @@ defmodule Re.Calendars do
     |> PubSub.publish_new("tour_appointment")
   end
 
-  defp get_one_datetimte(%{options: [%{datetime: datetime} | _rest]}), do: datetime
+  defp get_one_datetime(%{options: [%{datetime: datetime} | _rest]}), do: datetime
 
-  defp get_one_datetimte(_), do: nil
+  defp get_one_datetime(_), do: nil
 
   defp add_listing_id(changeset, %{listing_id: listing_id}) do
     case Repo.get(Listing, listing_id) do

--- a/apps/re/lib/calendars/tour_appointment.ex
+++ b/apps/re/lib/calendars/tour_appointment.ex
@@ -12,6 +12,8 @@ defmodule Re.Calendars.TourAppointment do
 
     embeds_many :options, Re.Calendars.Option
 
+    field :option, :naive_datetime
+
     belongs_to :user, Re.User
 
     belongs_to :listing, Re.Listing,
@@ -28,7 +30,7 @@ defmodule Re.Calendars.TourAppointment do
   end
 
   @required ~w(wants_pictures wants_tour)a
-  @optional ~w(user_id listing_uuid site_seller_lead_uuid)a
+  @optional ~w(user_id listing_uuid site_seller_lead_uuid option)a
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/apps/re/priv/repo/migrations/20190508140158_add_tour_appointment_datetime.exs
+++ b/apps/re/priv/repo/migrations/20190508140158_add_tour_appointment_datetime.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddTourAppointmentDatetime do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tour_appointments) do
+      add :option, :naive_datetime
+    end
+  end
+end

--- a/apps/re/test/calendars/calendars_test.exs
+++ b/apps/re/test/calendars/calendars_test.exs
@@ -1,7 +1,13 @@
 defmodule Re.CalendarsTest do
   use Re.ModelCase
 
-  alias Re.Calendars
+  alias Re.{
+    Calendars,
+    Calendars.TourAppointment,
+    PubSub
+  }
+
+  import Re.Factory
 
   describe "format_datetime/1" do
     test "should format datetime" do
@@ -39,6 +45,55 @@ defmodule Re.CalendarsTest do
                ~N[2018-09-27 09:00:00],
                ~N[2018-09-27 17:00:00]
              ] == Calendars.generate_tour_options(now, 4)
+    end
+  end
+
+  describe "schedule_tour/1" do
+    test "should schedule tour appointment" do
+      PubSub.subscribe("tour_appointment")
+      %{uuid: listing_uuid} = insert(:listing)
+      %{uuid: site_seller_lead_uuid} = insert(:site_seller_lead)
+
+      params = %{
+        options: [
+          %{datetime: ~N[2018-01-01 10:00:00]}
+        ],
+        wants_pictures: true,
+        wants_tour: true,
+        listing_uuid: listing_uuid,
+        site_seller_lead_uuid: site_seller_lead_uuid
+      }
+
+      {:ok, _} = Calendars.schedule_tour(params)
+
+      assert tour_appointment = Repo.one(TourAppointment)
+      assert listing_uuid == tour_appointment.listing_uuid
+      assert site_seller_lead_uuid == tour_appointment.site_seller_lead_uuid
+      assert ~N[2018-01-01 10:00:00] = tour_appointment.option
+
+      assert_receive %{new: _, topic: "tour_appointment", type: :new}
+    end
+
+    test "should schedule tour appointment without option" do
+      PubSub.subscribe("tour_appointment")
+      %{uuid: listing_uuid} = insert(:listing)
+      %{uuid: site_seller_lead_uuid} = insert(:site_seller_lead)
+
+      params = %{
+        wants_pictures: true,
+        wants_tour: true,
+        listing_uuid: listing_uuid,
+        site_seller_lead_uuid: site_seller_lead_uuid
+      }
+
+      {:ok, _} = Calendars.schedule_tour(params)
+
+      assert tour_appointment = Repo.one(TourAppointment)
+      assert listing_uuid == tour_appointment.listing_uuid
+      assert site_seller_lead_uuid == tour_appointment.site_seller_lead_uuid
+      refute tour_appointment.option
+
+      assert_receive %{new: _, topic: "tour_appointment", type: :new}
     end
   end
 end

--- a/apps/re_web/lib/graphql/types/calendar.ex
+++ b/apps/re_web/lib/graphql/types/calendar.ex
@@ -13,6 +13,7 @@ defmodule ReWeb.Types.Calendar do
     field :wants_pictures, :boolean
     field :wants_tour, :boolean
     field :options, list_of(:datetime_option)
+    field :option, :naive_datetime
 
     field :user, :user, resolve: dataloader(Re.Accounts)
     field :listing, :listing, resolve: &Resolvers.Calendars.listings/3

--- a/apps/re_web/test/graphql/calendars/mutation_test.exs
+++ b/apps/re_web/test/graphql/calendars/mutation_test.exs
@@ -48,6 +48,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
           options {
             datetime
           }
+          option
           user {
             id
           }
@@ -69,6 +70,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
 
     assert response["data"]["tourSchedule"]["wantsTour"]
     assert response["data"]["tourSchedule"]["wantsPictures"]
+    assert response["data"]["tourSchedule"]["option"]
 
     id = response["data"]["tourSchedule"]["id"]
     assert tour_appointment = Repo.get(TourAppointment, id)
@@ -100,6 +102,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
           options {
             datetime
           }
+          option
           user {
             id
           }
@@ -121,6 +124,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
 
     assert response["data"]["tourSchedule"]["wantsTour"]
     assert response["data"]["tourSchedule"]["wantsPictures"]
+    assert response["data"]["tourSchedule"]["option"]
 
     id = response["data"]["tourSchedule"]["id"]
     assert tour_appointment = Repo.get(TourAppointment, id)
@@ -152,6 +156,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
           options {
             datetime
           }
+          option
           user {
             id
           }

--- a/apps/re_web/test/graphql/calendars/mutation_test.exs
+++ b/apps/re_web/test/graphql/calendars/mutation_test.exs
@@ -30,7 +30,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00.000000"}
+          %{"datetime" => "2018-01-01T10:00:00"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,
@@ -84,7 +84,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00.000000"}
+          %{"datetime" => "2018-01-01T10:00:00"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,
@@ -138,7 +138,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00.000000"}
+          %{"datetime" => "2018-01-01T10:00:00"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,


### PR DESCRIPTION
To be able to be more easily picked up by skyvia, I'm creating a datetime field with a copy of the option being sent. Since the client is opting to send a single option, this will create a copy to be picked up until we are able to change the API (which is a breaking change).