### PR TITLE
Empty search buyer lead

### DIFF
--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -16,6 +16,7 @@ defmodule Re.BuyerLead do
     field :location, :string
     field :budget, :string
     field :neighborhood, :string
+    field :url, :string
 
     belongs_to :listing, Re.Listing,
       references: :uuid,
@@ -31,7 +32,7 @@ defmodule Re.BuyerLead do
   end
 
   @required ~w(name phone_number origin)a
-  @optional ~w(email location listing_uuid user_uuid budget neighborhood)a
+  @optional ~w(email location listing_uuid user_uuid budget neighborhood url)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/buyer_leads/buyer_leads.ex
+++ b/apps/re/lib/buyer_leads/buyer_leads.ex
@@ -55,5 +55,5 @@ defmodule Re.BuyerLeads do
     end
   end
 
-  defp insert_with_job(changeset), do: {:error, changeset}
+  defp insert_with_job(changeset, _), do: {:error, changeset}
 end

--- a/apps/re/lib/buyer_leads/buyer_leads.ex
+++ b/apps/re/lib/buyer_leads/buyer_leads.ex
@@ -31,7 +31,7 @@ defmodule Re.BuyerLeads do
 
     %EmptySearch{}
     |> EmptySearch.changeset(params)
-    |> Repo.insert()
+    |> insert_with_job("process_empty_search_buyer_lead")
   end
 
   defp insert_with_job(%{valid?: true} = changeset, type) do

--- a/apps/re/lib/buyer_leads/empty_search.ex
+++ b/apps/re/lib/buyer_leads/empty_search.ex
@@ -6,6 +6,8 @@ defmodule Re.BuyerLeads.EmptySearch do
 
   import Ecto.Changeset
 
+  alias Re.BuyerLead
+
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
   schema "empty_search_buyer_leads" do
@@ -43,4 +45,18 @@ defmodule Re.BuyerLeads.EmptySearch do
   end
 
   defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
+
+  def buyer_lead_changeset(nil), do: raise("BuyerLeads.EmptySearch not found")
+
+  def buyer_lead_changeset(lead) do
+    BuyerLead.changeset(%BuyerLead{}, %{
+      name: lead.user.name,
+      email: lead.user.email,
+      phone_number: lead.user.phone,
+      origin: "site",
+      location: "#{lead.city_slug}|#{lead.state_slug}",
+      user_uuid: lead.user_uuid,
+      url: lead.url
+    })
+  end
 end

--- a/apps/re/lib/buyer_leads/empty_search.ex
+++ b/apps/re/lib/buyer_leads/empty_search.ex
@@ -1,0 +1,46 @@
+defmodule Re.BuyerLeads.EmptySearch do
+  @moduledoc """
+  Schema for buyer leads coming from users that searched for listings but got no results
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:uuid, :binary_id, autogenerate: false}
+
+  schema "empty_search_buyer_leads" do
+    field :state, :string
+    field :city, :string
+    field :url, :string
+
+    field :state_slug, :string
+    field :city_slug, :string
+
+    belongs_to :user, Re.User,
+      references: :uuid,
+      foreign_key: :user_uuid,
+      type: Ecto.UUID
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @params ~w(state city url user_uuid)a
+
+  @sluggified_attr ~w(state city)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @params)
+    |> validate_required(@params)
+    |> generate_uuid()
+    |> generate_slugs()
+  end
+
+  def generate_slugs(%{valid?: false} = changeset), do: changeset
+
+  def generate_slugs(changeset) do
+    Enum.reduce(@sluggified_attr, changeset, &Re.Slugs.generate_slug(&1, &2))
+  end
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
+end

--- a/apps/re/lib/buyer_leads/job_queue.ex
+++ b/apps/re/lib/buyer_leads/job_queue.ex
@@ -10,6 +10,7 @@ defmodule Re.BuyerLeads.JobQueue do
 
   alias Re.{
     BuyerLeads.Budget,
+    BuyerLeads.EmptySearch,
     BuyerLeads.Facebook,
     BuyerLeads.Grupozap,
     BuyerLeads.ImovelWeb,
@@ -60,6 +61,15 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Query.preload(:user)
     |> Repo.get(uuid)
     |> Budget.buyer_lead_changeset()
+    |> insert_buyer_lead(multi)
+    |> Repo.transaction()
+  end
+
+  def perform(%Multi{} = multi, %{"type" => "process_empty_search_buyer_lead", "uuid" => uuid}) do
+    EmptySearch
+    |> Query.preload(:user)
+    |> Repo.get(uuid)
+    |> EmptySearch.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
   end

--- a/apps/re/priv/repo/migrations/20190605174356_create_empty_search_buyer_lead.exs
+++ b/apps/re/priv/repo/migrations/20190605174356_create_empty_search_buyer_lead.exs
@@ -1,0 +1,21 @@
+defmodule Re.Repo.Migrations.CreateEmptySearchBuyerLead do
+  use Ecto.Migration
+
+  def change do
+    create table(:empty_search_buyer_leads, primary_key: false) do
+      add :uuid, :uuid, primary_key: true
+      add :city, :string
+      add :state, :string
+      add :url, :string
+
+      add :city_slug, :string
+      add :state_slug, :string
+
+      add :user_uuid, references(:users, column: :uuid, type: :uuid)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create index(:empty_search_buyer_leads, [:user_uuid])
+  end
+end

--- a/apps/re/priv/repo/migrations/20190605181747_add_url_buyer_lead.exs
+++ b/apps/re/priv/repo/migrations/20190605181747_add_url_buyer_lead.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddUrlBuyerLead do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buyer_leads) do
+      add :url, :string
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/buyer_leads_test.exs
+++ b/apps/re/test/buyer_leads/buyer_leads_test.exs
@@ -6,19 +6,31 @@ defmodule Re.BuyerLeadsTest do
   alias Re.{
     BuyerLeads,
     BuyerLeads.Budget,
+    BuyerLeads.EmptySearch,
     BuyerLeads.JobQueue,
     Repo
   }
 
   describe "create_budget" do
-    test "should create a buyer lead and process and notify jobs" do
+    test "should create a buyer lead and process job" do
       user = insert(:user)
       params = params_for(:budget_buyer_lead, user_uuid: user.uuid)
 
       assert {:ok, _buyer_lead} = BuyerLeads.create_budget(params, user)
 
       assert Repo.one(Budget)
+      assert Repo.one(JobQueue)
+    end
+  end
 
+  describe "create_empty_search" do
+    test "should create a buyer lead and process job" do
+      user = insert(:user)
+      params = params_for(:empty_search_buyer_lead, user_uuid: user.uuid)
+
+      assert {:ok, _buyer_lead} = BuyerLeads.create_empty_search(params, user)
+
+      assert Repo.one(EmptySearch)
       assert Repo.one(JobQueue)
     end
   end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -304,4 +304,32 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.location == "new-york|ny"
     end
   end
+
+  describe "process_empty_search_buyer_lead" do
+    test "proecss lead" do
+      %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
+
+      %{uuid: uuid} =
+        insert(:empty_search_buyer_lead,
+          user_uuid: user_uuid,
+          city: "New York",
+          city_slug: "new-york",
+          state: "NY",
+          state_slug: "ny",
+          url: "https://www.emcasa.com/imoveis/ny/new-york"
+        )
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "process_empty_search_buyer_lead",
+                 "uuid" => uuid
+               })
+
+      assert buyer = Repo.one(BuyerLead)
+      assert buyer.uuid
+      assert buyer.user_uuid == user_uuid
+      assert buyer.location == "new-york|ny"
+      assert buyer.url == "https://www.emcasa.com/imoveis/ny/new-york"
+    end
+  end
 end

--- a/apps/re/test/listings/filters/filters_test.exs
+++ b/apps/re/test/listings/filters/filters_test.exs
@@ -1,6 +1,11 @@
 defmodule Re.Listings.FiltersTest do
   use Re.ModelCase
 
+  import Re.{
+    CustomAssertion,
+    Factory
+  }
+
   alias Re.{
     Listings.Filters,
     Listing,
@@ -9,14 +14,12 @@ defmodule Re.Listings.FiltersTest do
     Repo
   }
 
-  import Re.Factory
-
   describe "apply/2: filter by tags_slug" do
     test "filter by tag slug name" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
@@ -28,8 +31,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_slug: [tag_1.name_slug]})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert listing_1.id == Enum.at(result, 0).id
     end
 
     test "filter by multiple tags slug names" do
@@ -37,11 +40,11 @@ defmodule Re.Listings.FiltersTest do
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
       tag_3 = insert(:tag, name: "Tag 3", name_slug: "tag-3")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid, tag_3.uuid])
 
-      {:ok, listing_2} =
+      {:ok, %{id: id2}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_2.uuid, tag_3.uuid])
 
@@ -49,9 +52,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_slug: [tag_2.name_slug, tag_3.name_slug]})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
       assert 2 == Enum.count(result)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_1.id)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_2.id)
     end
 
     test "filter by non-existent tag slug name" do
@@ -65,13 +67,13 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_slug: ["non-existent-tag-1"]})
         |> Repo.all()
 
-      assert 0 == Enum.count(result)
+      assert [] == result
     end
 
     test "filter by empty tag slug name" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid])
 
@@ -79,8 +81,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_slug: []})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_1.id)
     end
   end
 
@@ -89,7 +91,7 @@ defmodule Re.Listings.FiltersTest do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid])
 
@@ -101,8 +103,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_uuid: [tag_1.uuid]})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert listing_1.id == Enum.at(result, 0).id
     end
 
     test "filter by multiple tags uuids" do
@@ -110,11 +112,11 @@ defmodule Re.Listings.FiltersTest do
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")
       tag_3 = insert(:tag, name: "Tag 3", name_slug: "tag-3")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid, tag_2.uuid, tag_3.uuid])
 
-      {:ok, listing_2} =
+      {:ok, %{id: id2}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_2.uuid, tag_3.uuid])
 
@@ -122,9 +124,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_uuid: [tag_2.uuid, tag_3.uuid]})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
       assert 2 == Enum.count(result)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_1.id)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_2.id)
     end
 
     test "filter by non-existent tag uuid" do
@@ -138,13 +139,13 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_uuid: [UUID.uuid4()]})
         |> Repo.all()
 
-      assert 0 == Enum.count(result)
+      assert [] == result
     end
 
     test "filter by empty tag id" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
 
-      {:ok, listing_1} =
+      {:ok, %{id: id1}} =
         insert(:listing)
         |> Listings.upsert_tags([tag_1.uuid])
 
@@ -152,8 +153,8 @@ defmodule Re.Listings.FiltersTest do
         Filters.apply(Listing, %{tags_uuid: []})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id1}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert Enum.member?(Enum.map(result, & &1.id), listing_1.id)
     end
   end
 
@@ -182,8 +183,8 @@ defmodule Re.Listings.FiltersTest do
     end
 
     test "filter listing with multiple statuses" do
-      listing_1 = insert(:listing, status: "active")
-      listing_2 = insert(:listing, status: "inactive")
+      %{id: id1} = insert(:listing, status: "active")
+      %{id: id2} = insert(:listing, status: "inactive")
       insert(:listing, status: "sold")
 
       result =
@@ -191,23 +192,24 @@ defmodule Re.Listings.FiltersTest do
         |> Filters.apply(%{statuses: ["active", "inactive"]})
         |> Repo.all()
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
 
     test "filter listing with empty orientation fetch all instances" do
-      %{id: listing_1} = insert(:listing, orientation: "frontside")
-      %{id: listing_2} = insert(:listing, orientation: "backside")
-      %{id: listing_3} = insert(:listing, orientation: "lateral")
-      %{id: listing_4} = insert(:listing, orientation: "inside")
+      %{id: id1} = insert(:listing, orientation: "frontside")
+      %{id: id2} = insert(:listing, orientation: "backside")
+      %{id: id3} = insert(:listing, orientation: "lateral")
+      %{id: id4} = insert(:listing, orientation: "inside")
 
       result =
         Listing
         |> Filters.apply(%{orientations: []})
         |> Queries.order_by_id()
         |> Repo.all()
-        |> Enum.map(& &1.id)
 
-      assert [listing_1, listing_2, listing_3, listing_4] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}, %{id: id3}, %{id: id4}], result, &map_id/1)
+      assert 4 == Enum.count(result)
     end
 
     test "filter listing by orientation" do
@@ -225,17 +227,17 @@ defmodule Re.Listings.FiltersTest do
     end
 
     test "filter listing with empty sun period fetch all instances" do
-      %{id: listing_1} = insert(:listing, sun_period: "morning")
-      %{id: listing_2} = insert(:listing, sun_period: "evening")
+      %{id: id1} = insert(:listing, sun_period: "morning")
+      %{id: id2} = insert(:listing, sun_period: "evening")
 
       result =
         Listing
         |> Filters.apply(%{sun_periods: []})
         |> Queries.order_by_id()
         |> Repo.all()
-        |> Enum.map(& &1.id)
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
 
     test "filter listing by sun period" do
@@ -251,88 +253,95 @@ defmodule Re.Listings.FiltersTest do
     end
 
     test "filter listing by floor count" do
-      listing_1 = insert(:listing, floor_count: 1)
-      listing_2 = insert(:listing, floor_count: 2)
-      listing_3 = insert(:listing, floor_count: 3)
-      listing_4 = insert(:listing, floor_count: 4)
+      %{id: id1} = insert(:listing, floor_count: 1)
+      %{id: id2} = insert(:listing, floor_count: 2)
+      %{id: id3} = insert(:listing, floor_count: 3)
+      %{id: id4} = insert(:listing, floor_count: 4)
 
       result =
         Listing
         |> Filters.apply(%{min_floor_count: 3})
         |> Repo.all()
 
-      assert [listing_3, listing_4] == result
+      assert_mapper_match([%{id: id3}, %{id: id4}], result, &map_id/1)
+      assert 2 == Enum.count(result)
 
       result =
         Listing
         |> Filters.apply(%{max_floor_count: 2})
         |> Repo.all()
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
 
     test "filter listing by unit per floor" do
-      listing_1 = insert(:listing, unit_per_floor: 1)
-      listing_2 = insert(:listing, unit_per_floor: 2)
-      listing_3 = insert(:listing, unit_per_floor: 3)
-      listing_4 = insert(:listing, unit_per_floor: 4)
+      %{id: id1} = insert(:listing, unit_per_floor: 1)
+      %{id: id2} = insert(:listing, unit_per_floor: 2)
+      %{id: id3} = insert(:listing, unit_per_floor: 3)
+      %{id: id4} = insert(:listing, unit_per_floor: 4)
 
       result =
         Listing
         |> Filters.apply(%{min_unit_per_floor: 3})
         |> Repo.all()
 
-      assert [listing_3, listing_4] == result
+      assert_mapper_match([%{id: id3}, %{id: id4}], result, &map_id/1)
+      assert 2 == Enum.count(result)
 
       result =
         Listing
         |> Filters.apply(%{max_unit_per_floor: 2})
         |> Repo.all()
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
 
     test "filter listing by age" do
       base_year = Date.utc_today().year
-      listing_1 = insert(:listing, construction_year: base_year - 5)
-      listing_2 = insert(:listing, construction_year: base_year - 10)
-      listing_3 = insert(:listing, construction_year: base_year - 15)
-      listing_4 = insert(:listing, construction_year: base_year - 20)
+      %{id: id1} = insert(:listing, construction_year: base_year - 5)
+      %{id: id2} = insert(:listing, construction_year: base_year - 10)
+      %{id: id3} = insert(:listing, construction_year: base_year - 15)
+      %{id: id4} = insert(:listing, construction_year: base_year - 20)
 
       result =
         Listing
         |> Filters.apply(%{max_age: 10})
         |> Repo.all()
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
 
       result =
         Listing
         |> Filters.apply(%{min_age: 15})
         |> Repo.all()
 
-      assert [listing_3, listing_4] == result
+      assert_mapper_match([%{id: id3}, %{id: id4}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
 
     test "filter listing by price per area" do
-      listing_1 = insert(:listing, price: 10, area: 1, price_per_area: 10)
-      listing_2 = insert(:listing, price: 15, area: 1, price_per_area: 15)
-      listing_3 = insert(:listing, price: 20, area: 1, price_per_area: 20)
-      listing_4 = insert(:listing, price: 25, area: 1, price_per_area: 25)
+      %{id: id1} = insert(:listing, price: 10, area: 1, price_per_area: 10)
+      %{id: id2} = insert(:listing, price: 15, area: 1, price_per_area: 15)
+      %{id: id3} = insert(:listing, price: 20, area: 1, price_per_area: 20)
+      %{id: id4} = insert(:listing, price: 25, area: 1, price_per_area: 25)
 
       result =
         Listing
         |> Filters.apply(%{min_price_per_area: 20})
         |> Repo.all()
 
-      assert [listing_3, listing_4] == result
+      assert_mapper_match([%{id: id3}, %{id: id4}], result, &map_id/1)
 
       result =
         Listing
         |> Filters.apply(%{max_price_per_area: 15})
         |> Repo.all()
 
-      assert [listing_1, listing_2] == result
+      assert_mapper_match([%{id: id1}, %{id: id2}], result, &map_id/1)
+      assert 2 == Enum.count(result)
     end
   end
 
@@ -346,8 +355,8 @@ defmodule Re.Listings.FiltersTest do
         |> Filters.apply(%{max_maintenance_fee: 110.0})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert id == Enum.at(result, 0).id
     end
 
     test "filter by min" do
@@ -359,8 +368,8 @@ defmodule Re.Listings.FiltersTest do
         |> Filters.apply(%{min_maintenance_fee: 90.0})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert id == Enum.at(result, 0).id
     end
 
     test "filter by max and min" do
@@ -373,8 +382,10 @@ defmodule Re.Listings.FiltersTest do
         |> Filters.apply(%{min_maintenance_fee: 90.0, max_maintenance_fee: 110.0})
         |> Repo.all()
 
+      assert_mapper_match([%{id: id}], result, &map_id/1)
       assert 1 == Enum.count(result)
-      assert id == Enum.at(result, 0).id
     end
   end
+
+  defp map_id(items), do: Enum.map(items, & &1.id)
 end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -293,6 +293,23 @@ defmodule Re.Factory do
     }
   end
 
+  def empty_search_buyer_lead_factory do
+    city = Address.city()
+    city_slug = Re.Slugs.sluggify(city)
+
+    state = Address.state_abbr()
+    state_slug = Re.Slugs.sluggify(state)
+
+    %Re.BuyerLeads.EmptySearch{
+      uuid: UUID.uuid4(),
+      city: city,
+      city_slug: city_slug,
+      state: state,
+      state_slug: state_slug,
+      url: Internet.url()
+    }
+  end
+
   def site_seller_lead_factory do
     %Re.SellerLeads.Site{
       uuid: UUID.uuid4(),

--- a/apps/re_web/lib/graphql/resolvers/buyer_leads.ex
+++ b/apps/re_web/lib/graphql/resolvers/buyer_leads.ex
@@ -10,4 +10,11 @@ defmodule ReWeb.Resolvers.BuyerLeads do
       {:ok, %{message: "ok"}}
     end
   end
+
+  def create_empty_search(%{input: params}, %{context: %{current_user: current_user}}) do
+    with :ok <- Bodyguard.permit(BuyerLeads, :create_buyer_lead, current_user, params),
+         {:ok, _} <- BuyerLeads.create_empty_search(params, current_user) do
+      {:ok, %{message: "ok"}}
+    end
+  end
 end

--- a/apps/re_web/lib/graphql/types/buyer_lead.ex
+++ b/apps/re_web/lib/graphql/types/buyer_lead.ex
@@ -13,12 +13,25 @@ defmodule ReWeb.Types.BuyerLead do
     field :budget, non_null(:string)
   end
 
+  input_object :empty_search_buyer_lead_input do
+    field :city, non_null(:string)
+    field :state, non_null(:string)
+    field :url, non_null(:string)
+  end
+
   object :buyer_lead_mutations do
-    @desc "Insert buyer lead"
+    @desc "Insert buyer lead asking for budget"
     field :budget_buyer_lead_create, type: :async_response do
       arg :input, non_null(:budget_buyer_lead_input)
 
       resolve &Resolvers.BuyerLeads.create_budget/2
+    end
+
+    @desc "Insert buyer lead with empty search URL"
+    field :empty_search_buyer_lead_create, type: :async_response do
+      arg :input, non_null(:empty_search_buyer_lead_input)
+
+      resolve &Resolvers.BuyerLeads.create_empty_search/2
     end
   end
 end

--- a/apps/re_web/test/graphql/buyer_leads/mutation_test.exs
+++ b/apps/re_web/test/graphql/buyer_leads/mutation_test.exs
@@ -148,7 +148,7 @@ defmodule ReWeb.GraphQL.BuyerLeads.MutationTest do
       assert buyer_lead["message"] == "ok"
     end
 
-    test "anonymous should add empty search buyer lead", %{
+    test "anonymous shouldn't add empty search buyer lead", %{
       unauthenticated_conn: conn
     } do
       %{state: state, city: city, url: url} = params_for(:empty_search_buyer_lead)

--- a/apps/re_web/test/graphql/buyer_leads/mutation_test.exs
+++ b/apps/re_web/test/graphql/buyer_leads/mutation_test.exs
@@ -96,4 +96,77 @@ defmodule ReWeb.GraphQL.BuyerLeads.MutationTest do
       assert_unauthorized_response(json_response(conn, 200))
     end
   end
+
+  describe "create_empty_search/2" do
+    @create_mutation """
+      mutation EmptySearchBuyerLeadCreate ($input: EmptySearchBuyerLeadInput!) {
+        emptySearchBuyerLeadCreate(input: $input) {
+          message
+        }
+      }
+    """
+
+    test "admin should add empty search buyer lead", %{
+      admin_conn: conn
+    } do
+      %{state: state, city: city, url: url} = params_for(:empty_search_buyer_lead)
+
+      variables = %{
+        "input" => %{
+          "state" => state,
+          "city" => city,
+          "url" => url
+        }
+      }
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@create_mutation, variables))
+
+      assert %{"emptySearchBuyerLeadCreate" => buyer_lead} = json_response(conn, 200)["data"]
+
+      assert buyer_lead["message"] == "ok"
+    end
+
+    test "user should add empty search buyer lead", %{
+      user_conn: conn
+    } do
+      %{state: state, city: city, url: url} = params_for(:empty_search_buyer_lead)
+
+      variables = %{
+        "input" => %{
+          "state" => state,
+          "city" => city,
+          "url" => url
+        }
+      }
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@create_mutation, variables))
+
+      assert %{"emptySearchBuyerLeadCreate" => buyer_lead} = json_response(conn, 200)["data"]
+
+      assert buyer_lead["message"] == "ok"
+    end
+
+    test "anonymous should add empty search buyer lead", %{
+      unauthenticated_conn: conn
+    } do
+      %{state: state, city: city, url: url} = params_for(:empty_search_buyer_lead)
+
+      variables = %{
+        "input" => %{
+          "state" => state,
+          "city" => city,
+          "url" => url
+        }
+      }
+
+      conn =
+        post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(@create_mutation, variables))
+
+      assert %{"emptySearchBuyerLeadCreate" => nil} = json_response(conn, 200)["data"]
+
+      assert_unauthorized_response(json_response(conn, 200))
+    end
+  end
 end


### PR DESCRIPTION
Core:
- Add a new mutation for a call to action when a listing search comes empty
- Process that lead as a buyer lead, adding a new `url` parameter to be sent as well
For details of the search, we'll ask the URL for now so we can have the search context in the lead.

Extra:
- Refactor `filters_test.exs` as it had a flip test, also improving assertions