### PR TITLE
sync typologies

### DIFF
--- a/apps/re/test/support/custom_assertion.ex
+++ b/apps/re/test/support/custom_assertion.ex
@@ -14,4 +14,21 @@ defmodule Re.CustomAssertion do
                Enum.sort(unquote(key_func).(unquote(right)))
     end
   end
+
+  @doc """
+  Function to check if a job was enqueued.
+    ## Options
+
+    * `:count` - Number of jobs of a given type, default is 1.
+  """
+  defmacro assert_enqueued_job(enqueued_jobs, expected_job_name, count \\ 1) do
+    quote do
+      expected_jobs =
+        Enum.filter(unquote(enqueued_jobs), fn %{params: %{"type" => job_type}} ->
+          job_type == unquote(expected_job_name)
+        end)
+
+      assert Enum.count(expected_jobs) == unquote(count)
+    end
+  end
 end

--- a/apps/re_integrations/lib/orulo/client.ex
+++ b/apps/re_integrations/lib/orulo/client.ex
@@ -23,6 +23,12 @@ defmodule ReIntegrations.Orulo.Client do
     |> @http_client.get(@api_headers)
   end
 
+  def get_typologies(id) do
+    @base_url
+    |> build_uri("buildings/#{id}/typologies")
+    |> @http_client.get(@api_headers)
+  end
+
   def build_uri(url, type) do
     url
     |> URI.parse()

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -37,6 +37,17 @@ defmodule ReIntegrations.Orulo.JobQueue do
     end
   end
 
+  def perform(%Multi{} = multi, %{"type" => "fetch_typology", "external_id" => id}) do
+    with {:ok, %{body: body}} <- Client.get_typologies(id),
+         {:ok, payload} <- Jason.decode(body),
+         {:ok, _} <-
+           Orulo.insert_typologies_payload(multi, %{external_id: id, payload: payload}) do
+    else
+      {:error, error} -> Logger.error(error)
+      error -> Logger.error(error)
+    end
+  end
+
   def perform(%Multi{} = multi, %{"type" => "parse_building_into_development", "uuid" => uuid}) do
     PayloadProcessor.insert_development_from_building_payload(multi, uuid)
   end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -21,8 +21,7 @@ defmodule ReIntegrations.Orulo.JobQueue do
          {:ok, _} <-
            Orulo.multi_building_payload_insert(multi, %{external_id: id, payload: payload}) do
     else
-      {:error, error} -> Logger.error(error)
-      error -> Logger.error(error)
+      error -> Logger.error("Error on building request: #{Kernel.inspect(error)}")
     end
   end
 
@@ -32,22 +31,21 @@ defmodule ReIntegrations.Orulo.JobQueue do
          {:ok, _} <-
            Orulo.multi_images_payload_insert(multi, %{external_id: id, payload: payload}) do
     else
-      {:error, error} -> Logger.error(error)
-      error -> Logger.error(error)
+      error -> Logger.error("Error on image request: #{Kernel.inspect(error)}")
     end
   end
 
   def perform(%Multi{} = multi, %{"type" => "fetch_typology", "building_id" => id}) do
     with {:ok, %{body: body}} <- Client.get_typologies(id),
          {:ok, payload} <- Jason.decode(body),
-         {:ok, _} <-
+         {:ok, new_typology_payload} <-
            Orulo.insert_typologies_payload(multi, %{
              building_id: Integer.to_string(id),
              payload: payload
            }) do
+      {:ok, new_typology_payload}
     else
-      {:error, error} -> Logger.error(error)
-      error -> Logger.error(error)
+      error -> Logger.error("Error on typology request:  #{Kernel.inspect(error)}")
     end
   end
 

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -37,11 +37,14 @@ defmodule ReIntegrations.Orulo.JobQueue do
     end
   end
 
-  def perform(%Multi{} = multi, %{"type" => "fetch_typology", "external_id" => id}) do
+  def perform(%Multi{} = multi, %{"type" => "fetch_typology", "building_id" => id}) do
     with {:ok, %{body: body}} <- Client.get_typologies(id),
          {:ok, payload} <- Jason.decode(body),
          {:ok, _} <-
-           Orulo.insert_typologies_payload(multi, %{external_id: id, payload: payload}) do
+           Orulo.insert_typologies_payload(multi, %{
+             building_id: Integer.to_string(id),
+             payload: payload
+           }) do
     else
       {:error, error} -> Logger.error(error)
       error -> Logger.error(error)

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -8,6 +8,7 @@ defmodule ReIntegrations.Orulo do
   alias ReIntegrations.{
     Orulo.BuildingPayload,
     Orulo.ImagePayload,
+    Orulo.TypologyPayload,
     Orulo.JobQueue,
     Repo
   }
@@ -54,6 +55,22 @@ defmodule ReIntegrations.Orulo do
     |> Multi.insert(:insert_images_payload, changeset)
     |> JobQueue.enqueue(:parse_images_job, %{
       "type" => "parse_images_payloads_into_images",
+      "uuid" => uuid
+    })
+    |> Repo.transaction()
+  end
+
+  def insert_typology_payload(multi, params) do
+    changeset =
+      %TypologyPayload{}
+      |> TypologyPayload.changeset(params)
+
+    uuid = Changeset.get_field(changeset, :uuid)
+
+    multi
+    |> Multi.insert(:insert_typologies_payload, changeset)
+    |> JobQueue.enqueue(:fetch_units_job, %{
+      "type" => "fetch_units",
       "uuid" => uuid
     })
     |> Repo.transaction()

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -3,7 +3,7 @@ defmodule ReIntegrations.Orulo do
   Context module to use importers.
   """
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [where: 2]
 
   alias ReIntegrations.{
     Orulo.BuildingPayload,
@@ -60,9 +60,8 @@ defmodule ReIntegrations.Orulo do
   end
 
   def building_payload_synced?(external_id) do
-    # credo:disable-for-lines:3
-    (bp in BuildingPayload)
-    |> from(where: bp.external_id == ^external_id)
+    BuildingPayload
+    |> where(external_id: ^external_id)
     |> Repo.exists?()
   end
 end

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -60,7 +60,7 @@ defmodule ReIntegrations.Orulo do
     |> Repo.transaction()
   end
 
-  def insert_typology_payload(multi, params) do
+  def insert_typologies_payload(multi, params) do
     changeset =
       %TypologyPayload{}
       |> TypologyPayload.changeset(params)

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -65,14 +65,8 @@ defmodule ReIntegrations.Orulo do
       %TypologyPayload{}
       |> TypologyPayload.changeset(params)
 
-    uuid = Changeset.get_field(changeset, :uuid)
-
     multi
     |> Multi.insert(:insert_typologies_payload, changeset)
-    |> JobQueue.enqueue(:fetch_units_job, %{
-      "type" => "fetch_units",
-      "uuid" => uuid
-    })
     |> Repo.transaction()
   end
 

--- a/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
@@ -19,7 +19,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
     |> insert_development(building)
     |> enqueue_image_job(building)
     |> enqueue_tag_job(building)
-    |> enqueue_units_job(building)
+    |> enqueue_typology_job(building)
     |> Repo.transaction()
   end
 
@@ -53,7 +53,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
     })
   end
 
-  defp enqueue_units_job(multi, building) do
+  defp enqueue_typology_job(multi, building) do
     JobQueue.enqueue(multi, :fetch_typologies, %{
       "type" => "fetch_typologies",
       "external_id" => building.external_id

--- a/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
@@ -19,6 +19,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
     |> insert_development(building)
     |> enqueue_image_job(building)
     |> enqueue_tag_job(building)
+    |> enqueue_units_job(building)
     |> Repo.transaction()
   end
 
@@ -48,6 +49,13 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
   defp enqueue_tag_job(multi, building) do
     JobQueue.enqueue(multi, :process_tags, %{
       "type" => "process_orulo_tags",
+      "external_id" => building.uuid
+    })
+  end
+
+  defp enqueue_units_job(multi, building) do
+    JobQueue.enqueue(multi, :fetch_units, %{
+      "type" => "fetch_typologies",
       "external_id" => building.uuid
     })
   end

--- a/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
@@ -54,9 +54,9 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
   end
 
   defp enqueue_units_job(multi, building) do
-    JobQueue.enqueue(multi, :fetch_units, %{
+    JobQueue.enqueue(multi, :fetch_typologies, %{
       "type" => "fetch_typologies",
-      "external_id" => building.uuid
+      "external_id" => building.external_id
     })
   end
 end

--- a/apps/re_integrations/lib/orulo/typology_payload.ex
+++ b/apps/re_integrations/lib/orulo/typology_payload.ex
@@ -10,13 +10,13 @@ defmodule ReIntegrations.Orulo.TypologyPayload do
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
   schema "orulo_typology_payloads" do
-    field :external_id, :integer
+    field :building_id, :string
     field :payload, :map
 
     timestamps()
   end
 
-  @required ~w(external_id payload)a
+  @required ~w(building_id payload)a
 
   def changeset(struct, params \\ %{}) do
     struct

--- a/apps/re_integrations/lib/orulo/typology_payload.ex
+++ b/apps/re_integrations/lib/orulo/typology_payload.ex
@@ -1,0 +1,29 @@
+defmodule ReIntegrations.Orulo.TypologyPayload do
+  @moduledoc """
+  Schema for Orulo typology sincronization
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @schema_prefix "re_integrations"
+  @primary_key {:uuid, :binary_id, autogenerate: false}
+
+  schema "orulo_typology_payloads" do
+    field :external_id, :integer
+    field :payload, :map
+
+    timestamps()
+  end
+
+  @required ~w(external_id payload)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required)
+    |> validate_required(@required)
+    |> generate_uuid()
+  end
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
+end

--- a/apps/re_integrations/priv/repo/migrations/20190611173927_create_orulo_typology_payload.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190611173927_create_orulo_typology_payload.exs
@@ -1,0 +1,12 @@
+defmodule ReIntegrations.Repo.Migrations.OruloCreateTypologyPayload do
+  use Ecto.Migration
+
+  def change do
+    create table(:orulo_typology_payloads, primary_key: false) do
+      add :uuid, :uuid, primary_key: true
+      add :external_id, :integer
+      add :payload, :map, null: false, default: %{}
+      timestamps()
+    end
+  end
+end

--- a/apps/re_integrations/priv/repo/migrations/20190611173927_create_orulo_typology_payload.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190611173927_create_orulo_typology_payload.exs
@@ -4,7 +4,7 @@ defmodule ReIntegrations.Repo.Migrations.OruloCreateTypologyPayload do
   def change do
     create table(:orulo_typology_payloads, primary_key: false) do
       add :uuid, :uuid, primary_key: true
-      add :external_id, :integer
+      add :building_id, :string
       add :payload, :map, null: false, default: %{}
       timestamps()
     end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -71,7 +71,7 @@ defmodule ReIntegrations.OruloTest do
       params = %{external_id: 666, payload: %{test: "typology_payload"}}
 
       assert {:ok, %{insert_typologies_payload: payload}} =
-               Orulo.insert_typology_payload(Multi.new(), params)
+               Orulo.insert_typologies_payload(Multi.new(), params)
 
       assert payload.uuid
       assert payload.external_id == 666
@@ -80,7 +80,7 @@ defmodule ReIntegrations.OruloTest do
 
     test "enqueue a new fetch_units job" do
       params = %{external_id: 666, payload: %{test: "images_payload"}}
-      assert {:ok, _} = Orulo.insert_typology_payload(Multi.new(), params)
+      assert {:ok, _} = Orulo.insert_typologies_payload(Multi.new(), params)
 
       enqueued_jobs = Repo.all(JobQueue)
       assert_enqueued_job(enqueued_jobs, "fetch_units")

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -1,7 +1,6 @@
 defmodule ReIntegrations.OruloTest do
   @moduledoc false
 
-  import Re.CustomAssertion
   import ReIntegrations.Factory
 
   use ReIntegrations.ModelCase
@@ -76,14 +75,6 @@ defmodule ReIntegrations.OruloTest do
       assert payload.uuid
       assert payload.building_id == "666"
       assert payload.payload == %{test: "typology_payload"}
-    end
-
-    test "enqueue a new fetch_units job" do
-      params = %{building_id: "666", payload: %{test: "images_payload"}}
-      assert {:ok, _} = Orulo.insert_typologies_payload(Multi.new(), params)
-
-      enqueued_jobs = Repo.all(JobQueue)
-      assert_enqueued_job(enqueued_jobs, "fetch_units")
     end
   end
 

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -1,6 +1,7 @@
 defmodule ReIntegrations.OruloTest do
   @moduledoc false
 
+  import Re.CustomAssertion
   import ReIntegrations.Factory
 
   use ReIntegrations.ModelCase
@@ -62,6 +63,27 @@ defmodule ReIntegrations.OruloTest do
       assert {:ok, _} = Orulo.multi_images_payload_insert(Multi.new(), params)
 
       assert Repo.one(JobQueue)
+    end
+  end
+
+  describe "insert_typology_payload/2" do
+    test "create new typology payload" do
+      params = %{external_id: 666, payload: %{test: "typology_payload"}}
+
+      assert {:ok, %{insert_typologies_payload: payload}} =
+               Orulo.insert_typology_payload(Multi.new(), params)
+
+      assert payload.uuid
+      assert payload.external_id == 666
+      assert payload.payload == %{test: "typology_payload"}
+    end
+
+    test "enqueue a new fetch_units job" do
+      params = %{external_id: 666, payload: %{test: "images_payload"}}
+      assert {:ok, _} = Orulo.insert_typology_payload(Multi.new(), params)
+
+      enqueued_jobs = Repo.all(JobQueue)
+      assert_enqueued_job(enqueued_jobs, "fetch_units")
     end
   end
 

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -68,18 +68,18 @@ defmodule ReIntegrations.OruloTest do
 
   describe "insert_typology_payload/2" do
     test "create new typology payload" do
-      params = %{external_id: 666, payload: %{test: "typology_payload"}}
+      params = %{building_id: "666", payload: %{test: "typology_payload"}}
 
       assert {:ok, %{insert_typologies_payload: payload}} =
                Orulo.insert_typologies_payload(Multi.new(), params)
 
       assert payload.uuid
-      assert payload.external_id == 666
+      assert payload.building_id == "666"
       assert payload.payload == %{test: "typology_payload"}
     end
 
     test "enqueue a new fetch_units job" do
-      params = %{external_id: 666, payload: %{test: "images_payload"}}
+      params = %{building_id: "666", payload: %{test: "images_payload"}}
       assert {:ok, _} = Orulo.insert_typologies_payload(Multi.new(), params)
 
       enqueued_jobs = Repo.all(JobQueue)

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -57,7 +57,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert development.builder == Map.get(developer, "name")
     end
 
-    test "enqueue fetch images and process tag and units jobs" do
+    test "enqueue fetch images, fetch typologies and process tag jobs" do
       building = build(:building_payload)
 
       %{uuid: uuid} =

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -13,6 +13,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
 
   alias Ecto.Multi
 
+  import Re.CustomAssertion
   import ReIntegrations.Factory
 
   describe "insert_development_from_building_payload/1" do
@@ -56,7 +57,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert development.builder == Map.get(developer, "name")
     end
 
-    test "enqueue fetch images and process tag jobs" do
+    test "enqueue fetch images and process tag and units jobs" do
       building = build(:building_payload)
 
       %{uuid: uuid} =
@@ -67,7 +68,11 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert {:ok, _} =
                PayloadProcessor.insert_development_from_building_payload(Multi.new(), uuid)
 
-      assert 2 == Enum.count(Repo.all(JobQueue))
+      enqueued_jobs = Repo.all(JobQueue)
+
+      assert_enqueued_job(enqueued_jobs, "fetch_images_from_orulo")
+      assert_enqueued_job(enqueued_jobs, "process_orulo_tags")
+      assert_enqueued_job(enqueued_jobs, "fetch_typologies")
     end
   end
 


### PR DESCRIPTION
Get payloads for a building's typology.

Some late fixes: 
- Alter the id from `integer` to `string` and change the name from `external_id` to `building_id` to be more specific about what object we're referring (I'll replicate the changes for the other payloads before start to use in prod).  

Other: 
- Add a helper to test specific jobs enqueued, don't know if it's the best approach, but help to false positives while testing jobs. 