### PR TITLE
feature(filter-errors): filter router errors

### DIFF
--- a/apps/re_web/lib/sentry_event_filter.ex
+++ b/apps/re_web/lib/sentry_event_filter.ex
@@ -1,0 +1,9 @@
+defmodule ReWeb.SentryEventFilter do
+  @moduledoc """
+  Module to ignore sentry events
+  """
+  @behaviour Sentry.EventFilter
+
+  def exclude_exception?(%Elixir.Phoenix.Router.NoRouteError{}, :plug), do: true
+  def exclude_exception?(_exception, _source), do: false
+end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -86,4 +86,5 @@ config :account_kit,
   app_secret: System.get_env("ACCOUNT_KIT_APP_SECRET")
 
 config :sentry,
+  filter: ReWeb.SentryEventFilter,
   dsn: System.get_env("SENTRY_DSN")


### PR DESCRIPTION
Use [sentry event filter](https://hexdocs.pm/sentry/Sentry.EventFilter.html#content) to filter ignorable errors. We used to filter `web-crawlers` with [inbound filters](https://docs.sentry.io/accounts/quotas/#inbound-data-filters) but it can shadow other errors in integrations who are identified as crawlers as well keep getting errors when it shouldn't. So we're doing it by error type right now. 

It also can hide `NoRouteError` when it shouldn't, but once most of our public interface is centralized in GraphQL we should be ok. 