### PR TITLE
Filters/add is release

### DIFF
--- a/apps/re/lib/listings/filters/filters.ex
+++ b/apps/re/lib/listings/filters/filters.ex
@@ -51,6 +51,7 @@ defmodule Re.Listings.Filters do
     field :max_price_per_area, :float
     field :min_maintenance_fee, :float
     field :max_maintenance_fee, :float
+    field :is_release, :boolean
   end
 
   @filters ~w(max_price min_price max_rooms min_rooms max_suites min_suites min_area max_area
@@ -59,7 +60,7 @@ defmodule Re.Listings.Filters do
               exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
               min_unit_per_floor max_unit_per_floor orientations sun_periods min_age max_age
               min_price_per_area max_price_per_area min_maintenance_fee max_maintenance_fee
-              max_bathrooms min_bathrooms)a
+              max_bathrooms min_bathrooms is_release)a
 
   def changeset(struct, params \\ %{}), do: cast(struct, params, @filters)
 
@@ -347,6 +348,13 @@ defmodule Re.Listings.Filters do
     from(
       l in query,
       where: l.maintenance_fee <= ^maintenance_fee
+    )
+  end
+
+  defp attr_filter({:is_release, is_release}, query) do
+    from(
+      l in query,
+      where: l.is_release == ^is_release
     )
   end
 

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -30,7 +30,7 @@ defmodule Re.Listing do
     field :is_active, :boolean, default: false
     field :status, :string, default: "inactive"
     field :is_exclusive, :boolean, default: false
-    field :is_release, :boolean
+    field :is_release, :boolean, default: false
     field :is_exportable, :boolean, default: true
     field :orientation, :string
     field :floor_count, :integer

--- a/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
+++ b/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
@@ -4,15 +4,8 @@ defmodule Re.Repo.Migrations.UpdateIsReleaseOnListings do
   require Ecto.Query
 
   def up do
-    listing_ids =
-      "listings"
-      |> Ecto.Query.from([l], select: l.id, where: is_nil(l.is_release))
-      |> Re.Repo.all()
-
     "listings"
-    |> Ecto.Query.from([l],
-      where: l.id in ^listing_ids
-    )
+    |> Ecto.Query.where([l], is_nil(l.is_release))
     |> Re.Repo.update_all(set: [is_release: false])
   end
 

--- a/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
+++ b/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
@@ -1,0 +1,19 @@
+defmodule Re.Repo.Migrations.UpdateIsReleaseOnListings do
+  use Ecto.Migration
+
+  require Ecto.Query
+
+  def up do
+    listing_ids =
+      Ecto.Query.from(l in "listings", select: l.id, where: is_nil(l.is_release))
+      |> Re.Repo.all()
+
+    Ecto.Query.from(i in "listings",
+      where: i.id in ^listing_ids
+    )
+    |> Re.Repo.update_all(set: [is_release: false])
+  end
+
+  def down do
+  end
+end

--- a/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
+++ b/apps/re/priv/repo/migrations/20190610140649_update_is_release_on_listings.exs
@@ -5,11 +5,13 @@ defmodule Re.Repo.Migrations.UpdateIsReleaseOnListings do
 
   def up do
     listing_ids =
-      Ecto.Query.from(l in "listings", select: l.id, where: is_nil(l.is_release))
+      "listings"
+      |> Ecto.Query.from([l], select: l.id, where: is_nil(l.is_release))
       |> Re.Repo.all()
 
-    Ecto.Query.from(i in "listings",
-      where: i.id in ^listing_ids
+    "listings"
+    |> Ecto.Query.from([l],
+      where: l.id in ^listing_ids
     )
     |> Re.Repo.update_all(set: [is_release: false])
   end

--- a/apps/re/test/listings/filters/filters_test.exs
+++ b/apps/re/test/listings/filters/filters_test.exs
@@ -437,5 +437,31 @@ defmodule Re.Listings.FiltersTest do
     end
   end
 
+  describe "apply/2: filter by releases" do
+    test "filter listings which are releases" do
+      %{id: id} = insert(:listing, is_release: true)
+      insert(:listing, is_release: false)
+
+      result =
+        Listing
+        |> Filters.apply(%{is_release: true})
+        |> Repo.all()
+
+      assert_mapper_match([%{id: id}], result, &map_id/1)
+    end
+
+    test "filter listings which aren't releases" do
+      %{id: id} = insert(:listing, is_release: false)
+      insert(:listing, is_release: true)
+
+      result =
+        Listing
+        |> Filters.apply(%{is_release: false})
+        |> Repo.all()
+
+      assert_mapper_match([%{id: id}], result, &map_id/1)
+    end
+  end
+
   defp map_id(items), do: Enum.map(items, & &1.id)
 end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -427,6 +427,24 @@ defmodule Re.ListingsTest do
       "construction_year" => 2005
     }
 
+    test "should insert listing with defaults when has no values" do
+      address = insert(:address)
+      user = insert(:user, role: "user")
+      owner_contact = insert(:owner_contact)
+
+      assert {:ok, inserted_listing} =
+               Listings.insert(@insert_listing_params,
+                 address: address,
+                 user: user,
+                 owner_contact: owner_contact
+               )
+
+      assert retrieved_listing = Repo.get(Listing, inserted_listing.id)
+      assert retrieved_listing.uuid
+      assert retrieved_listing.is_release == false
+      assert retrieved_listing.is_exportable == true
+    end
+
     test "should insert with description size bigger than 255" do
       address = insert(:address)
       user = insert(:user, role: "user")

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -246,6 +246,7 @@ defmodule ReWeb.Types.Listing do
     field :max_price_per_area, :float
     field :min_maintenance_fee, :float
     field :max_maintenance_fee, :float
+    field :is_release, :boolean
   end
 
   object :listing_filter do
@@ -284,6 +285,7 @@ defmodule ReWeb.Types.Listing do
     field :max_age, :integer
     field :min_price_per_area, :float
     field :max_price_per_area, :float
+    field :is_release, :boolean
   end
 
   object :price_history do

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -329,7 +329,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         garage_type: "contract",
         tags: [tag_1],
         price_per_area: 12_222.22,
-        maintenance_fee: 120.0
+        maintenance_fee: 120.0,
+        is_release: false
       )
 
       insert(
@@ -666,7 +667,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           garage_type: "contract",
           tags: [tag_1, tag_2],
           price_per_area: 10_000.00,
-          maintenance_fee: 100.0
+          maintenance_fee: 100.0,
+          is_release: true
         )
 
       variables = %{
@@ -697,7 +699,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           "citiesSlug" => ["rio-de-janeiro"],
           "tagsSlug" => ["tag-1", "tag-2"],
           "minMaintenanceFee" => 90.0,
-          "maxMaintenanceFee" => 110.0
+          "maxMaintenanceFee" => 110.0,
+          "isRelease" => true
         }
       }
 


### PR DESCRIPTION
Add filter to new/used listings. Frontend use to infer this rule from `developments` associations, it works but could cause some bad dependencies in the future. 

We already set all releases from developments with `is_release: true` but old ones don't use to be set. I'm setting the default for `is_release` as false now to use this attribute as a filter to differentiate primary and secondary market.  

Also, this PR made me see how confuse our test on listings query with filters is, I'll take some time to refactor trying to make it simple, and transfer the logic tested there to `filters_test` ... 