### PR TITLE
Import orulo tags

### DIFF
--- a/apps/re/lib/developments/development.ex
+++ b/apps/re/lib/developments/development.ex
@@ -25,6 +25,11 @@ defmodule Re.Development do
     has_many :images, Re.Image
     has_many :listings, Re.Listing
 
+    many_to_many :tags, Re.Tag,
+      join_through: Re.DevelopmentTag,
+      join_keys: [development_uuid: :uuid, tag_uuid: :uuid],
+      on_replace: :delete
+
     timestamps()
   end
 

--- a/apps/re/lib/tags/development_tag.ex
+++ b/apps/re/lib/tags/development_tag.ex
@@ -10,16 +10,18 @@ defmodule Re.DevelopmentTag do
 
   schema "developments_tags" do
     belongs_to :listing, Re.Development,
-      type: :binary_id,
+      type: Ecto.UUID,
       foreign_key: :development_uuid,
       references: :uuid,
       primary_key: true
 
     belongs_to :tag, Re.Tag,
-      type: :binary_id,
+      type: Ecto.UUID,
       foreign_key: :tag_uuid,
       references: :uuid,
       primary_key: true
+
+    timestamps(type: :utc_datetime)
   end
 
   @params ~w(development_uuid tag_uuid)a

--- a/apps/re/lib/tags/development_tag.ex
+++ b/apps/re/lib/tags/development_tag.ex
@@ -1,0 +1,32 @@
+defmodule Re.DevelopmentTag do
+  @moduledoc """
+  Model that resolve relation between development and tag.
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "developments_tags" do
+    belongs_to :listing, Re.Development,
+      type: :binary_id,
+      foreign_key: :development_uuid,
+      references: :uuid,
+      primary_key: true
+
+    belongs_to :tag, Re.Tag,
+      type: :binary_id,
+      foreign_key: :tag_uuid,
+      references: :uuid,
+      primary_key: true
+  end
+
+  @params ~w(development_uuid tag_uuid)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @params)
+    |> validate_required(@params)
+  end
+end

--- a/apps/re/lib/tags/tag.ex
+++ b/apps/re/lib/tags/tag.ex
@@ -24,6 +24,11 @@ defmodule Re.Tag do
       join_keys: [tag_uuid: :uuid, listing_uuid: :uuid],
       on_replace: :delete
 
+    many_to_many :developments, Re.Development,
+      join_through: Re.DevelopmentTag,
+      join_keys: [tag_uuid: :uuid, development_uuid: :uuid],
+      on_replace: :delete
+
     timestamps()
   end
 

--- a/apps/re/lib/tags/tags.ex
+++ b/apps/re/lib/tags/tags.ex
@@ -41,13 +41,11 @@ defmodule Re.Tags do
   end
 
   def get(uuid, user) do
-    tag =
-      %{uuid: uuid}
-      |> query_visibility(user)
-      |> Queries.filter_by()
-      |> Repo.one()
-
-    case tag do
+    %{uuid: uuid}
+    |> query_visibility(user)
+    |> Queries.filter_by()
+    |> Repo.one()
+    |> case do
       nil -> {:error, :not_found}
       tag -> {:ok, tag}
     end

--- a/apps/re/priv/repo/migrations/20190606191321_create_listing_tag_index.exs
+++ b/apps/re/priv/repo/migrations/20190606191321_create_listing_tag_index.exs
@@ -1,0 +1,7 @@
+defmodule Re.Repo.Migrations.CreateListingTagIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:listings_tags, [:listing_uuid, :tag_uuid])
+  end
+end

--- a/apps/re/priv/repo/migrations/20190606191418_create_tag_development_relation.exs
+++ b/apps/re/priv/repo/migrations/20190606191418_create_tag_development_relation.exs
@@ -7,6 +7,8 @@ defmodule Re.Repo.Migrations.CreateTagDevelopmentRelation do
         primary_key: true
 
       add :tag_uuid, references(:tags, column: :uuid, type: :uuid), primary_key: true
+
+      timestamps(type: :timestamptz)
     end
 
     create index(:developments_tags, [:development_uuid, :tag_uuid])

--- a/apps/re/priv/repo/migrations/20190606191418_create_tag_development_relation.exs
+++ b/apps/re/priv/repo/migrations/20190606191418_create_tag_development_relation.exs
@@ -1,0 +1,14 @@
+defmodule Re.Repo.Migrations.CreateTagDevelopmentRelation do
+  use Ecto.Migration
+
+  def change do
+    create table(:developments_tags, primary_key: false) do
+      add :development_uuid, references(:developments, column: :uuid, type: :uuid),
+        primary_key: true
+
+      add :tag_uuid, references(:tags, column: :uuid, type: :uuid), primary_key: true
+    end
+
+    create index(:developments_tags, [:development_uuid, :tag_uuid])
+  end
+end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -47,4 +47,11 @@ defmodule ReIntegrations.Orulo.JobQueue do
       }) do
     PayloadsProcessor.insert_images_from_image_payload(multi, uuid)
   end
+
+  def perform(%Multi{} = multi, %{
+        "type" => "process_orulo_tags",
+        "uuid" => uuid
+      }) do
+    PayloadsProcessor.process_orulo_tags(multi, uuid)
+  end
 end

--- a/apps/re_integrations/lib/orulo/tag_mapper.ex
+++ b/apps/re_integrations/lib/orulo/tag_mapper.ex
@@ -1,0 +1,46 @@
+defmodule ReIntegrations.Orulo.TagMapper do
+  @moduledoc """
+  Module to map orulo's tags into our tags.
+  """
+  alias ReIntegrations.{
+    Orulo.BuildingPayload
+  }
+
+  def map_tags(%BuildingPayload{} = %{payload: %{"features" => features}}) do
+    features
+    |> Enum.reduce([], &convert_tag(&1, &2))
+    |> Enum.dedup()
+  end
+
+  def map_tags(_), do: []
+
+  defp convert_tag("Fitness", acc), do: ["academia" | acc]
+  defp convert_tag("Fitness ao ar livre", acc), do: ["academia" | acc]
+  defp convert_tag("Churrasqueira condominial", acc), do: ["churrasqueira" | acc]
+  defp convert_tag("Espaço gourmet", acc), do: ["espaco-gourmet" | acc]
+  defp convert_tag("Jardim", acc), do: ["espaco-verde" | acc]
+  defp convert_tag("Praça", acc), do: ["espaco-verde" | acc]
+  defp convert_tag("Trilhas e bosque", acc), do: ["espaco-verde" | acc]
+  defp convert_tag("Piscina adulto", acc), do: ["piscina" | acc]
+  defp convert_tag("Piscina aquecida", acc), do: ["piscina" | acc]
+  defp convert_tag("Piscina com raia", acc), do: ["piscina" | acc]
+  defp convert_tag("Piscina infantil", acc), do: ["piscina" | acc]
+  defp convert_tag("Piscina térmica", acc), do: ["piscina" | acc]
+  defp convert_tag("Playground", acc), do: ["playground" | acc]
+  defp convert_tag("Quadra futebol sete", acc), do: ["quadra" | acc]
+  defp convert_tag("Quadra paddle", acc), do: ["quadra" | acc]
+  defp convert_tag("Quadra poliesportiva", acc), do: ["quadra" | acc]
+  defp convert_tag("Quadra tênis", acc), do: ["quadra" | acc]
+  defp convert_tag("Quadra volei", acc), do: ["quadra" | acc]
+  defp convert_tag("Salão de festas", acc), do: ["salao-de-festas" | acc]
+  defp convert_tag("Sala de jogos", acc), do: ["salao-de-jogos" | acc]
+  defp convert_tag("Sauna", acc), do: ["sauna" | acc]
+  defp convert_tag("Terraço", acc), do: ["terraco" | acc]
+  defp convert_tag("Terraço coletivo", acc), do: ["terraco" | acc]
+  defp convert_tag("Bicicletário", acc), do: ["bicicletario" | acc]
+  defp convert_tag("Espaço kids", acc), do: ["brinquedoteca" | acc]
+  defp convert_tag("Portaria 24 horas", acc), do: ["portaria-24-horas" | acc]
+  defp convert_tag("Portaria", acc), do: ["portaria-horario-comercial" | acc]
+  defp convert_tag("Porteiro eletrônico", acc), do: ["portaria-eletronica" | acc]
+  defp convert_tag(_, acc), do: acc
+end

--- a/apps/re_integrations/test/orulo/payloads_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payloads_processor_test.exs
@@ -143,7 +143,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
       {:ok, %{insert_tags: _}} = PayloadsProcessor.process_orulo_tags(Multi.new(), building_uuid)
 
       development = Re.Repo.preload(development, :tags)
-      assert 0 == Enum.count(development.tags)
+      assert Enum.empty?(development.tags)
     end
   end
 end

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -7,6 +7,7 @@ defmodule ReIntegrations.Factory do
 
   def building_factory do
     %ReIntegrations.Orulo.BuildingPayload{
+      uuid: UUID.uuid4(),
       external_id: 999,
       payload: %{
         "id" => "999",
@@ -32,7 +33,13 @@ defmodule ReIntegrations.Factory do
           "longitude" => -46.6871,
           "state" => "RJ",
           "zip_code" => "05021-001"
-        }
+        },
+        "features" => [
+          "Fitness",
+          "Fitness ao ar livre",
+          "Invalid Feature",
+          "Porteiro eletrônico"
+        ]
       }
     }
   end


### PR DESCRIPTION
Core:
- Import tags from orulo's building payload
  - Enqueue a job for doing that asynchronously.
  - Inside the attribute `features`, there's a list of strings containing development features
  - Use a hard-coded map (`TagMapper`) to map their tags to ours. Not mapped tags will be ignored
- Not handled: if there's a `building_payload` for the same development, tags will be inserted again and break a unique constraint. If there's a case where that happens, we should `delete_all` tags from that development prior to inserting or handling conflicts (not sure if `Multi.insert_all` would do that properly, maybe would have to be through individual inserts

TODO:
  - Expose development tags through the API

Extra:
- Refactor `PayloadsProcessor`.insert_development_from_building_payload/2` for readability