### PR TITLE
fix(re-integrations): fix test transactions

### DIFF
--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -13,7 +13,7 @@ defmodule ReIntegrations.Orulo do
   def get_building_payload(id) do
     %{"type" => "import_development_from_orulo", "external_id" => id}
     |> JobQueue.new()
-    |> Re.Repo.insert()
+    |> Repo.insert()
   end
 
   def multi_building_insert(multi, params) do

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -1,7 +1,7 @@
 defmodule ReIntegrations.OruloTest do
   @moduledoc false
 
-  use Re.ModelCase
+  use ReIntegrations.ModelCase
 
   alias ReIntegrations.{
     Orulo,

--- a/apps/re_integrations/test/support/model_case.ex
+++ b/apps/re_integrations/test/support/model_case.ex
@@ -1,5 +1,8 @@
 defmodule ReIntegrations.ModelCase do
+  @moduledoc false
+
   use ExUnit.CaseTemplate
+  alias Ecto.Adapters.SQL.Sandbox
 
   using do
     quote do
@@ -17,10 +20,10 @@ defmodule ReIntegrations.ModelCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(ReIntegrations.Repo)
+    :ok = Sandbox.checkout(ReIntegrations.Repo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
+      Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
     end
 
     :ok

--- a/apps/re_integrations/test/support/model_case.ex
+++ b/apps/re_integrations/test/support/model_case.ex
@@ -20,10 +20,12 @@ defmodule ReIntegrations.ModelCase do
   end
 
   setup tags do
+    :ok = Sandbox.checkout(Re.Repo)
     :ok = Sandbox.checkout(ReIntegrations.Repo)
 
     unless tags[:async] do
       Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
+      Sandbox.mode(Re.Repo, {:shared, self()})
     end
 
     :ok

--- a/apps/re_integrations/test/support/model_case.ex
+++ b/apps/re_integrations/test/support/model_case.ex
@@ -1,0 +1,28 @@
+defmodule ReIntegrations.ModelCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias ReIntegrations.Repo
+
+      import Ecto
+
+      import Ecto.{
+        Changeset,
+        Query
+      }
+
+      import ReIntegrations.ModelCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(ReIntegrations.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/apps/re_integrations/test/test_helper.exs
+++ b/apps/re_integrations/test/test_helper.exs
@@ -1,7 +1,8 @@
-ExUnit.configure formatters: [JUnitFormatter, ExUnit.CLIFormatter]
+ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Re.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(ReIntegrations.Repo, :manual)
 
 Faker.start()
 

--- a/apps/re_web/test/support/conn_case.ex
+++ b/apps/re_web/test/support/conn_case.ex
@@ -45,9 +45,11 @@ defmodule ReWeb.ConnCase do
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Re.Repo)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(ReIntegrations.Repo)
 
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(Re.Repo, {:shared, self()})
+      Ecto.Adapters.SQL.Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
     end
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}

--- a/apps/re_web/test/support/conn_case.ex
+++ b/apps/re_web/test/support/conn_case.ex
@@ -14,6 +14,7 @@ defmodule ReWeb.ConnCase do
   """
 
   use ExUnit.CaseTemplate
+  alias Ecto.Adapters.SQL.Sandbox
 
   using do
     quote do
@@ -21,7 +22,6 @@ defmodule ReWeb.ConnCase do
       use Phoenix.ConnTest
 
       alias Re.Repo
-      import Ecto
 
       import Ecto.{
         Changeset,
@@ -44,12 +44,12 @@ defmodule ReWeb.ConnCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Re.Repo)
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(ReIntegrations.Repo)
+    :ok = Sandbox.checkout(Re.Repo)
+    :ok = Sandbox.checkout(ReIntegrations.Repo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Re.Repo, {:shared, self()})
-      Ecto.Adapters.SQL.Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
+      Sandbox.mode(Re.Repo, {:shared, self()})
+      Sandbox.mode(ReIntegrations.Repo, {:shared, self()})
     end
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}


### PR DESCRIPTION
Add ModelCase on ReIntegration allowing to run each test in an independent transaction. Also, add both repositories on Web Conn helpers. 

I totally forgot it, 'cause I used to reset the database (testing prefixes/schemas) it didn't show up `ReIntegration.Repo` entities not being cleaned up. 