### PR TITLE
Add inserted_at as ordering criteria

### DIFF
--- a/apps/re/lib/listings/queries/queries.ex
+++ b/apps/re/lib/listings/queries/queries.ex
@@ -22,7 +22,9 @@ defmodule Re.Listings.Queries do
     images: Images.Queries.listing_preload()
   ]
 
-  @orderable_fields ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies updated_at price_per_area)a
+  @orderable_fields ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area
+                       garage_spots suites dependencies balconies updated_at price_per_area
+                       inserted_at)a
 
   def active(query \\ Listing), do: where(query, [l], l.status == "active")
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -305,6 +305,34 @@ defmodule Re.ListingsTest do
                  ]
                })
     end
+
+    test "should order by inserted_at asc" do
+      %{id: id1} = insert(:listing, inserted_at: ~N[2010-01-01 10:00:00])
+      %{id: id2} = insert(:listing, inserted_at: ~N[2010-01-02 10:00:00])
+      %{id: id3} = insert(:listing, inserted_at: ~N[2010-01-03 10:00:00])
+
+      assert %{
+               listings: [
+                 %{id: ^id1},
+                 %{id: ^id2},
+                 %{id: ^id3}
+               ]
+             } = Listings.paginated(%{order_by: [%{field: :inserted_at, type: :asc}]})
+    end
+
+    test "should order by inserted_at desc" do
+      %{id: id1} = insert(:listing, inserted_at: ~N[2010-01-01 10:00:00])
+      %{id: id2} = insert(:listing, inserted_at: ~N[2010-01-02 10:00:00])
+      %{id: id3} = insert(:listing, inserted_at: ~N[2010-01-03 10:00:00])
+
+      assert %{
+               listings: [
+                 %{id: ^id3},
+                 %{id: ^id2},
+                 %{id: ^id1}
+               ]
+             } = Listings.paginated(%{order_by: [%{field: :inserted_at, type: :desc}]})
+    end
   end
 
   describe "deactivate/1" do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -204,7 +204,7 @@ defmodule ReWeb.Types.Listing do
   enum :orderable_field,
     values:
       ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies
-      price_per_area)a
+      price_per_area inserted_at)a
 
   enum :order_type, values: ~w(desc asc)a
 


### PR DESCRIPTION
This is a naive approach to order by recency.
Ideally, we would use `status_histories` to get the recently published listings, but the current query code makes a little bit harder to add that feature.
Will add an improvement card for it.