### PR TITLE
Improve vivareal exporter

### DIFF
--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -133,7 +133,7 @@ defmodule Re.Exporters.Vivareal do
   end
 
   defp build_details(:description, acc, listing) do
-    [{"Description", %{}, {:cdata, listing.description || ""}} | acc]
+    [{"Description", %{}, add_description_timestamp(listing)} | acc]
   end
 
   defp build_details(:price, acc, listing) do
@@ -196,5 +196,12 @@ defmodule Re.Exporters.Vivareal do
 
   defp merge_defaults(options) do
     Map.merge(@default_options, options)
+  end
+
+  defp add_description_timestamp(%{description: nil, updated_at: updated_at}),
+    do: {:cdata, "Atualizado em: #{to_string(Timex.to_date(updated_at))}"}
+
+  defp add_description_timestamp(%{description: description, updated_at: updated_at}) do
+    {:cdata, description <> "\n Atualizado em: #{to_string(Timex.to_date(updated_at))}"}
   end
 end

--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -92,7 +92,7 @@ defmodule Re.Exporters.Vivareal do
     {"Media", %{}, Enum.map(images, &build_image/1)}
   end
 
-  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms garage_spots)a
+  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms suites garage_spots)a
 
   defp convert_attribute(:details, listing, _) do
     {"Details", %{},
@@ -167,6 +167,10 @@ defmodule Re.Exporters.Vivareal do
 
   defp build_details(:bathrooms, acc, listing) do
     [{"Bathrooms", %{}, listing.bathrooms || 0} | acc]
+  end
+
+  defp build_details(:suites, acc, listing) do
+    [{"Suites", %{}, listing.suites || 0} | acc]
   end
 
   defp build_details(:garage_spots, acc, listing) do

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -208,7 +208,8 @@ defmodule Re.Exporters.VivarealTest do
           type: listing_type,
           images: [
             %Image{filename: "test_1.jpg", description: nil}
-          ]
+          ],
+          updated_at: ~N[2018-06-07 15:30:00.000000]
         }
 
         translated_type = Map.get(Vivareal.listing_type_map(), listing_type)
@@ -219,7 +220,7 @@ defmodule Re.Exporters.VivarealTest do
           "<Listing>" <>
             "<Details>" <>
             "<PropertyType>Residential / #{Map.get(Vivareal.listing_type_map(), listing_type)}</PropertyType>" <>
-            "<Description><![CDATA[]]></Description>" <>
+            "<Description><![CDATA[Atualizado em: 2018-06-07]]></Description>" <>
             "<ListPrice/>" <>
             "<LivingArea unit=\"square metres\"/>" <>
             "<Bedrooms>0</Bedrooms>" <>
@@ -275,7 +276,7 @@ defmodule Re.Exporters.VivarealTest do
   defp details_tags do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description><![CDATA[descr]]></Description>" <>
+      "<Description><![CDATA[descr\n Atualizado em: 2018-06-07]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>
@@ -287,7 +288,7 @@ defmodule Re.Exporters.VivarealTest do
   defp details_tags_nils do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description><![CDATA[]]></Description>" <>
+      "<Description><![CDATA[Atualizado em: 2018-06-07]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<Bedrooms>2</Bedrooms>" <>
@@ -297,7 +298,7 @@ defmodule Re.Exporters.VivarealTest do
   defp rooms_nil_details_tags do
     "<Details>" <>
       "<PropertyType>Residential / Apartment</PropertyType>" <>
-      "<Description><![CDATA[descr]]></Description>" <>
+      "<Description><![CDATA[descr\n Atualizado em: 2018-06-07]]></Description>" <>
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -209,7 +209,8 @@ defmodule Re.Exporters.VivarealTest do
           images: [
             %Image{filename: "test_1.jpg", description: nil}
           ],
-          updated_at: ~N[2018-06-07 15:30:00.000000]
+          updated_at: ~N[2018-06-07 15:30:00.000000],
+          suites: 0
         }
 
         translated_type = Map.get(Vivareal.listing_type_map(), listing_type)
@@ -225,6 +226,7 @@ defmodule Re.Exporters.VivarealTest do
             "<LivingArea unit=\"square metres\"/>" <>
             "<Bedrooms>0</Bedrooms>" <>
             "<Bathrooms>0</Bathrooms>" <>
+            "<Suites>0</Suites>" <>
             "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>" <> "</Listing>"
 
         created_xml =
@@ -282,7 +284,9 @@ defmodule Re.Exporters.VivarealTest do
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>
       "<YearlyTax currency=\"BRL\">1000</YearlyTax>" <>
       "<Bedrooms>2</Bedrooms>" <>
-      "<Bathrooms>2</Bathrooms>" <> "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
+      "<Bathrooms>2</Bathrooms>" <>
+      "<Suites>0</Suites>" <>
+      "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
   end
 
   defp details_tags_nils do
@@ -292,7 +296,9 @@ defmodule Re.Exporters.VivarealTest do
       "<ListPrice>1000000</ListPrice>" <>
       "<LivingArea unit=\"square metres\">50</LivingArea>" <>
       "<Bedrooms>2</Bedrooms>" <>
-      "<Bathrooms>2</Bathrooms>" <> "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
+      "<Bathrooms>2</Bathrooms>" <>
+      "<Suites>0</Suites>" <>
+      "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
   end
 
   defp rooms_nil_details_tags do
@@ -304,7 +310,9 @@ defmodule Re.Exporters.VivarealTest do
       "<PropertyAdministrationFee currency=\"BRL\">1000</PropertyAdministrationFee>" <>
       "<YearlyTax currency=\"BRL\">1000</YearlyTax>" <>
       "<Bedrooms>0</Bedrooms>" <>
-      "<Bathrooms>0</Bathrooms>" <> "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>"
+      "<Bathrooms>0</Bathrooms>" <>
+      "<Suites>0</Suites>" <>
+      "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>"
   end
 
   defp location_tags do

--- a/apps/re_web/lib/exporters/vivareal/plug.ex
+++ b/apps/re_web/lib/exporters/vivareal/plug.ex
@@ -1,6 +1,6 @@
 defmodule ReWeb.Exporters.Vivareal.Plug do
   @moduledoc """
-  Plug to handle pipedrive webhooks
+  Plug to handle vivareal listing export
   """
   import Plug.Conn
 


### PR DESCRIPTION
- Put `updated_at` date on description to expose recency
- Export `suites`

These are some feedback from the data team to improve the rankings on vivareal's listings.
Parte 2 will be on another PR, which will export tags.