### PR TITLE
Get facebook retailer item

### DIFF
--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -83,7 +83,12 @@ defmodule Re.BuyerLeads.Facebook do
          {:ok, listing} <- Re.Listings.get(listing_id) do
       {:ok, listing.uuid}
     else
-      _error -> {:ok, nil}
+      error ->
+        Sentry.capture_message("error when processing facebook buyer lead",
+          extra: %{lead_id: lead_id, error: error}
+        )
+
+        {:ok, nil}
     end
   end
 end

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -77,10 +77,17 @@ defmodule Re.BuyerLeads.Facebook do
   end
 
   defp extract_listing_uuid(lead_id) do
-    with {:ok, %{body: body}} <- Re.BuyerLeads.FacebookClient.get_lead(lead_id),
+    with {:facebook_client_call, {:ok, %{body: body}}} <-
+           {:facebook_client_call, Re.BuyerLeads.FacebookClient.get_lead(lead_id)},
          {:ok, %{"retailer_item_id" => listing_id}} <- Jason.decode(body),
          {:ok, listing} <- Re.Listings.get(listing_id) do
       {:ok, listing.uuid}
+    else
+      {:facebook_client_call, error} ->
+        raise "Error calling FacebookClient. Error: #{Kernel.inspect(error)}"
+
+      _error ->
+        {:ok, nil}
     end
   end
 end

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -78,17 +78,12 @@ defmodule Re.BuyerLeads.Facebook do
   end
 
   defp extract_listing_uuid(lead_id) do
-    with {:facebook_client_call, {:ok, %{body: body}}} <-
-           {:facebook_client_call, FacebookClient.get_lead(lead_id)},
+    with {:ok, %{body: body}} <- FacebookClient.get_lead(lead_id),
          {:ok, %{"retailer_item_id" => listing_id}} <- Jason.decode(body),
          {:ok, listing} <- Re.Listings.get(listing_id) do
       {:ok, listing.uuid}
     else
-      {:facebook_client_call, error} ->
-        raise "Error calling FacebookClient. Error: #{Kernel.inspect(error)}"
-
-      _error ->
-        {:ok, nil}
+      _error -> {:ok, nil}
     end
   end
 end

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -10,7 +10,8 @@ defmodule Re.BuyerLeads.Facebook do
 
   alias Re.{
     Accounts.Users,
-    BuyerLead
+    BuyerLead,
+    BuyerLeads.FacebookClient
   }
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
@@ -78,7 +79,7 @@ defmodule Re.BuyerLeads.Facebook do
 
   defp extract_listing_uuid(lead_id) do
     with {:facebook_client_call, {:ok, %{body: body}}} <-
-           {:facebook_client_call, Re.BuyerLeads.FacebookClient.get_lead(lead_id)},
+           {:facebook_client_call, FacebookClient.get_lead(lead_id)},
          {:ok, %{"retailer_item_id" => listing_id}} <- Jason.decode(body),
          {:ok, listing} <- Re.Listings.get(listing_id) do
       {:ok, listing.uuid}

--- a/apps/re/lib/buyer_leads/facebook_client.ex
+++ b/apps/re/lib/buyer_leads/facebook_client.ex
@@ -1,11 +1,12 @@
 defmodule Re.BuyerLeads.FacebookClient do
-  @http_client Application.get_env(:re, :http_client, HTTPoison)
+  require Mockery.Macro
+
   @token Application.get_env(:re, :facebook_access_token, "")
 
-  def get(lead_id) do
+  def get_lead(lead_id) do
     lead_id
     |> build_url()
-    |> @http_client.get()
+    |> http_client().get()
   end
 
   defp build_url(lead_id) do
@@ -14,4 +15,6 @@ defmodule Re.BuyerLeads.FacebookClient do
     |> URI.merge("/#{lead_id}/")
     |> Map.put(:query, URI.encode_query(%{access_token: @token}))
   end
+
+  defp http_client(), do: Mockery.Macro.mockable(HTTPoison)
 end

--- a/apps/re/lib/buyer_leads/facebook_client.ex
+++ b/apps/re/lib/buyer_leads/facebook_client.ex
@@ -1,4 +1,7 @@
 defmodule Re.BuyerLeads.FacebookClient do
+  @moduledoc """
+  Module for facebook http API
+  """
   require Mockery.Macro
 
   @token Application.get_env(:re, :facebook_access_token, "")
@@ -16,5 +19,5 @@ defmodule Re.BuyerLeads.FacebookClient do
     |> Map.put(:query, URI.encode_query(%{access_token: @token}))
   end
 
-  defp http_client(), do: Mockery.Macro.mockable(HTTPoison)
+  defp http_client, do: Mockery.Macro.mockable(HTTPoison)
 end

--- a/apps/re/lib/buyer_leads/facebook_client.ex
+++ b/apps/re/lib/buyer_leads/facebook_client.ex
@@ -1,0 +1,17 @@
+defmodule Re.BuyerLeads.FacebookClient do
+  @http_client Application.get_env(:re, :http_client, HTTPoison)
+  @token Application.get_env(:re, :facebook_access_token, "")
+
+  def get(lead_id) do
+    lead_id
+    |> build_url()
+    |> @http_client.get()
+  end
+
+  defp build_url(lead_id) do
+    "https://graph.facebook.com/v3.3/"
+    |> URI.parse()
+    |> URI.merge("/#{lead_id}/")
+    |> Map.put(:query, URI.encode_query(%{access_token: @token}))
+  end
+end

--- a/apps/re/mix.exs
+++ b/apps/re/mix.exs
@@ -57,7 +57,8 @@ defmodule Re.Mixfile do
       {:sentry, "~> 7.0"},
       {:jason, "~> 1.1"},
       {:ecto_job, "~> 2.0"},
-      {:prometheus_ecto, "~> 1.4"}
+      {:prometheus_ecto, "~> 1.4"},
+      {:mockery, "~> 2.3"}
     ]
   end
 

--- a/apps/re/test/support/test_http.ex
+++ b/apps/re/test/support/test_http.ex
@@ -1,0 +1,11 @@
+defmodule Re.TestHTTP do
+  @moduledoc false
+
+  def get(%URI{host: "graph.facebook.com"}),
+    do:
+      {:ok,
+       %{
+         body:
+           "{\"created_time\":\"2010-01-01T10:00:00+0000\",\"id\":\"12345\",\"field_data\":[{\"name\":\"full_name\",\"values\":[\"mah name\"]},{\"name\":\"phone_number\",\"values\":[\"+5511999999999\"]},{\"name\":\"qual_o_seu_objetivo?\",\"values\":[\"quero_comprar_um_imóvel\"]},{\"name\":\"qual_região_vocêa_tem_interesse?\",\"values\":[\"outros_(zona_norte)\"]},{\"name\":\"email\",\"values\":[\"admin@emcasa.com\"]}],\"retailer_item_id\":\"1\"}"
+       }}
+end

--- a/config/dev.secret-example.exs
+++ b/config/dev.secret-example.exs
@@ -51,7 +51,8 @@ config :re,
   imovelweb_highlights_size_sao_paulo: 10,
   imovelweb_super_highlights_size_rio_de_janeiro: 10,
   imovelweb_super_highlights_size_sao_paulo: 10,
-  imovelweb_identity: "1"
+  imovelweb_identity: "1",
+  facebook_access_token: "FACEBOOK_ACCESS_TOKEN"
 
 config :account_kit,
   app_id: "your_dev_app_id",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -26,7 +26,8 @@ config :re, Re.Repo,
   url: System.get_env("DATABASE_URL"),
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   ssl: true,
-  migration_source: "old_schema_migrations"
+  migration_source: "old_schema_migrations",
+  facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN")
 
 config :re_integrations, ReIntegrations.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/test.exs
+++ b/config/test.exs
@@ -51,6 +51,7 @@ config :re_integrations, ReIntegrations.Notifications.Emails.Mailer, adapter: Sw
 config :re,
   visualizations: Re.TestVisualizations,
   account_kit: Re.TestAccountKit,
+  http: Re.TestHTTP,
   vivareal_highlights_size_rio_de_janeiro: 10,
   vivareal_highlights_size_sao_paulo: 10,
   zap_highlights_size_rio_de_janeiro: 10,
@@ -61,7 +62,8 @@ config :re,
   imovelweb_highlights_size_sao_paulo: 5,
   imovelweb_super_highlights_size_rio_de_janeiro: 5,
   imovelweb_super_highlights_size_sao_paulo: 5,
-  imovelweb_identity: "1"
+  imovelweb_identity: "1",
+  facebook_access_token: "testsecret"
 
 config :re_integrations,
   http: ReIntegrations.TestHTTP,

--- a/mix.lock
+++ b/mix.lock
@@ -47,6 +47,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
+  "mockery": {:hex, :mockery, "2.3.0", "f1af3976916e7402427116f491e3038a251857de8f0836952c2fa24ad6de4317", [:mix], [], "hexpm"},
   "msgpax": {:hex, :msgpax, "2.2.2", "559a07806bbe5fdd31e4597455be030bd96356f7a621ca9eed832747c83bfb67", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm"},
   "nimble_csv": {:hex, :nimble_csv, "0.4.0", "e2a21d93071cb3b3278411b5b49fe6b55a0e4b3e90485d1187e0c9c75c74f977", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},


### PR DESCRIPTION
Since facebook forms doesn't send `retailer_item_id`, we need to fetch the lead to retrieve it.

Here I introduced `mockery` to be able to inject dynamically `listing_id` as `retailer_item_id` to be returned from the mocked HTTP call