### PR TITLE
Add user url to buyer leads

### DIFF
--- a/apps/re/lib/accounts/users.ex
+++ b/apps/re/lib/accounts/users.ex
@@ -55,13 +55,4 @@ defmodule Re.Accounts.Users do
     |> Repo.preload(favorited: [:images])
     |> Map.get(:favorited)
   end
-
-  @garagem_url Application.get_env(:re, :garagem_url, "localhost")
-
-  def build_user_url(%{id: id}) do
-    @garagem_url
-    |> URI.parse()
-    |> URI.merge("usuarios/#{id}")
-    |> URI.to_string()
-  end
 end

--- a/apps/re/lib/accounts/users.ex
+++ b/apps/re/lib/accounts/users.ex
@@ -55,4 +55,13 @@ defmodule Re.Accounts.Users do
     |> Repo.preload(favorited: [:images])
     |> Map.get(:favorited)
   end
+
+  @garagem_url Application.get_env(:re, :garagem_url, "localhost")
+
+  def build_user_url(%{id: id}) do
+    @garagem_url
+    |> URI.parse()
+    |> URI.merge("usuarios/#{id}")
+    |> URI.to_string()
+  end
 end

--- a/apps/re/lib/accounts/users.ex
+++ b/apps/re/lib/accounts/users.ex
@@ -55,4 +55,13 @@ defmodule Re.Accounts.Users do
     |> Repo.preload(favorited: [:images])
     |> Map.get(:favorited)
   end
+
+  @garagem_url Application.get_env(:re, :garagem_url, "localhost")
+
+  def build_user_url(%{id: id}) do
+    @garagem_url
+    |> URI.parse()
+    |> URI.merge("/usuarios/#{id}")
+    |> URI.to_string()
+  end
 end

--- a/apps/re/lib/buyer_leads/budget.ex
+++ b/apps/re/lib/buyer_leads/budget.ex
@@ -8,7 +8,10 @@ defmodule Re.BuyerLeads.Budget do
 
   require Logger
 
-  alias Re.BuyerLead
+  alias Re.{
+    Accounts.Users,
+    BuyerLead
+  }
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
@@ -60,7 +63,8 @@ defmodule Re.BuyerLeads.Budget do
       location: "#{lead.city_slug}|#{lead.state_slug}",
       budget: lead.budget,
       user_uuid: lead.user_uuid,
-      neighborhood: lead.neighborhood
+      neighborhood: lead.neighborhood,
+      user_url: Users.build_user_url(lead.user)
     })
   end
 end

--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -17,6 +17,7 @@ defmodule Re.BuyerLead do
     field :budget, :string
     field :neighborhood, :string
     field :url, :string
+    field :user_url, :string
 
     belongs_to :listing, Re.Listing,
       references: :uuid,
@@ -32,7 +33,7 @@ defmodule Re.BuyerLead do
   end
 
   @required ~w(name phone_number origin)a
-  @optional ~w(email location listing_uuid user_uuid budget neighborhood url)a
+  @optional ~w(email location listing_uuid user_uuid budget neighborhood url user_url)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/buyer_leads/empty_search.ex
+++ b/apps/re/lib/buyer_leads/empty_search.ex
@@ -6,7 +6,10 @@ defmodule Re.BuyerLeads.EmptySearch do
 
   import Ecto.Changeset
 
-  alias Re.BuyerLead
+  alias Re.{
+    Accounts.Users,
+    BuyerLead
+  }
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
@@ -56,7 +59,8 @@ defmodule Re.BuyerLeads.EmptySearch do
       origin: "site",
       location: "#{lead.city_slug}|#{lead.state_slug}",
       user_uuid: lead.user_uuid,
-      url: lead.url
+      url: lead.url,
+      user_url: Users.build_user_url(lead.user)
     })
   end
 end

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -11,7 +11,8 @@ defmodule Re.BuyerLeads.Facebook do
   alias Re.{
     Accounts.Users,
     BuyerLead,
-    BuyerLeads.FacebookClient
+    BuyerLeads.FacebookClient,
+    Listings
   }
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
@@ -49,46 +50,64 @@ defmodule Re.BuyerLeads.Facebook do
   def buyer_lead_changeset(nil), do: raise("Leads.FacebookBuyer not found")
 
   def buyer_lead_changeset(lead) do
-    {:ok, listing_uuid} = extract_listing_uuid(lead.lead_id)
+    params =
+      %{
+        name: lead.full_name,
+        email: lead.email,
+        phone_number: lead.phone_number,
+        origin: "facebook",
+        budget: lead.budget,
+        neighborhood: lead.neighborhoods
+      }
+      |> put_location(lead)
+      |> put_user_info(lead)
 
-    BuyerLead.changeset(%BuyerLead{}, %{
-      name: lead.full_name,
-      email: lead.email,
-      phone_number: lead.phone_number,
-      origin: "facebook",
-      location: get_location(lead.location),
-      budget: lead.budget,
-      user_uuid: extract_user_uuid(lead.phone_number),
-      listing_uuid: listing_uuid,
-      neighborhood: lead.neighborhoods
-    })
+    BuyerLead.changeset(%BuyerLead{}, params)
+  end
+
+  defp put_location(params, %{lead_id: lead_id, location: location}) do
+    lead_id
+    |> get_listing()
+    |> case do
+      {:ok, %{address: address} = listing} ->
+        params
+        |> Map.put(:location, "#{address.city_slug}|#{address.state_slug}")
+        |> Map.put(:listing_uuid, listing.uuid)
+
+      {:error, _} ->
+        Map.put(params, :location, get_location(location))
+    end
+  end
+
+  defp put_user_info(params, %{phone_number: nil}), do: params
+
+  defp put_user_info(params, %{phone_number: phone_number}) do
+    case Users.get_by_phone(phone_number) do
+      {:ok, user} ->
+        Map.put(params, :user_uuid, user.uuid)
+
+      {:error, :not_found} ->
+        params
+    end
+    |> Map.put(:phone_number, phone_number)
   end
 
   defp get_location("SP"), do: "sao-paulo|sp"
   defp get_location("RJ"), do: "rio-de-janeiro|rj"
   defp get_location(_), do: "unknown"
 
-  defp extract_user_uuid(nil), do: nil
-
-  defp extract_user_uuid(phone_number) do
-    case Users.get_by_phone(phone_number) do
-      {:ok, user} -> user.uuid
-      _error -> nil
+  defp get_listing(lead_id) do
+    with {:ok, %{body: body}} <- FacebookClient.get_lead(lead_id),
+         {:ok, listing_id} <- get_retailer_item_id(body) do
+      Listings.get_partial_preloaded(listing_id, [:address])
     end
   end
 
-  defp extract_listing_uuid(lead_id) do
-    with {:ok, %{body: body}} <- FacebookClient.get_lead(lead_id),
-         {:ok, %{"retailer_item_id" => listing_id}} <- Jason.decode(body),
-         {:ok, listing} <- Re.Listings.get(listing_id) do
-      {:ok, listing.uuid}
-    else
-      error ->
-        Sentry.capture_message("error when processing facebook buyer lead",
-          extra: %{lead_id: lead_id, error: error}
-        )
-
-        {:ok, nil}
+  defp get_retailer_item_id(body) do
+    case Jason.decode(body) do
+      {:ok, %{"retailer_item_id" => listing_id}} -> {:ok, listing_id}
+      {:ok, _} -> {:error, :not_found}
+      error -> error
     end
   end
 end

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -84,7 +84,9 @@ defmodule Re.BuyerLeads.Facebook do
   defp put_user_info(params, %{phone_number: phone_number}) do
     case Users.get_by_phone(phone_number) do
       {:ok, user} ->
-        Map.put(params, :user_uuid, user.uuid)
+        params
+        |> Map.put(:user_uuid, user.uuid)
+        |> Map.put(:user_url, Users.build_user_url(user))
 
       {:error, :not_found} ->
         params

--- a/apps/re/lib/buyer_leads/facebook.ex
+++ b/apps/re/lib/buyer_leads/facebook.ex
@@ -82,7 +82,9 @@ defmodule Re.BuyerLeads.Facebook do
   defp put_user_info(params, %{phone_number: nil}), do: params
 
   defp put_user_info(params, %{phone_number: phone_number}) do
-    case Users.get_by_phone(phone_number) do
+    phone_number
+    |> Users.get_by_phone()
+    |> case do
       {:ok, user} ->
         params
         |> Map.put(:user_uuid, user.uuid)

--- a/apps/re/lib/buyer_leads/grupozap.ex
+++ b/apps/re/lib/buyer_leads/grupozap.ex
@@ -79,8 +79,13 @@ defmodule Re.BuyerLeads.Grupozap do
     phone_number
     |> Users.get_by_phone()
     |> case do
-      {:ok, user} -> Map.put(params, :user_uuid, user.uuid)
-      {:error, :not_found} -> params
+      {:ok, user} ->
+        params
+        |> Map.put(:user_uuid, user.uuid)
+        |> Map.put(:user_url, Users.build_user_url(user))
+
+      {:error, :not_found} ->
+        params
     end
     |> Map.put(:phone_number, phone_number)
   end

--- a/apps/re/lib/buyer_leads/grupozap.ex
+++ b/apps/re/lib/buyer_leads/grupozap.ex
@@ -47,21 +47,21 @@ defmodule Re.BuyerLeads.Grupozap do
 
   def buyer_lead_changeset(nil), do: raise("Leads.GrupozapBuyer not found")
 
-  def buyer_lead_changeset(gzb) do
+  def buyer_lead_changeset(lead) do
     params =
       %{
-        name: gzb.name,
-        email: gzb.email,
-        origin: gzb.lead_origin
+        name: lead.name,
+        email: lead.email,
+        origin: lead.lead_origin
       }
-      |> put_location(gzb)
-      |> put_user_info(gzb)
+      |> put_location(lead)
+      |> put_user_info(lead)
 
     BuyerLead.changeset(%BuyerLead{}, params)
   end
 
-  defp put_location(params, gzb) do
-    case Listings.get_partial_preloaded(gzb.client_listing_id, [:address]) do
+  defp put_location(params, lead) do
+    case Listings.get_partial_preloaded(lead.client_listing_id, [:address]) do
       {:ok, %{address: address} = listing} ->
         params
         |> Map.put(:location, "#{address.city_slug}|#{address.state_slug}")
@@ -73,8 +73,8 @@ defmodule Re.BuyerLeads.Grupozap do
     end
   end
 
-  defp put_user_info(params, gzb) do
-    phone_number = concat_phone_number(gzb)
+  defp put_user_info(params, lead) do
+    phone_number = concat_phone_number(lead)
 
     phone_number
     |> Users.get_by_phone()

--- a/apps/re/lib/buyer_leads/grupozap.ex
+++ b/apps/re/lib/buyer_leads/grupozap.ex
@@ -48,42 +48,46 @@ defmodule Re.BuyerLeads.Grupozap do
   def buyer_lead_changeset(nil), do: raise("Leads.GrupozapBuyer not found")
 
   def buyer_lead_changeset(gzb) do
-    phone_number = concat_phone_number(gzb)
-    listing = Listings.get_partial_preloaded(gzb.client_listing_id, [:address])
+    params =
+      %{
+        name: gzb.name,
+        email: gzb.email,
+        origin: gzb.lead_origin
+      }
+      |> put_location(gzb)
+      |> put_user_info(gzb)
 
-    BuyerLead.changeset(%BuyerLead{}, %{
-      name: gzb.name,
-      email: gzb.email,
-      phone_number: phone_number,
-      origin: gzb.lead_origin,
-      location: get_location(listing),
-      user_uuid: extract_user_uuid(phone_number),
-      listing_uuid: get_listing_uuid(listing),
-      neighborhood: get_neighborhood(listing)
-    })
+    BuyerLead.changeset(%BuyerLead{}, params)
   end
 
-  defp get_location({:ok, %{address: address}}), do: "#{address.city_slug}|#{address.state_slug}"
-  defp get_location(_), do: "unknown"
+  defp put_location(params, gzb) do
+    case Listings.get_partial_preloaded(gzb.client_listing_id, [:address]) do
+      {:ok, %{address: address} = listing} ->
+        params
+        |> Map.put(:location, "#{address.city_slug}|#{address.state_slug}")
+        |> Map.put(:listing_uuid, listing.uuid)
+        |> Map.put(:neighborhood, address.neighborhood)
+
+      {:error, :not_found} ->
+        params
+    end
+  end
+
+  defp put_user_info(params, gzb) do
+    phone_number = concat_phone_number(gzb)
+
+    phone_number
+    |> Users.get_by_phone()
+    |> case do
+      {:ok, user} -> Map.put(params, :user_uuid, user.uuid)
+      {:error, :not_found} -> params
+    end
+    |> Map.put(:phone_number, phone_number)
+  end
 
   defp concat_phone_number(%{ddd: _ddd, phone: nil}), do: "not informed"
 
   defp concat_phone_number(%{ddd: nil, phone: phone}), do: "+55" <> phone
 
   defp concat_phone_number(%{ddd: ddd, phone: phone}), do: "+55" <> ddd <> phone
-
-  defp extract_user_uuid("not informed"), do: nil
-
-  defp extract_user_uuid(phone_number) do
-    case Users.get_by_phone(phone_number) do
-      {:ok, user} -> user.uuid
-      _error -> nil
-    end
-  end
-
-  defp get_listing_uuid({:ok, listing}), do: listing.uuid
-  defp get_listing_uuid(_), do: nil
-
-  defp get_neighborhood({:ok, %{address: address}}), do: address.neighborhood
-  defp get_neighborhood(_), do: nil
 end

--- a/apps/re/lib/buyer_leads/imovel_web.ex
+++ b/apps/re/lib/buyer_leads/imovel_web.ex
@@ -74,8 +74,13 @@ defmodule Re.BuyerLeads.ImovelWeb do
     phone_number
     |> Users.get_by_phone()
     |> case do
-      {:ok, user} -> Map.put(params, :user_uuid, user.uuid)
-      {:error, :not_found} -> params
+      {:ok, user} ->
+        params
+        |> Map.put(:user_uuid, user.uuid)
+        |> Map.put(:user_url, Users.build_user_url(user))
+
+      {:error, :not_found} ->
+        params
     end
     |> Map.put(:phone_number, phone_number)
   end

--- a/apps/re/lib/interests/interest.ex
+++ b/apps/re/lib/interests/interest.ex
@@ -72,15 +72,15 @@ defmodule Re.Interest do
 
     phone_number
     |> Users.get_by_phone()
-    |> case do
-      {:ok, user} ->
-        params
-        |> Map.put(:user_uuid, user.uuid)
-        |> Map.put(:user_url, Users.build_user_url(user))
-
-      {:error, :not_found} ->
-        params
-    end
+    |> do_put_user_info(params)
     |> Map.put(:phone_number, phone_number)
   end
+
+  defp do_put_user_info({:ok, user}, params) do
+    params
+    |> Map.put(:user_uuid, user.uuid)
+    |> Map.put(:user_url, Users.build_user_url(user))
+  end
+
+  defp do_put_user_info({:error, :not_found}, params), do: params
 end

--- a/apps/re/lib/interests/interest.ex
+++ b/apps/re/lib/interests/interest.ex
@@ -73,8 +73,13 @@ defmodule Re.Interest do
     phone_number
     |> Users.get_by_phone()
     |> case do
-      {:ok, user} -> Map.put(params, :user_uuid, user.uuid)
-      {:error, :not_found} -> params
+      {:ok, user} ->
+        params
+        |> Map.put(:user_uuid, user.uuid)
+        |> Map.put(:user_url, Users.build_user_url(user))
+
+      {:error, :not_found} ->
+        params
     end
     |> Map.put(:phone_number, phone_number)
   end

--- a/apps/re/priv/repo/migrations/20190613163352_add_user_url_buyer_leads.exs
+++ b/apps/re/priv/repo/migrations/20190613163352_add_user_url_buyer_leads.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddUserUrlBuyerLeads do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buyer_leads) do
+      add :user_url, :string
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -114,7 +114,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
   describe "facebook_buyer_lead" do
     test "process lead with existing user and listing" do
-      %{id: listing_id, uuid: listing_uuid} = insert(:listing)
+      %{id: listing_id, uuid: listing_uuid} = insert(:listing, address: address = build(:address))
       mock(HTTPoison, :get, {:ok, %{body: "{\"retailer_item_id\":\"#{listing_id}\"}"}})
       %{uuid: user_uuid} = insert(:user, phone: "+5511999999999")
 
@@ -133,12 +133,12 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
-      assert buyer.location == "sao-paulo|sp"
+      assert buyer.location == "#{address.city_slug}|#{address.state_slug}"
       assert buyer.budget == "$1000 to $10000"
     end
 
     test "process lead with nil phone" do
-      %{id: listing_id} = insert(:listing)
+      %{id: listing_id} = insert(:listing, address: build(:address))
 
       mock(HTTPoison, [get: 1], fn _ ->
         {:ok, %{body: "{\"retailer_item_id\":\"#{listing_id}\"}"}}
@@ -153,7 +153,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with no user" do
-      %{id: listing_id, uuid: listing_uuid} = insert(:listing)
+      %{id: listing_id, uuid: listing_uuid} = insert(:listing, address: build(:address))
 
       mock(HTTPoison, [get: 1], fn _ ->
         {:ok, %{body: "{\"retailer_item_id\":\"#{listing_id}\"}"}}
@@ -171,7 +171,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "process lead with unknown location" do
-      %{id: listing_id, uuid: listing_uuid} = insert(:listing)
+      %{id: listing_id, uuid: listing_uuid} = insert(:listing, address: address = build(:address))
 
       mock(HTTPoison, [get: 1], fn _ ->
         {:ok, %{body: "{\"retailer_item_id\":\"#{listing_id}\"}"}}
@@ -188,7 +188,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
-      assert buyer.location == "unknown"
+      assert buyer.location == "#{address.city_slug}|#{address.state_slug}"
     end
 
     test "process lead with invalid listing" do

--- a/config/dev.secret-example.exs
+++ b/config/dev.secret-example.exs
@@ -52,7 +52,8 @@ config :re,
   imovelweb_super_highlights_size_rio_de_janeiro: 10,
   imovelweb_super_highlights_size_sao_paulo: 10,
   imovelweb_identity: "1",
-  facebook_access_token: "FACEBOOK_ACCESS_TOKEN"
+  facebook_access_token: "FACEBOOK_ACCESS_TOKEN",
+  garagem_url: "localhost"
 
 config :account_kit,
   app_id: "your_dev_app_id",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -62,7 +62,8 @@ config :re,
   imovelweb_super_highlights_size_sao_paulo:
     String.to_integer(System.get_env("IMOVELWEB_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO")),
   imovelweb_identity: System.get_env("IMOVELWEB_IDENTITY"),
-  facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN")
+  facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN"),
+  garagem_url: System.get_env("GARAGEM_URL")
 
 config :re_integrations,
   to: System.get_env("INTEREST_NOTIFICATION_EMAILS"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -63,7 +63,8 @@ config :re,
   imovelweb_super_highlights_size_rio_de_janeiro: 5,
   imovelweb_super_highlights_size_sao_paulo: 5,
   imovelweb_identity: "1",
-  facebook_access_token: "testsecret"
+  facebook_access_token: "testsecret",
+  garagem_url: "http://localhost:3000"
 
 config :re_integrations,
   http: ReIntegrations.TestHTTP,


### PR DESCRIPTION
~The buyer leads processing was a little messy with a bunch of functions pattern matching possibly new values, so I grouped into `location` and `user`, reducing a little the branching conditions.
This was prompted by the necessity to add the user URL to buyer lead (incoming PR).~

Since the change itself was minuscule because of the refactoring, here it is altogether.