### PR TITLE
Send 'empty' name when wasn't provided

### DIFF
--- a/apps/re/lib/buyer_leads/empty_search.ex
+++ b/apps/re/lib/buyer_leads/empty_search.ex
@@ -50,7 +50,7 @@ defmodule Re.BuyerLeads.EmptySearch do
 
   def buyer_lead_changeset(lead) do
     BuyerLead.changeset(%BuyerLead{}, %{
-      name: lead.user.name,
+      name: lead.user.name || "empty",
       email: lead.user.email,
       phone_number: lead.user.phone,
       origin: "site",

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -423,5 +423,31 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.location == "new-york|ny"
       assert buyer.url == "https://www.emcasa.com/imoveis/ny/new-york"
     end
+
+    test "proecss lead with nil name" do
+      %{uuid: user_uuid} = insert(:user, phone: "+5511999999999", name: nil)
+
+      %{uuid: uuid} =
+        insert(:empty_search_buyer_lead,
+          user_uuid: user_uuid,
+          city: "New York",
+          city_slug: "new-york",
+          state: "NY",
+          state_slug: "ny",
+          url: "https://www.emcasa.com/imoveis/ny/new-york"
+        )
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "process_empty_search_buyer_lead",
+                 "uuid" => uuid
+               })
+
+      assert buyer = Repo.one(BuyerLead)
+      assert buyer.uuid
+      assert buyer.user_uuid == user_uuid
+      assert buyer.location == "new-york|ny"
+      assert buyer.url == "https://www.emcasa.com/imoveis/ny/new-york"
+    end
   end
 end


### PR DESCRIPTION
The new `empty_search_buyer_lead` form in the frontend was added without asking for name, so sending an `empty` value for now until it's provided.