### PR TITLE
fix(user-management): doesn't override pagination params

### DIFF
--- a/apps/re/lib/accounts/accounts.ex
+++ b/apps/re/lib/accounts/accounts.ex
@@ -12,10 +12,8 @@ defmodule Re.Accounts do
 
   def query(query, _args), do: query
 
-  def paginated(params) do
-    pagination = Map.get(params, :pagination, %{})
-
-    Repo.paginate(Re.User, pagination)
+  def paginated(params \\ %{}) do
+    Repo.paginate(Re.User, params)
   end
 
   def promote_user_to_admin(user) do

--- a/apps/re_web/lib/graphql/resolvers/accounts.ex
+++ b/apps/re_web/lib/graphql/resolvers/accounts.ex
@@ -81,8 +81,10 @@ defmodule ReWeb.Resolvers.Accounts do
   def users(params, %{context: %{current_user: current_user}}) do
     pagination = Map.get(params, :pagination, %{})
 
+    params = Map.merge(params, pagination)
+
     case Bodyguard.permit(Users, :list_users, current_user) do
-      :ok -> {:ok, Re.Accounts.paginated(pagination)}
+      :ok -> {:ok, Re.Accounts.paginated(params)}
       error -> error
     end
   end


### PR DESCRIPTION
I was extracting pagination params twice so it ended lost pagination. Change it using other paginations as the pattern. 