### PR TITLE
Send complete address to vivareal integration

### DIFF
--- a/apps/re/lib/exporters/vivareal.ex
+++ b/apps/re/lib/exporters/vivareal.ex
@@ -103,7 +103,7 @@ defmodule Re.Exporters.Vivareal do
   end
 
   defp convert_attribute(:location, %{address: address}, _) do
-    {"Location", %{displayAddress: "Street"},
+    {"Location", %{displayAddress: "All"},
      [
        {"Country", %{abbreviation: "BR"}, "Brasil"},
        {"State", %{abbreviation: address.state}, expand_state(address.state)},

--- a/apps/re/test/exporters/vivareal_test.exs
+++ b/apps/re/test/exporters/vivareal_test.exs
@@ -362,7 +362,7 @@ defmodule Re.Exporters.VivarealTest do
   end
 
   defp location_tags do
-    "<Location displayAddress=\"Street\">" <>
+    "<Location displayAddress=\"All\">" <>
       "<Country abbreviation=\"BR\">Brasil</Country>" <>
       "<State abbreviation=\"RJ\">Rio de Janeiro</State>" <>
       "<City>Rio de Janeiro</City>" <>


### PR DESCRIPTION
We'll be sending the complete address through vivareal's integration since it improves the listings' score.

Modifications according to the [official documentation](https://sites.google.com/grupozap.com/manualdeintegracaovivareal/integra%C3%A7%C3%A3o-de-im%C3%B3veis/localiza%C3%A7%C3%A3o)