### PR TITLE
Show address's street name when announcing on vivareal

### DIFF
--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -102,7 +102,7 @@ defmodule Re.Exporters.Vivareal do
   end
 
   defp convert_attribute(:location, %{address: address}, _) do
-    {"Location", %{displayAddress: "Neighborhood"},
+    {"Location", %{displayAddress: "Street"},
      [
        {"Country", %{abbreviation: "BR"}, "Brasil"},
        {"State", %{abbreviation: address.state}, expand_state(address.state)},

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -316,7 +316,7 @@ defmodule Re.Exporters.VivarealTest do
   end
 
   defp location_tags do
-    "<Location displayAddress=\"Neighborhood\">" <>
+    "<Location displayAddress=\"Street\">" <>
       "<Country abbreviation=\"BR\">Brasil</Country>" <>
       "<State abbreviation=\"RJ\">Rio de Janeiro</State>" <>
       "<City>Rio de Janeiro</City>" <>


### PR DESCRIPTION
By setting `displayAddress="Neighborhood"`, we're not showing the street name on the publications.
Changed to `"Street"`.