### PR TITLE
Orulo/reject duplicated building payloads

### DIFF
--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -2,6 +2,9 @@ defmodule ReIntegrations.Orulo do
   @moduledoc """
   Context module to use importers.
   """
+
+  import Ecto.Query, only: [from: 2]
+
   alias ReIntegrations.{
     Orulo.BuildingPayload,
     Orulo.ImagePayload,
@@ -50,5 +53,10 @@ defmodule ReIntegrations.Orulo do
       "uuid" => uuid
     })
     |> Repo.transaction()
+  end
+
+  def building_payload_synced?(external_id) do
+    from(bp in BuildingPayload, where: bp.external_id == ^external_id)
+    |> Repo.exists?()
   end
 end

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -60,7 +60,8 @@ defmodule ReIntegrations.Orulo do
   end
 
   def building_payload_synced?(external_id) do
-    from(bp in BuildingPayload, where: bp.external_id == ^external_id)
+    (bp in BuildingPayload)
+    |> from(where: bp.external_id == ^external_id)
     |> Repo.exists?()
   end
 end

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -60,6 +60,7 @@ defmodule ReIntegrations.Orulo do
   end
 
   def building_payload_synced?(external_id) do
+    # credo:disable-for-lines:3
     (bp in BuildingPayload)
     |> from(where: bp.external_id == ^external_id)
     |> Repo.exists?()

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -18,9 +18,13 @@ defmodule ReIntegrations.Orulo do
   }
 
   def get_building_payload(id) do
-    %{"type" => "import_development_from_orulo", "external_id" => id}
-    |> JobQueue.new()
-    |> Repo.insert()
+    if building_payload_synced?(id) do
+      {:error, "Sync already scheduled!"}
+    else
+      %{"type" => "import_development_from_orulo", "external_id" => id}
+      |> JobQueue.new()
+      |> Repo.insert()
+    end
   end
 
   def multi_building_payload_insert(multi, params) do

--- a/apps/re_integrations/priv/repo/migrations/20190610122549_add_constraint_to_building_payloads.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190610122549_add_constraint_to_building_payloads.exs
@@ -1,0 +1,7 @@
+defmodule ReIntegrations.Repo.Migrations.AddConstraintToBuildingPayloads do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:orulo_building_payloads, [:external_id])
+  end
+end

--- a/apps/re_integrations/test/orulo/mapper_test.exs
+++ b/apps/re_integrations/test/orulo/mapper_test.exs
@@ -11,7 +11,7 @@ defmodule ReIntegrations.Orulo.MapperTest do
 
   describe "building_payload_into_development_params" do
     test "parse building payload into development" do
-      %{payload: %{"developer" => developer} = payload} = building = build(:building)
+      %{payload: %{"developer" => developer} = payload} = building = build(:building_payload)
       params = Mapper.building_payload_into_development_params(building)
 
       assert params == %{
@@ -28,7 +28,7 @@ defmodule ReIntegrations.Orulo.MapperTest do
 
   describe "building_payload_into_address_params" do
     test "parse building payload into address params" do
-      %{payload: %{"address" => address}} = building = build(:building)
+      %{payload: %{"address" => address}} = building = build(:building_payload)
       params = Mapper.building_payload_into_address_params(building)
 
       assert params == %{

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -18,6 +18,12 @@ defmodule ReIntegrations.OruloTest do
       assert {:ok, _} = Orulo.get_building_payload(100)
       assert Repo.one(JobQueue)
     end
+
+    test "doesn't create a job if building payload already exists for orulo id" do
+      insert(:building_payload, external_id: 100)
+      assert {:error, _} = Orulo.get_building_payload(100)
+      assert [] == Repo.all(JobQueue)
+    end
   end
 
   describe "multi_building_payload_insert/2" do

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -1,6 +1,8 @@
 defmodule ReIntegrations.OruloTest do
   @moduledoc false
 
+  import ReIntegrations.Factory
+
   use ReIntegrations.ModelCase
 
   alias ReIntegrations.{
@@ -54,6 +56,18 @@ defmodule ReIntegrations.OruloTest do
       assert {:ok, _} = Orulo.multi_images_payload_insert(Multi.new(), params)
 
       assert Repo.one(JobQueue)
+    end
+  end
+
+  describe "building_already_synced?/2" do
+    test "return false when payload does not exists" do
+      insert(:building_payload, external_id: 1)
+      refute Orulo.building_payload_synced?(2)
+    end
+
+    test "return true when payload does exists" do
+      insert(:building_payload, external_id: 1)
+      assert Orulo.building_payload_synced?(1)
     end
   end
 end

--- a/apps/re_integrations/test/orulo/payloads_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payloads_processor_test.exs
@@ -18,7 +18,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
   describe "insert_development_from_building_payload/1" do
     test "create new address from building" do
       %{uuid: uuid} =
-        build(:building)
+        build(:building_payload)
         |> BuildingPayload.changeset()
         |> Repo.insert!()
 
@@ -36,7 +36,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
     end
 
     test "create new development from building" do
-      %{payload: payload = %{"developer" => developer}} = building = build(:building)
+      %{payload: payload = %{"developer" => developer}} = building = build(:building_payload)
 
       %{uuid: uuid} =
         building
@@ -57,7 +57,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
     end
 
     test "enqueue fetch images and process tag jobs" do
-      building = build(:building)
+      building = build(:building_payload)
 
       %{uuid: uuid} =
         building
@@ -94,7 +94,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
     test "create new tags from building payload" do
       Re.Factory.insert(:tag, name: "Academia", name_slug: "academia")
       Re.Factory.insert(:tag, name: "Portaria Eletrônica", name_slug: "portaria-eletronica")
-      %{uuid: building_uuid} = insert(:building)
+      %{uuid: building_uuid} = insert(:building_payload)
 
       development = Re.Factory.insert(:development, orulo_id: "999")
 
@@ -106,7 +106,7 @@ defmodule ReIntegrations.Orulo.PayloadsProcessorTest do
 
     test "do not create new tags when there's no feature on payload" do
       %{uuid: building_uuid} =
-        insert(:building,
+        insert(:building_payload,
           payload: %{
             "id" => "999",
             "name" => "EmCasa 01",

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule ReIntegrations.Factory do
 
   use ExMachina.Ecto, repo: ReIntegrations.Repo
 
-  def building_factory do
+  def building_payload_factory do
     %ReIntegrations.Orulo.BuildingPayload{
       uuid: UUID.uuid4(),
       external_id: 999,

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -6,8 +6,6 @@ defmodule ReWeb.Resolvers.Developments do
     Developments
   }
 
-  alias ReIntegrations.Orulo
-
   import Absinthe.Resolution.Helpers, only: [on_load: 2]
 
   def index(_params, _context) do
@@ -52,13 +50,9 @@ defmodule ReWeb.Resolvers.Developments do
   end
 
   def import_from_orulo(%{external_id: id}, %{context: %{current_user: current_user}}) do
-    with :ok <- Bodyguard.permit(Developments, :import_development_from_orulo, current_user) do
-      if Orulo.building_payload_synced?(id) do
-        case ReIntegrations.Orulo.get_building_payload(id) do
-          {:ok, _job} -> {:ok, %{message: "Development syncronization scheduled!"}}
-          {:error, error} -> {:error, error}
-        end
-      end
+    with :ok <- Bodyguard.permit(Developments, :import_development_from_orulo, current_user),
+         {:ok, _job} <- ReIntegrations.Orulo.get_building_payload(id) do
+      {:ok, %{message: "Development syncronization scheduled!"}}
     end
   end
 

--- a/apps/re_web/lib/graphql/resolvers/developments.ex
+++ b/apps/re_web/lib/graphql/resolvers/developments.ex
@@ -6,6 +6,8 @@ defmodule ReWeb.Resolvers.Developments do
     Developments
   }
 
+  alias ReIntegrations.Orulo
+
   import Absinthe.Resolution.Helpers, only: [on_load: 2]
 
   def index(_params, _context) do
@@ -50,9 +52,13 @@ defmodule ReWeb.Resolvers.Developments do
   end
 
   def import_from_orulo(%{external_id: id}, %{context: %{current_user: current_user}}) do
-    with :ok <- Bodyguard.permit(Developments, :import_development_from_orulo, current_user),
-         {:ok, _job} <- ReIntegrations.Orulo.get_building_payload(id) do
-      {:ok, %{message: "Development syncronization scheduled!"}}
+    with :ok <- Bodyguard.permit(Developments, :import_development_from_orulo, current_user) do
+      if Orulo.building_payload_synced?(id) do
+        case ReIntegrations.Orulo.get_building_payload(id) do
+          {:ok, _job} -> {:ok, %{message: "Development syncronization scheduled!"}}
+          {:error, error} -> {:error, error}
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Reject client request to sync new building if building payload already exists. So we don't reintroduce one building which was already inserted. 

This is partial, I need to solve the problem for the scenario: if two different clients send the request at the same time, so both will be accepted and one of failing on save development step (cause we have a constraint on developments). 

I see two different approaches here: 
- Add a unique constraint for `external_id` in `building_payloads` table, I'm no confident about this one cause we could keep the payloads to updates on this table as well (not done yet). 
- Or to check if a building payload already exists [on this multi](https://github.com/emcasa/backend/pull/594/files#diff-794db1e40f3a626f1d3f240c77626081R38), the problem is this one can also get a race condition once two different transactions can return false to `building_payload_exists?/1` at the same time, the timeframe here need to be tight to this situation happen, but still a possible issue. 

What do you think about this possible problem, should we solve this right now or expect it to be a "real problem" to deal with?  