### PR TITLE
Orulo/parse buildings to development

### DIFF
--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -23,4 +23,8 @@ defmodule ReIntegrations.Orulo.JobQueue do
       error -> Logger.error(error)
     end
   end
+
+  def perform(%Multi{} = _multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
+    Orulo.insert_development_from_building(uuid)
+  end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -23,7 +23,4 @@ defmodule ReIntegrations.Orulo.JobQueue do
       error -> Logger.error(error)
     end
   end
-
-  def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
-  end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -9,8 +9,7 @@ defmodule ReIntegrations.Orulo.JobQueue do
 
   alias ReIntegrations.{
     Orulo,
-    Orulo.Client,
-    Repo
+    Orulo.Client
   }
 
   alias Ecto.Multi
@@ -26,7 +25,6 @@ defmodule ReIntegrations.Orulo.JobQueue do
   end
 
   def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
-    Orulo.insert_development_from_building(uuid)
-    Repo.transaction(multi)
+    Orulo.insert_development_from_building(multi, uuid)
   end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -23,4 +23,7 @@ defmodule ReIntegrations.Orulo.JobQueue do
       error -> Logger.error(error)
     end
   end
+
+  def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
+  end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -9,7 +9,8 @@ defmodule ReIntegrations.Orulo.JobQueue do
 
   alias ReIntegrations.{
     Orulo,
-    Orulo.Client
+    Orulo.Client,
+    Repo
   }
 
   alias Ecto.Multi
@@ -24,7 +25,8 @@ defmodule ReIntegrations.Orulo.JobQueue do
     end
   end
 
-  def perform(%Multi{} = _multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
+  def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
     Orulo.insert_development_from_building(uuid)
+    Repo.transaction(multi)
   end
 end

--- a/apps/re_integrations/lib/orulo/mapper.ex
+++ b/apps/re_integrations/lib/orulo/mapper.ex
@@ -1,0 +1,41 @@
+defmodule ReIntegrations.Orulo.Mapper do
+  @moduledoc """
+  Module to map external structures into persistable internal structures.
+  """
+  alias ReIntegrations.{
+    Orulo.Building
+  }
+
+  def building_payload_into_development_params(%Building{} = %{payload: payload}) do
+    Enum.reduce(payload, %{}, &convert_attribute(&1, &2))
+  end
+
+  defp convert_attribute({:name, name}, acc), do: Map.put(acc, :name, name)
+
+  defp convert_attribute({:description, description}, acc),
+    do: Map.put(acc, :description, description)
+
+  defp convert_attribute({:developer, %{name: name}}, acc) do
+    Map.put(acc, :builder, name)
+  end
+
+  defp convert_attribute({:number_of_floors, floor_count}, acc) do
+    Map.put(acc, :floor_count, floor_count)
+  end
+
+  defp convert_attribute({:apts_per_floor, units_per_floor}, acc) do
+    Map.put(acc, :units_per_floor, units_per_floor)
+  end
+
+  @phase_map %{
+    "Em construção" => "building",
+    "Pronto novo" => "delivered",
+    "Pronto usado" => "delivered"
+  }
+  defp convert_attribute({:status, status}, acc) do
+    phase = Map.get(@phase_map, status)
+    Map.put(acc, :phase, phase)
+  end
+
+  defp convert_attribute(_, acc), do: acc
+end

--- a/apps/re_integrations/lib/orulo/mapper.ex
+++ b/apps/re_integrations/lib/orulo/mapper.ex
@@ -10,20 +10,20 @@ defmodule ReIntegrations.Orulo.Mapper do
     Enum.reduce(payload, %{}, &convert_development_attribute(&1, &2))
   end
 
-  defp convert_development_attribute({:name, name}, acc), do: Map.put(acc, :name, name)
+  defp convert_development_attribute({"name", name}, acc), do: Map.put(acc, :name, name)
 
-  defp convert_development_attribute({:description, description}, acc),
+  defp convert_development_attribute({"description", description}, acc),
     do: Map.put(acc, :description, description)
 
-  defp convert_development_attribute({:developer, %{name: name}}, acc) do
+  defp convert_development_attribute({"developer", %{"name" => name}}, acc) do
     Map.put(acc, :builder, name)
   end
 
-  defp convert_development_attribute({:number_of_floors, floor_count}, acc) do
+  defp convert_development_attribute({"number_of_floors", floor_count}, acc) do
     Map.put(acc, :floor_count, floor_count)
   end
 
-  defp convert_development_attribute({:apts_per_floor, units_per_floor}, acc) do
+  defp convert_development_attribute({"apts_per_floor", units_per_floor}, acc) do
     Map.put(acc, :units_per_floor, units_per_floor)
   end
 
@@ -33,47 +33,47 @@ defmodule ReIntegrations.Orulo.Mapper do
     "Pronto usado" => "delivered"
   }
 
-  defp convert_development_attribute({:status, status}, acc) do
+  defp convert_development_attribute({"status", status}, acc) do
     phase = Map.get(@phase_map, status)
     Map.put(acc, :phase, phase)
   end
 
   defp convert_development_attribute(_, acc), do: acc
 
-  def building_payload_into_address_params(%Building{} = %{payload: %{address: address}}) do
+  def building_payload_into_address_params(%Building{} = %{payload: %{"address" => address}}) do
     Enum.reduce(address, %{}, &convert_address_attribute(&1, &2))
   end
 
-  defp convert_address_attribute({:street, street}, acc) do
+  defp convert_address_attribute({"street", street}, acc) do
     Map.put(acc, :street, street)
   end
 
-  defp convert_address_attribute({:area, neighborhood}, acc) do
+  defp convert_address_attribute({"area", neighborhood}, acc) do
     Map.put(acc, :neighborhood, neighborhood)
   end
 
-  defp convert_address_attribute({:city, city}, acc) do
+  defp convert_address_attribute({"city", city}, acc) do
     Map.put(acc, :city, city)
   end
 
-  defp convert_address_attribute({:state, state}, acc) do
+  defp convert_address_attribute({"state", state}, acc) do
     Map.put(acc, :state, state)
   end
 
-  defp convert_address_attribute({:zip_code, postal_code}, acc) do
+  defp convert_address_attribute({"zip_code", postal_code}, acc) do
     Map.put(acc, :postal_code, postal_code)
   end
 
-  defp convert_address_attribute({:latitude, lat}, acc) do
+  defp convert_address_attribute({"latitude", lat}, acc) do
     Map.put(acc, :lat, lat)
   end
 
-  defp convert_address_attribute({:longitude, lng}, acc) do
+  defp convert_address_attribute({"longitude", lng}, acc) do
     Map.put(acc, :lng, lng)
   end
 
-  defp convert_address_attribute({:number, number}, acc) do
-    Map.put(acc, :street_number, number)
+  defp convert_address_attribute({"number", number}, acc) do
+    Map.put(acc, :street_number, Integer.to_string(number))
   end
 
   defp convert_address_attribute(_, acc), do: acc

--- a/apps/re_integrations/lib/orulo/mapper.ex
+++ b/apps/re_integrations/lib/orulo/mapper.ex
@@ -7,23 +7,23 @@ defmodule ReIntegrations.Orulo.Mapper do
   }
 
   def building_payload_into_development_params(%Building{} = %{payload: payload}) do
-    Enum.reduce(payload, %{}, &convert_attribute(&1, &2))
+    Enum.reduce(payload, %{}, &convert_development_attribute(&1, &2))
   end
 
-  defp convert_attribute({:name, name}, acc), do: Map.put(acc, :name, name)
+  defp convert_development_attribute({:name, name}, acc), do: Map.put(acc, :name, name)
 
-  defp convert_attribute({:description, description}, acc),
+  defp convert_development_attribute({:description, description}, acc),
     do: Map.put(acc, :description, description)
 
-  defp convert_attribute({:developer, %{name: name}}, acc) do
+  defp convert_development_attribute({:developer, %{name: name}}, acc) do
     Map.put(acc, :builder, name)
   end
 
-  defp convert_attribute({:number_of_floors, floor_count}, acc) do
+  defp convert_development_attribute({:number_of_floors, floor_count}, acc) do
     Map.put(acc, :floor_count, floor_count)
   end
 
-  defp convert_attribute({:apts_per_floor, units_per_floor}, acc) do
+  defp convert_development_attribute({:apts_per_floor, units_per_floor}, acc) do
     Map.put(acc, :units_per_floor, units_per_floor)
   end
 
@@ -32,10 +32,49 @@ defmodule ReIntegrations.Orulo.Mapper do
     "Pronto novo" => "delivered",
     "Pronto usado" => "delivered"
   }
-  defp convert_attribute({:status, status}, acc) do
+
+  defp convert_development_attribute({:status, status}, acc) do
     phase = Map.get(@phase_map, status)
     Map.put(acc, :phase, phase)
   end
 
-  defp convert_attribute(_, acc), do: acc
+  defp convert_development_attribute(_, acc), do: acc
+
+  def building_payload_into_address_params(%Building{} = %{payload: %{address: address}}) do
+    Enum.reduce(address, %{}, &convert_address_attribute(&1, &2))
+  end
+
+  defp convert_address_attribute({:street, street}, acc) do
+    Map.put(acc, :street, street)
+  end
+
+  defp convert_address_attribute({:area, neighborhood}, acc) do
+    Map.put(acc, :neighborhood, neighborhood)
+  end
+
+  defp convert_address_attribute({:city, city}, acc) do
+    Map.put(acc, :city, city)
+  end
+
+  defp convert_address_attribute({:state, state}, acc) do
+    Map.put(acc, :state, state)
+  end
+
+  defp convert_address_attribute({:zip_code, postal_code}, acc) do
+    Map.put(acc, :postal_code, postal_code)
+  end
+
+  defp convert_address_attribute({:latitude, lat}, acc) do
+    Map.put(acc, :lat, lat)
+  end
+
+  defp convert_address_attribute({:longitude, lng}, acc) do
+    Map.put(acc, :lng, lng)
+  end
+
+  defp convert_address_attribute({:number, number}, acc) do
+    Map.put(acc, :street_number, number)
+  end
+
+  defp convert_address_attribute(_, acc), do: acc
 end

--- a/apps/re_integrations/lib/orulo/mapper.ex
+++ b/apps/re_integrations/lib/orulo/mapper.ex
@@ -6,8 +6,11 @@ defmodule ReIntegrations.Orulo.Mapper do
     Orulo.Building
   }
 
+  @development_attributes ~w(name description developer number_of_floors apts_per_floor status)
   def building_payload_into_development_params(%Building{} = %{payload: payload}) do
-    Enum.reduce(payload, %{}, &convert_development_attribute(&1, &2))
+    payload
+    |> Map.take(@development_attributes)
+    |> Enum.reduce(%{}, &convert_development_attribute(&1, &2))
   end
 
   defp convert_development_attribute({"name", name}, acc), do: Map.put(acc, :name, name)
@@ -40,8 +43,11 @@ defmodule ReIntegrations.Orulo.Mapper do
 
   defp convert_development_attribute(_, acc), do: acc
 
+  @address_attributes ~w(street area city state zip_code latitude longitude number)
   def building_payload_into_address_params(%Building{} = %{payload: %{"address" => address}}) do
-    Enum.reduce(address, %{}, &convert_address_attribute(&1, &2))
+    address
+    |> Map.take(@address_attributes)
+    |> Enum.reduce(%{}, &convert_address_attribute(&1, &2))
   end
 
   defp convert_address_attribute({"street", street}, acc) do

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -27,7 +27,8 @@ defmodule ReIntegrations.Orulo do
 
     uuid = Changeset.get_field(changeset, :uuid)
 
-    Multi.insert(multi, :building, changeset)
+    multi
+    |> Multi.insert(:building, changeset)
     |> JobQueue.enqueue(:building_parse, %{
       "type" => "parse_building_into_development",
       "uuid" => uuid

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -5,6 +5,7 @@ defmodule ReIntegrations.Orulo do
   alias ReIntegrations.{
     Orulo.Building,
     Orulo.JobQueue,
+    Orulo.Mapper,
     Repo
   }
 
@@ -32,5 +33,17 @@ defmodule ReIntegrations.Orulo do
       "uuid" => uuid
     })
     |> Repo.transaction()
+  end
+
+  def insert_development_from_building(uuid) do
+    with building <- Repo.get(Building, uuid),
+         address_params <- Mapper.building_payload_into_address_params(building),
+         {:ok, new_address} <- Re.Addresses.insert_or_update(address_params),
+         development_params <- Mapper.building_payload_into_development_params(building),
+         {:ok, new_development} <- Re.Developments.insert(development_params, new_address) do
+      {:ok, new_development}
+    else
+      err -> err
+    end
   end
 end

--- a/apps/re_integrations/mix.exs
+++ b/apps/re_integrations/mix.exs
@@ -48,6 +48,7 @@ defmodule ReIntegrations.Mixfile do
       {:httpoison, "~> 1.3", override: true},
       {:jason, "~> 1.0"},
       {:sentry, "~> 7.0"},
+      {:ex_machina, "~> 2.2", only: :test},
       {:ecto_job, "~> 2.0"}
     ]
   end

--- a/apps/re_integrations/test/orulo/mapper_test.exs
+++ b/apps/re_integrations/test/orulo/mapper_test.exs
@@ -25,23 +25,22 @@ defmodule ReIntegrations.Orulo.MapperTest do
         name: "EmCasa Incorporadora"
       },
       address: %{
-        street_type: "Rua",
-        street: "Cotoxó",
+        street_type: "Avenida",
+        street: "Copacabana",
         number: 926,
-        area: "Perdizes",
-        city: "São Paulo",
+        area: "Copacabana",
+        city: "Rio de Janeiro",
         latitude: -23.5345,
         longitude: -46.6871,
-        state: "SP",
+        state: "RJ",
         zip_code: "05021-001"
       }
     }
   }
 
   describe "building_payload_into_development_params" do
-    @tag dev: true
     test "parse building payload into development" do
-      %{payload: payload} = @building
+      %{payload: %{developer: developer} = payload} = @building
       params = Mapper.building_payload_into_development_params(@building)
 
       assert params == %{
@@ -51,6 +50,24 @@ defmodule ReIntegrations.Orulo.MapperTest do
                floor_count: 8,
                units_per_floor: 2,
                phase: "building"
+             }
+    end
+  end
+
+  describe "building_payload_into_address_params" do
+    test "parse building payload into address params" do
+      %{payload: %{address: address}} = @building
+      params = Mapper.building_payload_into_address_params(@building)
+
+      assert params == %{
+               street: Map.get(address, :street),
+               neighborhood: Map.get(address, :area),
+               city: Map.get(address, :city),
+               state: Map.get(address, :state),
+               postal_code: Map.get(address, :zip_code),
+               lat: Map.get(address, :latitude),
+               lng: Map.get(address, :longitude),
+               street_number: Map.get(address, :number)
              }
     end
   end

--- a/apps/re_integrations/test/orulo/mapper_test.exs
+++ b/apps/re_integrations/test/orulo/mapper_test.exs
@@ -4,44 +4,15 @@ defmodule ReIntegrations.Orulo.MapperTest do
   use ReIntegrations.ModelCase
 
   alias ReIntegrations.{
-    Orulo.Building,
     Orulo.Mapper
   }
 
-  @building %Building{
-    external_id: 999,
-    payload: %{
-      "id" => "999",
-      "name" => "EmCasa 01",
-      "description" =>
-        "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
-      "floor_area" => 0.0,
-      "apts_per_floor" => 2,
-      "number_of_floors" => 8,
-      "status" => "Em construção",
-      "webpage" => "http://www.emcasa.com/",
-      "developer" => %{
-        "id" => "799",
-        "name" => "EmCasa Incorporadora"
-      },
-      "address" => %{
-        "street_type" => "Avenida",
-        "street" => "Copacabana",
-        "number" => 926,
-        "area" => "Copacabana",
-        "city" => "Rio de Janeiro",
-        "latitude" => -23.5345,
-        "longitude" => -46.6871,
-        "state" => "RJ",
-        "zip_code" => "05021-001"
-      }
-    }
-  }
+  import ReIntegrations.Factory
 
   describe "building_payload_into_development_params" do
     test "parse building payload into development" do
-      %{payload: %{"developer" => developer} = payload} = @building
-      params = Mapper.building_payload_into_development_params(@building)
+      %{payload: %{"developer" => developer} = payload} = building = build(:building)
+      params = Mapper.building_payload_into_development_params(building)
 
       assert params == %{
                name: Map.get(payload, "name"),
@@ -56,8 +27,8 @@ defmodule ReIntegrations.Orulo.MapperTest do
 
   describe "building_payload_into_address_params" do
     test "parse building payload into address params" do
-      %{payload: %{"address" => address}} = @building
-      params = Mapper.building_payload_into_address_params(@building)
+      %{payload: %{"address" => address}} = building = build(:building)
+      params = Mapper.building_payload_into_address_params(building)
 
       assert params == %{
                street: Map.get(address, "street"),
@@ -67,7 +38,7 @@ defmodule ReIntegrations.Orulo.MapperTest do
                postal_code: Map.get(address, "zip_code"),
                lat: Map.get(address, "latitude"),
                lng: Map.get(address, "longitude"),
-               street_number: Map.get(address, "number") |> Integer.to_string()
+               street_number: address |> Map.get("number") |> Integer.to_string()
              }
     end
   end

--- a/apps/re_integrations/test/orulo/mapper_test.exs
+++ b/apps/re_integrations/test/orulo/mapper_test.exs
@@ -1,0 +1,57 @@
+defmodule ReIntegrations.Orulo.MapperTest do
+  @moduledoc false
+
+  use ReIntegrations.ModelCase
+
+  alias ReIntegrations.{
+    Orulo.Building,
+    Orulo.Mapper
+  }
+
+  @building %Building{
+    external_id: 999,
+    payload: %{
+      id: "999",
+      name: "EmCasa 01",
+      description:
+        "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
+      floor_area: 0.0,
+      apts_per_floor: 2,
+      number_of_floors: 8,
+      status: "Em construção",
+      webpage: "http://www.emcasa.com/",
+      developer: %{
+        id: "799",
+        name: "EmCasa Incorporadora"
+      },
+      address: %{
+        street_type: "Rua",
+        street: "Cotoxó",
+        number: 926,
+        area: "Perdizes",
+        city: "São Paulo",
+        latitude: -23.5345,
+        longitude: -46.6871,
+        state: "SP",
+        zip_code: "05021-001"
+      }
+    }
+  }
+
+  describe "building_payload_into_development_params" do
+    @tag dev: true
+    test "parse building payload into development" do
+      %{payload: payload} = @building
+      params = Mapper.building_payload_into_development_params(@building)
+
+      assert params == %{
+               name: Map.get(payload, :name),
+               description: Map.get(payload, :description),
+               builder: "EmCasa Incorporadora",
+               floor_count: 8,
+               units_per_floor: 2,
+               phase: "building"
+             }
+    end
+  end
+end

--- a/apps/re_integrations/test/orulo/mapper_test.exs
+++ b/apps/re_integrations/test/orulo/mapper_test.exs
@@ -11,44 +11,44 @@ defmodule ReIntegrations.Orulo.MapperTest do
   @building %Building{
     external_id: 999,
     payload: %{
-      id: "999",
-      name: "EmCasa 01",
-      description:
+      "id" => "999",
+      "name" => "EmCasa 01",
+      "description" =>
         "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
-      floor_area: 0.0,
-      apts_per_floor: 2,
-      number_of_floors: 8,
-      status: "Em construção",
-      webpage: "http://www.emcasa.com/",
-      developer: %{
-        id: "799",
-        name: "EmCasa Incorporadora"
+      "floor_area" => 0.0,
+      "apts_per_floor" => 2,
+      "number_of_floors" => 8,
+      "status" => "Em construção",
+      "webpage" => "http://www.emcasa.com/",
+      "developer" => %{
+        "id" => "799",
+        "name" => "EmCasa Incorporadora"
       },
-      address: %{
-        street_type: "Avenida",
-        street: "Copacabana",
-        number: 926,
-        area: "Copacabana",
-        city: "Rio de Janeiro",
-        latitude: -23.5345,
-        longitude: -46.6871,
-        state: "RJ",
-        zip_code: "05021-001"
+      "address" => %{
+        "street_type" => "Avenida",
+        "street" => "Copacabana",
+        "number" => 926,
+        "area" => "Copacabana",
+        "city" => "Rio de Janeiro",
+        "latitude" => -23.5345,
+        "longitude" => -46.6871,
+        "state" => "RJ",
+        "zip_code" => "05021-001"
       }
     }
   }
 
   describe "building_payload_into_development_params" do
     test "parse building payload into development" do
-      %{payload: %{developer: developer} = payload} = @building
+      %{payload: %{"developer" => developer} = payload} = @building
       params = Mapper.building_payload_into_development_params(@building)
 
       assert params == %{
-               name: Map.get(payload, :name),
-               description: Map.get(payload, :description),
-               builder: "EmCasa Incorporadora",
-               floor_count: 8,
-               units_per_floor: 2,
+               name: Map.get(payload, "name"),
+               description: Map.get(payload, "description"),
+               builder: Map.get(developer, "name"),
+               floor_count: Map.get(payload, "number_of_floors"),
+               units_per_floor: Map.get(payload, "apts_per_floor"),
                phase: "building"
              }
     end
@@ -56,18 +56,18 @@ defmodule ReIntegrations.Orulo.MapperTest do
 
   describe "building_payload_into_address_params" do
     test "parse building payload into address params" do
-      %{payload: %{address: address}} = @building
+      %{payload: %{"address" => address}} = @building
       params = Mapper.building_payload_into_address_params(@building)
 
       assert params == %{
-               street: Map.get(address, :street),
-               neighborhood: Map.get(address, :area),
-               city: Map.get(address, :city),
-               state: Map.get(address, :state),
-               postal_code: Map.get(address, :zip_code),
-               lat: Map.get(address, :latitude),
-               lng: Map.get(address, :longitude),
-               street_number: Map.get(address, :number)
+               street: Map.get(address, "street"),
+               neighborhood: Map.get(address, "area"),
+               city: Map.get(address, "city"),
+               state: Map.get(address, "state"),
+               postal_code: Map.get(address, "zip_code"),
+               lat: Map.get(address, "latitude"),
+               lng: Map.get(address, "longitude"),
+               street_number: Map.get(address, "number") |> Integer.to_string()
              }
     end
   end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -5,12 +5,34 @@ defmodule ReIntegrations.OruloTest do
 
   alias ReIntegrations.{
     Orulo,
-    Orulo.JobQueue
+    Orulo.JobQueue,
+    Repo
   }
+
+  alias Ecto.Multi
 
   describe "get_building_payload/2" do
     test "create o new job with to sync development" do
       assert {:ok, _} = Orulo.get_building_payload(100)
+      assert Repo.one(JobQueue)
+    end
+  end
+
+  describe "multi_building_insert/2" do
+    test "create new building" do
+      params = %{external_id: 666, payload: %{test: "building_payload"}}
+
+      assert {:ok, %{building: inserted_building}} =
+               Orulo.multi_building_insert(Multi.new(), params)
+
+      assert inserted_building.uuid
+      assert inserted_building.external_id == 666
+      assert inserted_building.payload == %{test: "building_payload"}
+    end
+
+    test "enqueue a new parse job" do
+      params = %{external_id: 666, payload: %{test: "building_payload"}}
+      assert {:ok, _} = Orulo.multi_building_insert(Multi.new(), params)
       assert Repo.one(JobQueue)
     end
   end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -47,8 +47,9 @@ defmodule ReIntegrations.OruloTest do
         |> Building.changeset()
         |> Repo.insert!()
 
-      Orulo.insert_development_from_building(uuid)
-      assert new_address = Re.Repo.one(Re.Address)
+      assert {:ok, %{insert_address: new_address}} =
+               Orulo.insert_development_from_building(Multi.new(), uuid)
+
       assert new_address.street == "Copacabana"
       assert new_address.street_number == "926"
       assert new_address.neighborhood == "Copacabana"
@@ -67,7 +68,10 @@ defmodule ReIntegrations.OruloTest do
         |> Building.changeset()
         |> Repo.insert!()
 
-      assert {:ok, development} = Orulo.insert_development_from_building(uuid)
+      assert {:ok, %{insert_development: development}} =
+               Orulo.insert_development_from_building(Multi.new(), uuid)
+
+      assert development.uuid
       assert development.name == Map.get(payload, "name")
       assert development.description == Map.get(payload, "description")
       assert development.phase == "building"

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -5,6 +5,7 @@ defmodule ReIntegrations.OruloTest do
 
   alias ReIntegrations.{
     Orulo,
+    Orulo.Building,
     Orulo.JobQueue,
     Repo
   }
@@ -34,6 +35,74 @@ defmodule ReIntegrations.OruloTest do
       params = %{external_id: 666, payload: %{test: "building_payload"}}
       assert {:ok, _} = Orulo.multi_building_insert(Multi.new(), params)
       assert Repo.one(JobQueue)
+    end
+  end
+
+  @building %Building{
+    external_id: 999,
+    payload: %{
+      id: "999",
+      name: "EmCasa 01",
+      description:
+        "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
+      floor_area: 0.0,
+      apts_per_floor: 2,
+      number_of_floors: 8,
+      status: "Em construção",
+      webpage: "http://www.emcasa.com/",
+      developer: %{
+        id: "799",
+        name: "EmCasa Incorporadora"
+      },
+      address: %{
+        street_type: "Avenida",
+        street: "Copacabana",
+        number: 926,
+        area: "Copacabana",
+        city: "Rio de Janeiro",
+        latitude: -23.5345,
+        longitude: -46.6871,
+        state: "RJ",
+        zip_code: "05021-001"
+      }
+    }
+  }
+
+  describe "insert_development_from_building/1" do
+    test "create new address from building" do
+      %{uuid: uuid} =
+        @building
+        |> Building.changeset()
+        |> Repo.insert!()
+
+      Orulo.insert_development_from_building(uuid)
+      assert new_address = Re.Repo.one(Re.Address)
+      assert new_address.street == "Copacabana"
+      assert new_address.street_number == "926"
+      assert new_address.neighborhood == "Copacabana"
+      assert new_address.city == "Rio de Janeiro"
+      assert new_address.state == "RJ"
+      assert new_address.lat == -23.5345
+      assert new_address.lng == -46.6871
+      assert new_address.postal_code == "05021-001"
+    end
+
+    test "create new development from building" do
+      %{payload: payload = %{developer: developer}} = @building
+
+      %{uuid: uuid} =
+        @building
+        |> Building.changeset()
+        |> Repo.insert!()
+
+      assert {:ok, development} = Orulo.insert_development_from_building(uuid)
+      assert development.name == Map.get(payload, :name)
+      assert development.description == Map.get(payload, :description)
+      assert development.phase == "building"
+      assert development.floor_count == Map.get(payload, :number_of_floors)
+      assert development.units_per_floor == Map.get(payload, :apts_per_floor)
+
+      assert development.builder == Map.get(developer, :name)
     end
   end
 end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -12,6 +12,8 @@ defmodule ReIntegrations.OruloTest do
 
   alias Ecto.Multi
 
+  import ReIntegrations.Factory
+
   describe "get_building_payload/2" do
     test "create o new job with to sync development" do
       assert {:ok, _} = Orulo.get_building_payload(100)
@@ -38,40 +40,10 @@ defmodule ReIntegrations.OruloTest do
     end
   end
 
-  @building %Building{
-    external_id: 999,
-    payload: %{
-      id: "999",
-      name: "EmCasa 01",
-      description:
-        "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
-      floor_area: 0.0,
-      apts_per_floor: 2,
-      number_of_floors: 8,
-      status: "Em construção",
-      webpage: "http://www.emcasa.com/",
-      developer: %{
-        id: "799",
-        name: "EmCasa Incorporadora"
-      },
-      address: %{
-        street_type: "Avenida",
-        street: "Copacabana",
-        number: 926,
-        area: "Copacabana",
-        city: "Rio de Janeiro",
-        latitude: -23.5345,
-        longitude: -46.6871,
-        state: "RJ",
-        zip_code: "05021-001"
-      }
-    }
-  }
-
   describe "insert_development_from_building/1" do
     test "create new address from building" do
       %{uuid: uuid} =
-        @building
+        build(:building)
         |> Building.changeset()
         |> Repo.insert!()
 
@@ -88,21 +60,21 @@ defmodule ReIntegrations.OruloTest do
     end
 
     test "create new development from building" do
-      %{payload: payload = %{developer: developer}} = @building
+      %{payload: payload = %{"developer" => developer}} = building = build(:building)
 
       %{uuid: uuid} =
-        @building
+        building
         |> Building.changeset()
         |> Repo.insert!()
 
       assert {:ok, development} = Orulo.insert_development_from_building(uuid)
-      assert development.name == Map.get(payload, :name)
-      assert development.description == Map.get(payload, :description)
+      assert development.name == Map.get(payload, "name")
+      assert development.description == Map.get(payload, "description")
       assert development.phase == "building"
-      assert development.floor_count == Map.get(payload, :number_of_floors)
-      assert development.units_per_floor == Map.get(payload, :apts_per_floor)
+      assert development.floor_count == Map.get(payload, "number_of_floors")
+      assert development.units_per_floor == Map.get(payload, "apts_per_floor")
 
-      assert development.builder == Map.get(developer, :name)
+      assert development.builder == Map.get(developer, "name")
     end
   end
 end

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -1,0 +1,39 @@
+defmodule ReIntegrations.Factory do
+  @moduledoc """
+  Use the factories here in tests.
+  """
+
+  use ExMachina.Ecto, repo: ReIntegrations.Repo
+
+  def building_factory do
+    %ReIntegrations.Orulo.Building{
+      external_id: 999,
+      payload: %{
+        "id" => "999",
+        "name" => "EmCasa 01",
+        "description" =>
+          "Com 3 dormitórios e espaços amplos, o apartamento foi desenhado de uma forma que permite ventilação e iluminação natural e generosas em praticamente todos os seus ambientes – e funciona quase como uma casa solta no ar. Na melhor localização de Perdizes: com ótimas escolas, restaurantes e lojinhas simpáticas no entorno.",
+        "floor_area" => 0.0,
+        "apts_per_floor" => 2,
+        "number_of_floors" => 8,
+        "status" => "Em construção",
+        "webpage" => "http://www.emcasa.com/",
+        "developer" => %{
+          "id" => "799",
+          "name" => "EmCasa Incorporadora"
+        },
+        "address" => %{
+          "street_type" => "Avenida",
+          "street" => "Copacabana",
+          "number" => 926,
+          "area" => "Copacabana",
+          "city" => "Rio de Janeiro",
+          "latitude" => -23.5345,
+          "longitude" => -46.6871,
+          "state" => "RJ",
+          "zip_code" => "05021-001"
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
Continuing the work started on PR #573. 

Here I'm getting a payload previously fetched from the external API, parsing the params to compatible address' and development's params and create new entities in our systems. Some highlights from this process are: 
- Making all in a transaction using [run](https://hexdocs.pm/ecto/Ecto.Multi.html#run/3). 
- Static factory setup for Building. 
---

One thing that caught my attention while writing this PR, maybe a better name to `Building` module (consequently also the table) is `BuidingPayload`, it's a better representation about what it represents, @rhnonose what are your thoughts about it?  

---

Docs don't make explicit how powerful run is, found it in some [random](https://geoffreylessel.com/2017/using-ecto-multi-to-group-database-operations/) [articles](http://engineering.teacherspayteachers.com/2018/02/22/database-transactions-or-how-i-learned-to-stop-worrying-and-love-ecto-multi.html). Using this interface we can use transactions without rewrite all our context crud operations, in the long term I guess it could be a good solution, we still writing atomic operations, and group them in multi transactions as needed, so we don't need to keep an `insert/?`, `insert_multi/?`, `update/?`, `update_multi/?` ... in each context.