### PR TITLE
fix(facebook-exporter): use development to match listing type

### DIFF
--- a/apps/re/lib/exporters/facebook_ads/product.ex
+++ b/apps/re/lib/exporters/facebook_ads/product.ex
@@ -75,11 +75,11 @@ defmodule Re.Exporters.FacebookAds.Product do
     {"title", %{}, "#{type} a venda em #{city}"}
   end
 
-  defp convert_attribute(:availability, %{units: []}) do
+  defp convert_attribute(:availability, %{development: nil}) do
     {"availability", %{}, "in stock"}
   end
 
-  defp convert_attribute(:availability, %{units: [_ | _], development: %{phase: phase}}) do
+  defp convert_attribute(:availability, %{development: %{phase: phase}}) do
     {"availability", %{}, Map.get(@availabilities, phase)}
   end
 
@@ -121,11 +121,11 @@ defmodule Re.Exporters.FacebookAds.Product do
     {"product_type", %{}, type}
   end
 
-  defp convert_attribute(:condition, %{units: []}) do
+  defp convert_attribute(:condition, %{development: nil}) do
     {"condition", %{}, "used"}
   end
 
-  defp convert_attribute(:condition, %{units: [_ | _]}) do
+  defp convert_attribute(:condition, _) do
     {"condition", %{}, "new"}
   end
 

--- a/apps/re/lib/listings/exporter.ex
+++ b/apps/re/lib/listings/exporter.ex
@@ -10,8 +10,9 @@ defmodule Re.Listings.Exporter do
     Repo
   }
 
-  @partial_preload [
+  @preload [
     :address,
+    :development,
     images: Images.Queries.listing_preload()
   ]
 
@@ -20,7 +21,7 @@ defmodule Re.Listings.Exporter do
 
     Queries.active()
     |> Filtering.apply(filters)
-    |> Queries.preload_relations(@partial_preload)
+    |> Queries.preload_relations(@preload)
     |> Queries.order_by_id()
     |> Repo.all()
   end

--- a/apps/re/test/exporters/facebook_ads/product_test.exs
+++ b/apps/re/test/exporters/facebook_ads/product_test.exs
@@ -1,8 +1,6 @@
 defmodule Re.Exporters.FacebookAds.ProductTest do
   use Re.ModelCase
 
-  import Re.Factory
-
   alias Re.{
     Address,
     Development,
@@ -52,7 +50,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
             description: nil
           }
         ],
-        units: []
+        development: nil
       }
 
       expected_xml =
@@ -111,7 +109,6 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
             description: "Living room"
           }
         ],
-        units: build_list(3, :unit),
         development: %Development{
           phase: "building"
         }
@@ -172,7 +169,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
             description: "Living room"
           }
         ],
-        units: []
+        development: nil
       }
 
       expected_xml =
@@ -224,7 +221,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           lng: -0.179
         },
         images: [],
-        units: []
+        development: nil
       }
 
       expected_xml =
@@ -275,7 +272,7 @@ defmodule Re.Exporters.FacebookAds.ProductTest do
           lng: -0.179
         },
         images: [],
-        units: []
+        development: nil
       }
 
       expected_xml =


### PR DESCRIPTION
* Match development instead units, so we don't need to load
a bunch of assocs when a listing is associated with a lot
of units.
* Preload development association while export listing.
* Rename partial preload to preload.

-- 
[This problem](https://app.timber.io/em-casa/logs/console?apps%5B0%5D=2040&id=ae2cb96e-7150-11e9-bdb4-0a0fbe998292&date=2019-05-08T05%3A18%3A13.730634Z) was introduced in PR #534, once I was trying to match against units but they weren't loaded. Now, I'm using development to check if it's a unit's listing or a common one, once the development - listing association is 1:1 and units - listing association is 1:n and both mean the same thing (it's a listing from primary market) is a good idea to be lean here and load only one association. 