### PR TITLE
Extract location from buyer leads

### DIFF
--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -13,6 +13,7 @@ defmodule Re.BuyerLead do
     field :phone_number, :string
     field :email, :string
     field :origin, :string
+    field :location, :string
 
     belongs_to :listing, Re.Listing,
       references: :uuid,
@@ -28,7 +29,7 @@ defmodule Re.BuyerLead do
   end
 
   @required ~w(name phone_number origin)a
-  @optional ~w(email listing_uuid user_uuid)a
+  @optional ~w(email location listing_uuid user_uuid)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -52,9 +52,14 @@ defmodule Re.BuyerLeads.Facebook do
       email: lead.email,
       phone_number: lead.phone_number,
       origin: "facebook",
+      location: get_location(lead.location),
       user_uuid: extract_user_uuid(lead.phone_number)
     })
   end
+
+  defp get_location("SP"), do: "sao-paulo|sp"
+  defp get_location("RJ"), do: "rio-de-janeiro|rj"
+  defp get_location(_), do: "unknown"
 
   defp extract_user_uuid(nil), do: nil
 

--- a/apps/re/lib/buyer_leads/imovel_web.ex
+++ b/apps/re/lib/buyer_leads/imovel_web.ex
@@ -42,16 +42,21 @@ defmodule Re.BuyerLeads.ImovelWeb do
 
   def buyer_lead_changeset(lead) do
     phone_number = format_phone_number(lead.phone)
+    listing = Listings.get_partial_preloaded(lead.listing_id, [:address])
 
     BuyerLead.changeset(%BuyerLead{}, %{
       name: lead.name,
       email: lead.email,
       phone_number: lead.phone,
       origin: "imovelweb",
+      location: get_location(listing),
       user_uuid: extract_user_uuid(phone_number),
-      listing_uuid: extract_listing_uuid(lead.listing_id)
+      listing_uuid: get_listing_uuid(listing)
     })
   end
+
+  defp get_location({:ok, %{address: address}}), do: "#{address.city_slug}|#{address.state_slug}"
+  defp get_location(_), do: "unknown"
 
   defp format_phone_number(nil), do: nil
 
@@ -68,10 +73,6 @@ defmodule Re.BuyerLeads.ImovelWeb do
     end
   end
 
-  defp extract_listing_uuid(id) do
-    case Listings.get(id) do
-      {:ok, listing} -> listing.uuid
-      _error -> nil
-    end
-  end
+  defp get_listing_uuid({:ok, listing}), do: listing.uuid
+  defp get_listing_uuid(_), do: nil
 end

--- a/apps/re/priv/repo/migrations/20190509141040_add_buyer_leads_location.exs
+++ b/apps/re/priv/repo/migrations/20190509141040_add_buyer_leads_location.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddBuyerLeadsLocation do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buyer_leads) do
+      add :location, :string
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -13,7 +13,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
   describe "grupozap_buyer_lead" do
     test "process lead with existing user and listing" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
       %{uuid: uuid} =
@@ -25,10 +25,11 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer = Repo.one(BuyerLead)
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
+      assert buyer.location == "manhattan|ny"
     end
 
     test "process lead with nil ddd" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} =
         insert(:grupozap_buyer_lead, ddd: nil, phone: "999999999", client_listing_id: "#{id}")
@@ -42,7 +43,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with nil phone" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} =
         insert(:grupozap_buyer_lead, ddd: "11", phone: nil, client_listing_id: "#{id}")
@@ -56,7 +57,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with nil ddd and phone" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} =
         insert(:grupozap_buyer_lead, ddd: nil, phone: nil, client_listing_id: "#{id}")
@@ -71,7 +72,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no user" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} =
         insert(:grupozap_buyer_lead, ddd: "11", phone: "999999999", client_listing_id: "#{id}")
@@ -85,7 +86,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no listing" do
-      %{id: id} = listing = insert(:listing)
+      %{id: id} = listing = insert(:listing, address: build(:address))
       Repo.delete(listing)
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
@@ -105,7 +106,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     test "process lead with existing user and listing" do
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
-      %{uuid: uuid} = insert(:facebook_buyer_lead, phone_number: "+5511999999999")
+      %{uuid: uuid} = insert(:facebook_buyer_lead, phone_number: "+5511999999999", location: "SP")
 
       assert {:ok, _} =
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
@@ -113,6 +114,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer = Repo.one(BuyerLead)
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
+      assert buyer.location == "sao-paulo|sp"
     end
 
     test "process lead with nil phone" do
@@ -133,11 +135,25 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer = Repo.one(BuyerLead)
       refute buyer.user_uuid
     end
+
+    test "process lead with unknown location" do
+      %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
+
+      %{uuid: uuid} = insert(:facebook_buyer_lead, phone_number: "+5511999999999")
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
+
+      assert buyer = Repo.one(BuyerLead)
+      assert buyer.user_uuid == user_uuid
+      refute buyer.listing_uuid
+      assert buyer.location == "unknown"
+    end
   end
 
   describe "imovelweb_buyer_lead" do
     test "process lead with existing user and listing" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
       %{uuid: uuid} = insert(:imovelweb_buyer_lead, phone: "011999999999", listing_id: "#{id}")
@@ -148,10 +164,11 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer = Repo.one(BuyerLead)
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
+      assert buyer.location == "manhattan|ny"
     end
 
     test "process lead with nil phone" do
-      %{id: id} = insert(:listing)
+      %{id: id} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} = insert(:imovelweb_buyer_lead, phone: nil, listing_id: "#{id}")
 
@@ -162,7 +179,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no user" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} = insert(:imovelweb_buyer_lead, phone: "011999999999", listing_id: "#{id}")
 
@@ -175,7 +192,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no listing" do
-      %{id: id} = listing = insert(:listing)
+      %{id: id} = listing = insert(:listing, address: build(:address))
       Repo.delete(listing)
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
@@ -187,12 +204,13 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer = Repo.one(BuyerLead)
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
+      assert buyer.location == "unknown"
     end
   end
 
   describe "interest" do
     test "process lead with existing user and listing" do
-      %{uuid: listing_uuid} = listing = insert(:listing)
+      %{uuid: listing_uuid} = listing = insert(:listing, address: build(:address))
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
       %{uuid: uuid} = insert(:interest, listing: listing, phone: "+5511999999999")
@@ -205,7 +223,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with nil phone" do
-      listing = insert(:listing)
+      listing = insert(:listing, address: build(:address))
 
       %{uuid: uuid} = insert(:interest, listing: listing, phone: nil)
 
@@ -216,7 +234,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no user" do
-      %{id: id, uuid: listing_uuid} = insert(:listing)
+      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       %{uuid: uuid} = insert(:interest, phone: "011999999999", listing_id: "#{id}")
 

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -13,7 +13,9 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
   describe "grupozap_buyer_lead" do
     test "process lead with existing user and listing" do
-      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
+      %{id: id, uuid: listing_uuid} =
+        insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
+
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
       %{uuid: uuid} =
@@ -153,7 +155,9 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
   describe "imovelweb_buyer_lead" do
     test "process lead with existing user and listing" do
-      %{id: id, uuid: listing_uuid} = insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
+      %{id: id, uuid: listing_uuid} =
+        insert(:listing, address: build(:address, state_slug: "ny", city_slug: "manhattan"))
+
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
       %{uuid: uuid} = insert(:imovelweb_buyer_lead, phone: "011999999999", listing_id: "#{id}")


### PR DESCRIPTION
This modification extracts locations from the leads so SalesForce can attribute to the right team.
Imovelweb and grupozap, we get through listing/address
Facebook, a hardcoded `location` in the integrations (now, only `SP` and `RJ`).