### PR TITLE
Refactor neighborhood

### DIFF
--- a/apps/re/lib/addresses/addresses.ex
+++ b/apps/re/lib/addresses/addresses.ex
@@ -49,11 +49,7 @@ defmodule Re.Addresses do
     |> Repo.insert_or_update()
   end
 
-  def is_covered(address) do
-    address
-    |> Map.take(~w(state city neighborhood)a)
-    |> Neighborhoods.is_covered()
-  end
+  def is_covered(address), do: Neighborhoods.is_covered(address)
 
   defp build_address({:error, :not_found}, %{
          "street" => street,

--- a/apps/re/lib/addresses/district.ex
+++ b/apps/re/lib/addresses/district.ex
@@ -27,6 +27,8 @@ defmodule Re.Addresses.District do
 
   @sluggified_attr ~w(state city name)a
 
+  @statuses ~w(active inactive)
+
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
@@ -38,6 +40,9 @@ defmodule Re.Addresses.District do
     |> validate_length(:city, max: 128)
     |> validate_length(:state, is: 2)
     |> unique_constraint(:neighborhood, name: :neighborhood)
+    |> validate_inclusion(:status, @statuses,
+      message: "should be one of: [#{Enum.join(@statuses, " ")}]"
+    )
     |> generate_slugs()
   end
 

--- a/apps/re/lib/addresses/neighborhoods.ex
+++ b/apps/re/lib/addresses/neighborhoods.ex
@@ -25,9 +25,9 @@ defmodule Re.Addresses.Neighborhoods do
 
   def get_description(address) do
     case Repo.get_by(District,
-           state: address.state,
-           city: address.city,
-           name: address.neighborhood
+           state_slug: address.state_slug,
+           city_slug: address.city_slug,
+           name_slug: address.neighborhood_slug
          ) do
       nil -> {:error, :not_found}
       description -> {:ok, description}

--- a/apps/re/lib/addresses/neighborhoods.ex
+++ b/apps/re/lib/addresses/neighborhoods.ex
@@ -59,52 +59,30 @@ defmodule Re.Addresses.Neighborhoods do
   def nearby("Leblon"), do: "Gávea"
   def nearby("São Conrado"), do: "Itanhangá"
 
-  @covered_neighborhoods [
-    %{state: "RJ", neighborhood: "Humaitá", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Copacabana", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Botafogo", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Catete", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Cosme Velho", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Flamengo", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Gávea", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Ipanema", city: "Rio de Janeiro"},
-    %{
-      state: "RJ",
-      neighborhood: "Jardim Botânico",
-      city: "Rio de Janeiro"
-    },
-    %{state: "RJ", neighborhood: "Joá", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Lagoa", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Laranjeiras", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Leblon", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Leme", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "São Conrado", city: "Rio de Janeiro"},
-    %{state: "RJ", neighborhood: "Urca", city: "Rio de Janeiro"},
-    %{state: "SP", neighborhood: "Perdizes", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Vila Pompéia", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Pompeia", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Pinheiros", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Sumaré", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Sumarezinho", city: "São Paulo"},
-    %{state: "SP", neighborhood: "Vila Anglo Brasileira", city: "São Paulo"}
-  ]
+  defp do_is_covered(neighborhood) do
+    case Repo.get_by(District,
+           name_slug: neighborhood.neighborhood_slug,
+           city_slug: neighborhood.city_slug,
+           state_slug: neighborhood.state_slug,
+           status: "active"
+         ) do
+      nil -> false
+      _district -> true
+    end
+  end
+
+  def is_covered(%Address{} = address), do: do_is_covered(address)
 
   def is_covered(neighborhood) do
-    @covered_neighborhoods
-    |> sluggify_covered_neighborhoods()
-    |> MapSet.member?(sluggify_attributes(neighborhood))
+    neighborhood
+    |> sluggify_attributes()
+    |> do_is_covered()
   end
 
-  defp sluggify_covered_neighborhoods(covered_neighborhoods) do
-    covered_neighborhoods
-    |> Enum.map(&sluggify_attributes(&1))
-    |> MapSet.new()
-  end
-
-  defp sluggify_attributes(neighborhoods) do
-    neighborhoods
-    |> Map.update!(:city, &Slugs.sluggify(&1))
-    |> Map.update!(:neighborhood, &Slugs.sluggify(&1))
-    |> Map.update!(:state, &Slugs.sluggify(&1))
+  defp sluggify_attributes(neighborhood) do
+    neighborhood
+    |> Map.put(:city_slug, Slugs.sluggify(neighborhood.city))
+    |> Map.put(:neighborhood_slug, Slugs.sluggify(neighborhood.neighborhood))
+    |> Map.put(:state_slug, Slugs.sluggify(neighborhood.state))
   end
 end

--- a/apps/re/test/addresses/neighborhoods_test.exs
+++ b/apps/re/test/addresses/neighborhoods_test.exs
@@ -19,19 +19,25 @@ defmodule Re.NeighborhoodsTest do
 
   describe "get_description" do
     test "should return neighborhood description according to address" do
-      address = insert(:address, city: "Rio de Janeiro", state: "RJ", neighborhood: "Lapa")
+      address = insert(:address)
 
       insert(:district,
-        city: "Rio de Janeiro",
-        state: "RJ",
-        name: "Lapa",
+        city: address.city,
+        city_slug: address.city_slug,
+        state: address.state,
+        state_slug: address.state_slug,
+        name: address.neighborhood,
+        name_slug: address.neighborhood_slug,
         description: "descr"
       )
 
       {:ok, district} = Neighborhoods.get_description(address)
-      assert district.city == "Rio de Janeiro"
-      assert district.state == "RJ"
-      assert district.name == "Lapa"
+      assert district.city == address.city
+      assert district.city_slug == address.city_slug
+      assert district.state == address.state
+      assert district.state_slug == address.state_slug
+      assert district.name == address.neighborhood
+      assert district.name_slug == address.neighborhood_slug
       assert district.description == "descr"
     end
 

--- a/apps/re/test/addresses/neighborhoods_test.exs
+++ b/apps/re/test/addresses/neighborhoods_test.exs
@@ -56,6 +56,20 @@ defmodule Re.NeighborhoodsTest do
   end
 
   describe "is_covered/1" do
+    setup do
+      district =
+        insert(:district,
+          state: "RJ",
+          state_slug: "rj",
+          name: "Humaitá",
+          name_slug: "humaita",
+          city: "Rio de Janeiro",
+          city_slug: "rio-de-janeiro"
+        )
+
+      {:ok, district: district}
+    end
+
     test "should be true when neighborhood exists" do
       neighborhood = %{state: "RJ", neighborhood: "Humaitá", city: "Rio de Janeiro"}
       assert Neighborhoods.is_covered(neighborhood)

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -113,7 +113,7 @@ defmodule Re.Factory do
     }
   end
 
-  def from_address(address) do
+  def district_from_address(address) do
     insert(:district,
       name: address.neighborhood,
       name_slug: address.neighborhood_slug,
@@ -121,6 +121,7 @@ defmodule Re.Factory do
       city_slug: address.city_slug,
       state: address.state,
       state_slug: address.state_slug,
+      description: Shakespeare.hamlet(),
       status: "active"
     )
   end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -104,11 +104,25 @@ defmodule Re.Factory do
     %Re.Addresses.District{
       name: name,
       name_slug: name_slug,
+      city: city,
       city_slug: city_slug,
+      state: state,
       state_slug: state_slug,
       description: Shakespeare.hamlet(),
       status: "active"
     }
+  end
+
+  def from_address(address) do
+    insert(:district,
+      name: address.neighborhood,
+      name_slug: address.neighborhood_slug,
+      city: address.city,
+      city_slug: address.city_slug,
+      state: address.state,
+      state_slug: address.state_slug,
+      status: "active"
+    )
   end
 
   def image_factory do

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -93,15 +93,19 @@ defmodule Re.Factory do
 
   def district_factory do
     name = Pokemon.location()
+    name_slug = Re.Slugs.sluggify(name)
 
-    city_name = Address.city()
+    city = Address.city()
+    city_slug = Re.Slugs.sluggify(city)
 
-    state_name = Address.state_abbr()
+    state = Address.state_abbr()
+    state_slug = Re.Slugs.sluggify(state)
 
     %Re.Addresses.District{
       name: name,
-      city: city_name,
-      state: state_name,
+      name_slug: name_slug,
+      city_slug: city_slug,
+      state_slug: state_slug,
       description: Shakespeare.hamlet(),
       status: "active"
     }

--- a/apps/re_web/test/graphql/addresses/mutation_test.exs
+++ b/apps/re_web/test/graphql/addresses/mutation_test.exs
@@ -240,14 +240,15 @@ defmodule ReWeb.GraphQL.Addresses.MutationTest do
 
   test "should insert covered neighborhood", %{user_conn: conn} do
     address = insert(:address)
+    from_address(address)
 
     variables = %{
       "input" => %{
-        "city" => "Rio de Janeiro",
-        "state" => "RJ",
+        "city" => address.city,
+        "state" => address.state,
         "lat" => address.lat,
         "lng" => address.lng,
-        "neighborhood" => "Copacabana",
+        "neighborhood" => address.neighborhood,
         "street" => address.street,
         "streetNumber" => address.street_number,
         "postalCode" => address.postal_code
@@ -275,11 +276,11 @@ defmodule ReWeb.GraphQL.Addresses.MutationTest do
 
     assert %{
              "id" => to_string(address.id),
-             "city" => "Rio de Janeiro",
-             "state" => "RJ",
+             "city" => address.city,
+             "state" => address.state,
              "lat" => address.lat,
              "lng" => address.lng,
-             "neighborhood" => "Copacabana",
+             "neighborhood" => address.neighborhood,
              "street" => address.street,
              "streetNumber" => address.street_number,
              "postalCode" => address.postal_code,

--- a/apps/re_web/test/graphql/addresses/mutation_test.exs
+++ b/apps/re_web/test/graphql/addresses/mutation_test.exs
@@ -240,7 +240,7 @@ defmodule ReWeb.GraphQL.Addresses.MutationTest do
 
   test "should insert covered neighborhood", %{user_conn: conn} do
     address = insert(:address)
-    from_address(address)
+    district_from_address(address)
 
     variables = %{
       "input" => %{

--- a/apps/re_web/test/graphql/addresses/query_test.exs
+++ b/apps/re_web/test/graphql/addresses/query_test.exs
@@ -180,10 +180,12 @@ defmodule ReWeb.GraphQL.Addresses.QueryTest do
     """
 
     test "should confirm that address is is covered", %{unauthenticated_conn: conn} do
+      district = insert(:district)
+
       variables = %{
-        "state" => "RJ",
-        "city" => "Rio de Janeiro",
-        "neighborhood" => "Joá"
+        "state" => district.state,
+        "city" => district.city,
+        "neighborhood" => district.name
       }
 
       conn =

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -1103,9 +1103,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         address = insert(:address)
 
       insert(:district,
-        state: address.state,
-        city: address.city,
-        name: address.neighborhood,
+        state_slug: address.state_slug,
+        city_slug: address.city_slug,
+        name_slug: address.neighborhood_slug,
         description: "descr"
       )
 
@@ -1275,9 +1275,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       %{street: street, street_number: street_number} = address = insert(:address)
 
       insert(:district,
-        state: address.state,
-        city: address.city,
-        name: address.neighborhood,
+        state_slug: address.state_slug,
+        city_slug: address.city_slug,
+        name_slug: address.neighborhood_slug,
         description: "descr"
       )
 
@@ -1431,9 +1431,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       %{street: street} = address = insert(:address)
 
       insert(:district,
-        state: address.state,
-        city: address.city,
-        name: address.neighborhood,
+        state_slug: address.state_slug,
+        city_slug: address.city_slug,
+        name_slug: address.neighborhood_slug,
         description: "descr"
       )
 
@@ -1556,9 +1556,9 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       %{street: street} = address = insert(:address)
 
       insert(:district,
-        state: address.state,
-        city: address.city,
-        name: address.neighborhood,
+        state_slug: address.state_slug,
+        city_slug: address.city_slug,
+        name_slug: address.neighborhood_slug,
         description: "descr"
       )
 

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -1102,12 +1102,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       %{state: state, city: city, street: street, street_number: street_number} =
         address = insert(:address)
 
-      insert(:district,
-        state_slug: address.state_slug,
-        city_slug: address.city_slug,
-        name_slug: address.neighborhood_slug,
-        description: "descr"
-      )
+      district = district_from_address(address)
 
       user = insert(:user)
       development = insert(:development)
@@ -1221,7 +1216,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                "address" => %{
                  "street" => street,
                  "streetNumber" => street_number,
-                 "neighborhoodDescription" => "descr"
+                 "neighborhoodDescription" => district.description
                },
                "activeImages" => [
                  %{"filename" => to_string(active_image_filename1)},
@@ -1274,12 +1269,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
 
       %{street: street, street_number: street_number} = address = insert(:address)
 
-      insert(:district,
-        state_slug: address.state_slug,
-        city_slug: address.city_slug,
-        name_slug: address.neighborhood_slug,
-        description: "descr"
-      )
+      district = district_from_address(address)
 
       interests = insert_list(3, :interest)
       in_person_visits = insert_list(3, :in_person_visit)
@@ -1385,7 +1375,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                "address" => %{
                  "street" => street,
                  "streetNumber" => street_number,
-                 "neighborhoodDescription" => "descr"
+                 "neighborhoodDescription" => district.description
                },
                "activeImages" => [
                  %{"filename" => to_string(active_image_filename1)},
@@ -1430,12 +1420,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       image5 = insert(:image, is_active: false, position: 5)
       %{street: street} = address = insert(:address)
 
-      insert(:district,
-        state_slug: address.state_slug,
-        city_slug: address.city_slug,
-        name_slug: address.neighborhood_slug,
-        description: "descr"
-      )
+      district = district_from_address(address)
 
       user = insert(:user)
       [unit1, unit2] = insert_list(2, :unit)
@@ -1513,7 +1498,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                "address" => %{
                  "street" => street,
                  "streetNumber" => nil,
-                 "neighborhoodDescription" => "descr"
+                 "neighborhoodDescription" => district.description
                },
                "activeImages" => [
                  %{"filename" => to_string(active_image_filename1)},
@@ -1555,12 +1540,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       image5 = insert(:image, is_active: false, position: 5)
       %{street: street} = address = insert(:address)
 
-      insert(:district,
-        state_slug: address.state_slug,
-        city_slug: address.city_slug,
-        name_slug: address.neighborhood_slug,
-        description: "descr"
-      )
+      district = district_from_address(address)
 
       user = insert(:user)
       [unit1, unit2] = insert_list(2, :unit)
@@ -1638,7 +1618,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                "address" => %{
                  "street" => street,
                  "streetNumber" => nil,
-                 "neighborhoodDescription" => "descr"
+                 "neighborhoodDescription" => district.description
                },
                "activeImages" => [
                  %{"filename" => to_string(active_image_filename1)},


### PR DESCRIPTION
- Remove hard-coded covered district lookup in favor of database lookup
- Get districts by name/city/state slugs rather than raw values
- In the `is_covered` function, handle address and raw input transparently

This modification will allow to activate/deactive coverage through the database, so we can build a UI for it.
It also prompted me to think about refactoring `Addresses` and `Neighborhoods` which should be one single context (something like `Location`), a refactoring task was created for that.