### PR TITLE
refactor(orulo): rename Building module to BuildingPayload

### DIFF
--- a/apps/re_integrations/lib/orulo/building_payload.ex
+++ b/apps/re_integrations/lib/orulo/building_payload.ex
@@ -1,4 +1,4 @@
-defmodule ReIntegrations.Orulo.Building do
+defmodule ReIntegrations.Orulo.BuildingPayload do
   @moduledoc """
   Schema for Orulo Buildings sincronization
   """
@@ -9,7 +9,7 @@ defmodule ReIntegrations.Orulo.Building do
   @schema_prefix "re_integrations"
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
-  schema "orulo_buildings" do
+  schema "orulo_building_payloads" do
     field :external_id, :integer
     field :payload, :map
 

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -25,6 +25,6 @@ defmodule ReIntegrations.Orulo.JobQueue do
   end
 
   def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
-    Orulo.insert_development_from_building(multi, uuid)
+    Orulo.insert_development_from_building_payload(multi, uuid)
   end
 end

--- a/apps/re_integrations/lib/orulo/mapper.ex
+++ b/apps/re_integrations/lib/orulo/mapper.ex
@@ -3,11 +3,11 @@ defmodule ReIntegrations.Orulo.Mapper do
   Module to map external structures into persistable internal structures.
   """
   alias ReIntegrations.{
-    Orulo.Building
+    Orulo.BuildingPayload
   }
 
   @development_attributes ~w(name description developer number_of_floors apts_per_floor status)
-  def building_payload_into_development_params(%Building{} = %{payload: payload}) do
+  def building_payload_into_development_params(%BuildingPayload{} = %{payload: payload}) do
     payload
     |> Map.take(@development_attributes)
     |> Enum.reduce(%{}, &convert_development_attribute(&1, &2))
@@ -44,7 +44,9 @@ defmodule ReIntegrations.Orulo.Mapper do
   defp convert_development_attribute(_, acc), do: acc
 
   @address_attributes ~w(street area city state zip_code latitude longitude number)
-  def building_payload_into_address_params(%Building{} = %{payload: %{"address" => address}}) do
+  def building_payload_into_address_params(
+        %BuildingPayload{} = %{payload: %{"address" => address}}
+      ) do
     address
     |> Map.take(@address_attributes)
     |> Enum.reduce(%{}, &convert_address_attribute(&1, &2))

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -3,7 +3,7 @@ defmodule ReIntegrations.Orulo do
   Context module to use importers.
   """
   alias ReIntegrations.{
-    Orulo.Building,
+    Orulo.BuildingPayload,
     Orulo.JobQueue,
     Orulo.Mapper,
     Repo
@@ -22,8 +22,8 @@ defmodule ReIntegrations.Orulo do
 
   def multi_building_insert(multi, params) do
     changeset =
-      %Building{}
-      |> Building.changeset(params)
+      %BuildingPayload{}
+      |> BuildingPayload.changeset(params)
 
     uuid = Changeset.get_field(changeset, :uuid)
 
@@ -36,8 +36,8 @@ defmodule ReIntegrations.Orulo do
     |> Repo.transaction()
   end
 
-  def insert_development_from_building(multi, building_uuid) do
-    with building <- Repo.get(Building, building_uuid),
+  def insert_development_from_building_payload(multi, building_uuid) do
+    with building <- Repo.get(BuildingPayload, building_uuid),
          address_params <- Mapper.building_payload_into_address_params(building),
          development_params <- Mapper.building_payload_into_development_params(building),
          {:ok, transaction} <- insert_transaction(multi, address_params, development_params) do

--- a/apps/re_integrations/priv/repo/migrations/20190601013645_rename_buildings_to_building_payloads.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190601013645_rename_buildings_to_building_payloads.exs
@@ -1,0 +1,7 @@
+defmodule ReIntegrations.Repo.Migrations.RenameBuildingsToBuildingPayloads do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:orulo_buildings), to: table(:orulo_building_payloads))
+  end
+end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -5,7 +5,7 @@ defmodule ReIntegrations.OruloTest do
 
   alias ReIntegrations.{
     Orulo,
-    Orulo.Building,
+    Orulo.BuildingPayload,
     Orulo.JobQueue,
     Repo
   }
@@ -40,15 +40,15 @@ defmodule ReIntegrations.OruloTest do
     end
   end
 
-  describe "insert_development_from_building/1" do
+  describe "insert_development_from_building_payload/1" do
     test "create new address from building" do
       %{uuid: uuid} =
         build(:building)
-        |> Building.changeset()
+        |> BuildingPayload.changeset()
         |> Repo.insert!()
 
       assert {:ok, %{insert_address: new_address}} =
-               Orulo.insert_development_from_building(Multi.new(), uuid)
+               Orulo.insert_development_from_building_payload(Multi.new(), uuid)
 
       assert new_address.street == "Copacabana"
       assert new_address.street_number == "926"
@@ -65,11 +65,11 @@ defmodule ReIntegrations.OruloTest do
 
       %{uuid: uuid} =
         building
-        |> Building.changeset()
+        |> BuildingPayload.changeset()
         |> Repo.insert!()
 
       assert {:ok, %{insert_development: development}} =
-               Orulo.insert_development_from_building(Multi.new(), uuid)
+               Orulo.insert_development_from_building_payload(Multi.new(), uuid)
 
       assert development.uuid
       assert development.name == Map.get(payload, "name")

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -6,7 +6,7 @@ defmodule ReIntegrations.Factory do
   use ExMachina.Ecto, repo: ReIntegrations.Repo
 
   def building_factory do
-    %ReIntegrations.Orulo.Building{
+    %ReIntegrations.Orulo.BuildingPayload{
       external_id: 999,
       payload: %{
         "id" => "999",


### PR DESCRIPTION
Apply the suggestion made early on [this PR](https://github.com/emcasa/backend/pull/580#issue-283783918) after I notice the name could be better in a sense to communicate the real role on the system. 