### PR TITLE
Do not send e-mail when user is admin

### DIFF
--- a/apps/re_integrations/lib/notifications/emails/server.ex
+++ b/apps/re_integrations/lib/notifications/emails/server.ex
@@ -150,7 +150,10 @@ defmodule ReIntegrations.Notifications.Emails.Server do
       ) do
     request = Repo.preload(request, [:address, :user])
 
-    handle_cast({Emails.User, :price_suggestion_requested, [request, price]}, state)
+    case request do
+      %{user: %{role: "admin"}} -> {:noreply, state}
+      request -> handle_cast({Emails.User, :price_suggestion_requested, [request, price]}, state)
+    end
   end
 
   def handle_info(_, state), do: {:noreply, state}


### PR DESCRIPTION
An e-mail with price suggestion request is being sent when user is admin.
Since garagem uses the same mutation for this, we were not handling this case.