### PR TITLE
Truncate naive_datetime seconds

### DIFF
--- a/apps/re/lib/calendars/calendars.ex
+++ b/apps/re/lib/calendars/calendars.ex
@@ -24,7 +24,8 @@ defmodule Re.Calendars do
     |> PubSub.publish_new("tour_appointment")
   end
 
-  defp get_one_datetime(%{options: [%{datetime: datetime} | _rest]}), do: datetime
+  defp get_one_datetime(%{options: [%{datetime: datetime} | _rest]}),
+    do: NaiveDateTime.truncate(datetime, :second)
 
   defp get_one_datetime(_), do: nil
 

--- a/apps/re/test/calendars/calendars_test.exs
+++ b/apps/re/test/calendars/calendars_test.exs
@@ -56,7 +56,7 @@ defmodule Re.CalendarsTest do
 
       params = %{
         options: [
-          %{datetime: ~N[2018-01-01 10:00:00]}
+          %{datetime: ~N[2018-01-01 10:00:00.000Z]}
         ],
         wants_pictures: true,
         wants_tour: true,

--- a/apps/re_web/test/graphql/calendars/mutation_test.exs
+++ b/apps/re_web/test/graphql/calendars/mutation_test.exs
@@ -30,7 +30,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00"}
+          %{"datetime" => "2018-01-01T10:00:00.000Z"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,
@@ -84,7 +84,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00"}
+          %{"datetime" => "2018-01-01T10:00:00.000Z"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,
@@ -138,7 +138,7 @@ defmodule ReWeb.GraphQL.Calendars.MutationTest do
     args = %{
       "input" => %{
         "options" => [
-          %{"datetime" => "2018-01-01T10:00:00"}
+          %{"datetime" => "2018-01-01T10:00:00.000Z"}
         ],
         "wantsPictures" => true,
         "wantsTour" => true,


### PR DESCRIPTION
This wasn't a problem before when the `datetime` was being encoded in `json` when saving to the database.
When creating a specific database field for it, truncating became necessary.