### PR TITLE
Export tags in vivareal integration

### DIFF
--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -92,7 +92,8 @@ defmodule Re.Exporters.Vivareal do
     {"Media", %{}, Enum.map(images, &build_image/1)}
   end
 
-  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms suites garage_spots)a
+  @details_attributes ~w(type description price area maintenance_fee property_tax rooms bathrooms
+                         suites garage_spots tags)a
 
   defp convert_attribute(:details, listing, _) do
     {"Details", %{},
@@ -176,6 +177,35 @@ defmodule Re.Exporters.Vivareal do
   defp build_details(:garage_spots, acc, listing) do
     [{"Garage", %{type: "Parking Space"}, listing.garage_spots || 0} | acc]
   end
+
+  defp build_details(:tags, acc, listing) do
+    [{"Features", %{}, Enum.reduce(listing.tags, [], &build_feature/2)} | acc]
+  end
+
+  defp build_feature(%{name_slug: name_slug}, acc) do
+    case map_feature(name_slug) do
+      {:ok, mapped_name} -> [{"Feature", %{}, mapped_name} | acc]
+      {:error, :not_mapped} -> acc
+    end
+  end
+
+  defp map_feature("academia"), do: {:ok, "Gym"}
+  defp map_feature("churrasqueira"), do: {:ok, "BBQ"}
+  defp map_feature("espaco-gourmet"), do: {:ok, "Gourmet Area"}
+  defp map_feature("espaco-verde"), do: {:ok, "Green space / Park"}
+  defp map_feature("parque"), do: {:ok, "Green space / Park"}
+  defp map_feature("piscina"), do: {:ok, "Pool"}
+  defp map_feature("playground"), do: {:ok, "Playground"}
+  defp map_feature("quadra"), do: {:ok, "Sports Court"}
+  defp map_feature("salao-de-festas"), do: {:ok, "Party Room"}
+  defp map_feature("salao-de-jogos"), do: {:ok, "Game room"}
+  defp map_feature("sacada"), do: {:ok, "Balcony"}
+  defp map_feature("varanda"), do: {:ok, "Veranda"}
+  defp map_feature("varanda-gourmet"), do: {:ok, "Veranda"}
+  defp map_feature("portaria-24-horas"), do: {:ok, "Security Guard on Duty"}
+  defp map_feature("vista-mar"), do: {:ok, "Ocean View"}
+  defp map_feature("vista-montanhas"), do: {:ok, "Mountain View"}
+  defp map_feature(_), do: {:error, :not_mapped}
 
   defp build_image(%{filename: filename, description: description}) do
     {"Item", %{caption: description, medium: "image"},

--- a/apps/re/lib/listings/exporter.ex
+++ b/apps/re/lib/listings/exporter.ex
@@ -7,12 +7,14 @@ defmodule Re.Listings.Exporter do
     Images,
     Filtering,
     Listings.Queries,
-    Repo
+    Repo,
+    Tags
   }
 
   @preload [
     :address,
     :development,
+    tags: Tags.Queries.listing_preload(),
     images: Images.Queries.listing_preload()
   ]
 

--- a/apps/re/lib/tags/queries/queries.ex
+++ b/apps/re/lib/tags/queries/queries.ex
@@ -34,4 +34,14 @@ defmodule Re.Tags.Queries do
   def filter_next({:visibility, visibility}, query) do
     where(query, [t], t.visibility == ^visibility)
   end
+
+  def listing_preload(query \\ Tag) do
+    query
+    |> public()
+    |> order_by_name_slug()
+  end
+
+  def public(query \\ Tag), do: where(query, [t], t.visibility == "public")
+
+  def order_by_name_slug(query \\ Tag), do: order_by(query, [t], desc: t.name_slug)
 end

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -5,7 +5,8 @@ defmodule Re.Exporters.VivarealTest do
     Address,
     Exporters.Vivareal,
     Image,
-    Listing
+    Listing,
+    Tag
   }
 
   describe "build_xml/1" do
@@ -28,6 +29,11 @@ defmodule Re.Exporters.VivarealTest do
             %Image{filename: "test1.jpg", description: "descr"},
             %Image{filename: "test2.jpg", description: "descr"},
             %Image{filename: "test3.jpg", description: "descr"}
+          ],
+          tags: [
+            %Tag{name: "Piscina", name_slug: "piscina"},
+            %Tag{name: "Academia", name_slug: "academia"},
+            %Tag{name: "Not Mapped", name_slug: "not-mapped"}
           ],
           description: "descr",
           area: 50,
@@ -76,6 +82,11 @@ defmodule Re.Exporters.VivarealTest do
             %Image{filename: "test2.jpg", description: "descr"},
             %Image{filename: "test3.jpg", description: "descr"}
           ],
+          tags: [
+            %Tag{name: "Piscina", name_slug: "piscina"},
+            %Tag{name: "Academia", name_slug: "academia"},
+            %Tag{name: "Not Mapped", name_slug: "not-mapped"}
+          ],
           description: nil,
           area: 50,
           price: 1_000_000,
@@ -122,6 +133,11 @@ defmodule Re.Exporters.VivarealTest do
             %Image{filename: "test1.jpg", description: "descr"},
             %Image{filename: "test2.jpg", description: "descr"},
             %Image{filename: "test3.jpg", description: "descr"}
+          ],
+          tags: [
+            %Tag{name: "Piscina", name_slug: "piscina"},
+            %Tag{name: "Academia", name_slug: "academia"},
+            %Tag{name: "Not Mapped", name_slug: "not-mapped"}
           ],
           description: "descr",
           area: 50,
@@ -170,6 +186,11 @@ defmodule Re.Exporters.VivarealTest do
             %Image{filename: "test2.jpg", description: "descr"},
             %Image{filename: "test3.jpg", description: "descr"}
           ],
+          tags: [
+            %Tag{name: "Piscina", name_slug: "piscina"},
+            %Tag{name: "Academia", name_slug: "academia"},
+            %Tag{name: "Not Mapped", name_slug: "not-mapped"}
+          ],
           description: "descr",
           area: 50,
           price: 1_000_000,
@@ -209,6 +230,11 @@ defmodule Re.Exporters.VivarealTest do
           images: [
             %Image{filename: "test_1.jpg", description: nil}
           ],
+          tags: [
+            %Tag{name: "Piscina", name_slug: "piscina"},
+            %Tag{name: "Academia", name_slug: "academia"},
+            %Tag{name: "Not Mapped", name_slug: "not-mapped"}
+          ],
           updated_at: ~N[2018-06-07 15:30:00.000000],
           suites: 0
         }
@@ -227,7 +253,12 @@ defmodule Re.Exporters.VivarealTest do
             "<Bedrooms>0</Bedrooms>" <>
             "<Bathrooms>0</Bathrooms>" <>
             "<Suites>0</Suites>" <>
-            "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>" <> "</Listing>"
+            "<Garage type=\"Parking Space\">0</Garage>" <>
+            "<Features>" <>
+            "<Feature>Gym</Feature>" <>
+            "<Feature>Pool</Feature>" <>
+            "</Features>" <>
+            "</Details>" <> "</Listing>"
 
         created_xml =
           listing
@@ -286,7 +317,12 @@ defmodule Re.Exporters.VivarealTest do
       "<Bedrooms>2</Bedrooms>" <>
       "<Bathrooms>2</Bathrooms>" <>
       "<Suites>0</Suites>" <>
-      "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
+      "<Garage type=\"Parking Space\">2</Garage>" <>
+      "<Features>" <>
+      "<Feature>Gym</Feature>" <>
+      "<Feature>Pool</Feature>" <>
+      "</Features>" <>
+      "</Details>"
   end
 
   defp details_tags_nils do
@@ -298,7 +334,12 @@ defmodule Re.Exporters.VivarealTest do
       "<Bedrooms>2</Bedrooms>" <>
       "<Bathrooms>2</Bathrooms>" <>
       "<Suites>0</Suites>" <>
-      "<Garage type=\"Parking Space\">2</Garage>" <> "</Details>"
+      "<Garage type=\"Parking Space\">2</Garage>" <>
+      "<Features>" <>
+      "<Feature>Gym</Feature>" <>
+      "<Feature>Pool</Feature>" <>
+      "</Features>" <>
+      "</Details>"
   end
 
   defp rooms_nil_details_tags do
@@ -312,7 +353,12 @@ defmodule Re.Exporters.VivarealTest do
       "<Bedrooms>0</Bedrooms>" <>
       "<Bathrooms>0</Bathrooms>" <>
       "<Suites>0</Suites>" <>
-      "<Garage type=\"Parking Space\">0</Garage>" <> "</Details>"
+      "<Garage type=\"Parking Space\">0</Garage>" <>
+      "<Features>" <>
+      "<Feature>Gym</Feature>" <>
+      "<Feature>Pool</Feature>" <>
+      "</Features>" <>
+      "</Details>"
   end
 
   defp location_tags do


### PR DESCRIPTION
Export some tags for vivareal integration.
Features mappings (loosely) according to [the documentation](https://sites.google.com/grupozap.com/manualdeintegracaovivareal/integra%C3%A7%C3%A3o-de-im%C3%B3veis/detalhes-do-im%C3%B3vel/benef%C3%ADcios).
Order by `name_slug` just for consistency (`desc` since `Enum.reduce/3` builds the list backwards and `reverse` is costly)

This is the remaining modifications mentioned in #548

@joaodubas not sure if there's any tag mappings missing, since it seems like you got some from them, so please take a look.