### PR TITLE
Add missing neighborhood field in buyer_leads

### DIFF
--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -15,6 +15,7 @@ defmodule Re.BuyerLead do
     field :origin, :string
     field :location, :string
     field :budget, :string
+    field :neighborhood, :string
 
     belongs_to :listing, Re.Listing,
       references: :uuid,
@@ -30,7 +31,7 @@ defmodule Re.BuyerLead do
   end
 
   @required ~w(name phone_number origin)a
-  @optional ~w(email location listing_uuid user_uuid budget)a
+  @optional ~w(email location listing_uuid user_uuid budget neighborhood)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -55,7 +55,8 @@ defmodule Re.BuyerLeads.Facebook do
       origin: "facebook",
       location: get_location(lead.location),
       budget: lead.budget,
-      user_uuid: extract_user_uuid(lead.phone_number)
+      user_uuid: extract_user_uuid(lead.phone_number),
+      neighborhood: lead.neighborhoods
     })
   end
 

--- a/apps/re/lib/buyer_leads/grupozap.ex
+++ b/apps/re/lib/buyer_leads/grupozap.ex
@@ -58,7 +58,8 @@ defmodule Re.BuyerLeads.Grupozap do
       origin: gzb.lead_origin,
       location: get_location(listing),
       user_uuid: extract_user_uuid(phone_number),
-      listing_uuid: get_listing_uuid(listing)
+      listing_uuid: get_listing_uuid(listing),
+      neighborhood: get_neighborhood(listing)
     })
   end
 
@@ -82,4 +83,7 @@ defmodule Re.BuyerLeads.Grupozap do
 
   defp get_listing_uuid({:ok, listing}), do: listing.uuid
   defp get_listing_uuid(_), do: nil
+
+  defp get_neighborhood({:ok, %{address: address}}), do: address.neighborhood
+  defp get_neighborhood(_), do: nil
 end

--- a/apps/re/lib/buyer_leads/imovel_web.ex
+++ b/apps/re/lib/buyer_leads/imovel_web.ex
@@ -51,7 +51,8 @@ defmodule Re.BuyerLeads.ImovelWeb do
       origin: "imovelweb",
       location: get_location(listing),
       user_uuid: extract_user_uuid(phone_number),
-      listing_uuid: get_listing_uuid(listing)
+      listing_uuid: get_listing_uuid(listing),
+      neighborhood: get_neighborhood(listing)
     })
   end
 
@@ -75,4 +76,7 @@ defmodule Re.BuyerLeads.ImovelWeb do
 
   defp get_listing_uuid({:ok, listing}), do: listing.uuid
   defp get_listing_uuid(_), do: nil
+
+  defp get_neighborhood({:ok, %{address: address}}), do: address.neighborhood
+  defp get_neighborhood(_), do: nil
 end

--- a/apps/re/lib/interests/interest.ex
+++ b/apps/re/lib/interests/interest.ex
@@ -55,7 +55,8 @@ defmodule Re.Interest do
       origin: "site",
       location: get_location(interest.listing),
       listing_uuid: interest.listing.uuid,
-      user_uuid: extract_user_uuid(phone_number)
+      user_uuid: extract_user_uuid(phone_number),
+      neighborhood: get_neighborhood(interest.listing)
     })
   end
 
@@ -73,4 +74,7 @@ defmodule Re.Interest do
       _error -> nil
     end
   end
+
+  defp get_neighborhood(%{address: address}), do: address.neighborhood
+  defp get_neighborhood(_), do: nil
 end

--- a/apps/re/priv/repo/migrations/20190521152817_add_neighborhood_buyer_leads.exs
+++ b/apps/re/priv/repo/migrations/20190521152817_add_neighborhood_buyer_leads.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddNeighborhoodBuyerLeads do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buyer_leads) do
+      add :neighborhood, :string
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -118,7 +118,8 @@ defmodule Re.BuyerLeads.JobQueueTest do
         insert(:facebook_buyer_lead,
           phone_number: "+5511999999999",
           location: "SP",
-          budget: "$1000 to $10000"
+          budget: "$1000 to $10000",
+          neighborhoods: "downtown"
         )
 
       assert {:ok, _} =


### PR DESCRIPTION
Looks like we forgot to process `neighborhood` field from other buyer leads. Since some buyer leads don't come with attached `listing.address` to extract from, we need a field to save it.