### PR TITLE
Add codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
 
+      - run: mix do compile --warnings-as-errors, coveralls.json
+      - run: curl -s https://codecov.io/bash | bash
       - run: mix coveralls.circle --umbrella
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
 
       - run: mix do compile --warnings-as-errors, coveralls.json
       - run: curl -s https://codecov.io/bash | bash
-      - run: mix coveralls.circle --umbrella
 
       - store_test_results:
           path: _build/test/lib/re/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  round: nearest
+  precision: 3

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,7 +1,0 @@
----
-linters:
-    credo:
-      ignore-checks: duplicated
-      all: 'true'
-      all-priorities: 'true'
-      strict: 'true'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![CircleCI](https://circleci.com/gh/emcasa/backend.svg?style=svg)](https://circleci.com/gh/emcasa/backend)
-[![Ebert](https://ebertapp.io/github/emcasa/backend.svg)](https://ebertapp.io/github/emcasa/backend)
-[![Coverage Status](https://coveralls.io/repos/github/emcasa/backend/badge.svg?branch=master)](https://coveralls.io/github/emcasa/backend?branch=master)
-[![codebeat badge](https://codebeat.co/badges/eaf3bdc4-572b-4c84-8a93-347850ca530c)](https://codebeat.co/projects/github-com-emcasa-backend-master)
+[![codecov](https://codecov.io/gh/emcasa/backend/branch/master/graph/badge.svg)](https://codecov.io/gh/emcasa/backend)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/96ac2f098f0342619ecd90cd3df6c4da)](https://www.codacy.com/app/pmargreff/backend?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=emcasa/backend&amp;utm_campaign=Badge_Grade)
 
 # Re WebService
 


### PR DESCRIPTION
Once it uses coveralls same settings we need no config changes to make it work. :tada: 	

As it hasn't run in master yet and it's the default branch it has no status, but you can navigate in the [current branch](https://codecov.io/gh/emcasa/backend/branch/add-codecov). The interface looks pretty good, expect it help us with better visibility about coverage. 