### PR TITLE
Add update user role to graphql

### DIFF
--- a/apps/re/lib/accounts/accounts.ex
+++ b/apps/re/lib/accounts/accounts.ex
@@ -18,9 +18,9 @@ defmodule Re.Accounts do
     Repo.paginate(Re.User, pagination)
   end
 
-  def promote_user_to_admin(user) do
+  def change_role(user, role) do
     user
-    |> User.update_changeset(%{role: "admin"})
+    |> User.update_changeset(%{role: role})
     |> Repo.update()
   end
 end

--- a/apps/re/test/accounts/accounts_test.exs
+++ b/apps/re/test/accounts/accounts_test.exs
@@ -9,14 +9,23 @@ defmodule Re.Accounts.AccountsTest do
 
   import Re.Factory
 
-  describe "promote_user_to_admin/1" do
-    test "should promote user to admin" do
-      %{uuid: uuid} = user = insert(:user)
+  describe "change_role/2" do
+    test "should make a common user an admin" do
+      %{uuid: uuid} = user = insert(:user, role: "user")
 
-      assert {:ok, _user} = Accounts.promote_user_to_admin(user)
+      assert {:ok, _user} = Accounts.change_role(user, "admin")
 
       assert user = Repo.get_by(User, uuid: uuid)
       assert "admin" == user.role
+    end
+
+    test "should make an admin a common user" do
+      %{uuid: uuid} = user = insert(:user) |> make_admin()
+
+      assert {:ok, _user} = Accounts.change_role(user, "user")
+
+      assert user = Repo.get_by(User, uuid: uuid)
+      assert "user" == user.role
     end
   end
 end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -21,6 +21,10 @@ defmodule Re.Factory do
     }
   end
 
+  def make_admin(user) do
+    %{user | role: "admin"}
+  end
+
   def listing_factory do
     price = random(:price)
     area = Enum.random(1..500)

--- a/apps/re_web/lib/graphql/resolvers/accounts.ex
+++ b/apps/re_web/lib/graphql/resolvers/accounts.ex
@@ -55,10 +55,10 @@ defmodule ReWeb.Resolvers.Accounts do
     end
   end
 
-  def change_role(%{uuid: uuid}, %{context: %{current_user: current_user}}) do
+  def change_role(%{uuid: uuid, role: role}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Users, :update_role_to_admin, current_user),
          {:ok, user} <- Users.get_by_uuid(uuid),
-         {:ok, user} <- Accounts.promote_user_to_admin(user) do
+         {:ok, user} <- Accounts.change_role(user, role) do
       {:ok, user}
     else
       {:error, %Ecto.Changeset{} = changeset} -> {:error, format_errors(changeset)}

--- a/apps/re_web/lib/graphql/types/user.ex
+++ b/apps/re_web/lib/graphql/types/user.ex
@@ -42,6 +42,8 @@ defmodule ReWeb.Types.User do
     field :user, :user
   end
 
+  enum :user_role, values: ~w(admin user)
+
   input_object :notification_preferences_input do
     field :email, :boolean
     field :app, :boolean
@@ -111,8 +113,9 @@ defmodule ReWeb.Types.User do
     end
 
     @desc "Promote an user to admin role"
-    field :user_update_role_to_admin, type: :user do
+    field :user_update_role, type: :user do
       arg :uuid, non_null(:uuid)
+      arg :role, non_null(:user_role)
 
       resolve &AccountsResolver.change_role/2
     end

--- a/apps/re_web/test/graphql/accounts/mutation_test.exs
+++ b/apps/re_web/test/graphql/accounts/mutation_test.exs
@@ -383,10 +383,10 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
     end
   end
 
-  describe "userUpdateRoleToAdmin" do
+  describe "userUpdateRole" do
     @update_role_mutation """
-      mutation UserUpdateRoleToAdmin($uuid: UUID!) {
-        userUpdateRoleToAdmin(uuid: $uuid) {
+      mutation UserUpdateRole($uuid: UUID!, $role: UserRole) {
+        userUpdateRole(uuid: $uuid, role: $role) {
           uuid
           role
         }
@@ -397,7 +397,8 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
       user = insert(:user)
 
       variables = %{
-        "uuid" => user.uuid
+        "uuid" => user.uuid,
+        "role" => "ADMIN"
       }
 
       conn =
@@ -407,14 +408,15 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
           AbsintheHelpers.mutation_wrapper(@update_role_mutation, variables)
         )
       assert %{"uuid" => user.uuid, "role" => "admin"} ==
-               json_response(conn, 200)["data"]["userUpdateRoleToAdmin"]
+               json_response(conn, 200)["data"]["userUpdateRole"]
     end
 
     test "common user cannot update user role", %{user_conn: conn} do
       user = insert(:user)
 
       variables = %{
-        "uuid" => user.uuid
+        "uuid" => user.uuid,
+        "role" => "ADMIN"
       }
 
       conn =
@@ -425,7 +427,7 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
         )
 
       assert_forbidden_response(json_response(conn, 200))
-      assert %{"userUpdateRoleToAdmin" => nil} == json_response(conn, 200)["data"]
+      assert %{"userUpdateRole" => nil} == json_response(conn, 200)["data"]
     end
 
     test "unauthenticated user cannot update user role", %{unauthenticated_conn: conn} do
@@ -433,6 +435,7 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
 
       variables = %{
         "uuid" => user.uuid,
+        "role" => "ADMIN"
       }
 
       conn =
@@ -443,7 +446,7 @@ defmodule ReWeb.GraphQL.Accounts.MutationTest do
         )
 
       assert_unauthorized_response(json_response(conn, 200))
-      assert %{"userUpdateRoleToAdmin" => nil} == json_response(conn, 200)["data"]
+      assert %{"userUpdateRole" => nil} == json_response(conn, 200)["data"]
     end
   end
 end

--- a/apps/re_web/test/graphql/accounts/query_test.exs
+++ b/apps/re_web/test/graphql/accounts/query_test.exs
@@ -276,7 +276,6 @@ defmodule ReWeb.GraphQL.Accounts.QueryTest do
   end
 
   describe "users" do
-    @tag dev: true
     test "for admin list all users", %{admin_conn: conn, admin_user: admin, user_user: user} do
       query = """
         query User {


### PR DESCRIPTION
The same subject from #543 came back. @gabiseabra point out it's not a good idea have a no reversible action on API, as well add a mutation to each role transition while we are adding roles is a backend dependency which we could avoid. 

We should take care of role update on future using some kind of state machine and it would be transparent to frontend clients. By now, every admin can update all users roles. 