### PR TITLE
Persist price suggestion

### DIFF
--- a/apps/re/lib/application.ex
+++ b/apps/re/lib/application.ex
@@ -10,6 +10,7 @@ defmodule Re.Application do
   alias Re.{
     BuyerLeads,
     Developments,
+    Listings,
     Listings.History,
     PubSub,
     Repo,
@@ -36,6 +37,7 @@ defmodule Re.Application do
       worker(History.Server, []),
       worker(Visualizations, []),
       {BuyerLeads.JobQueue, repo: Repo},
-      {Developments.JobQueue, repo: Repo}
+      {Developments.JobQueue, repo: Repo},
+      {Listings.JobQueue, repo: Repo}
     ]
 end

--- a/apps/re/lib/buyer_leads/job_queue.ex
+++ b/apps/re/lib/buyer_leads/job_queue.ex
@@ -29,7 +29,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Grupozap.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(%Multi{} = multi, %{"type" => "facebook_buyer", "uuid" => uuid}) do
@@ -38,7 +38,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Facebook.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(%Multi{} = multi, %{"type" => "imovelweb_buyer", "uuid" => uuid}) do
@@ -47,7 +47,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> ImovelWeb.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(%Multi{} = multi, %{"type" => "interest", "uuid" => uuid}) do
@@ -57,7 +57,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Interest.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(%Multi{} = multi, %{"type" => "process_budget_buyer_lead", "uuid" => uuid}) do
@@ -67,7 +67,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Budget.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(%Multi{} = multi, %{"type" => "process_empty_search_buyer_lead", "uuid" => uuid}) do
@@ -77,7 +77,7 @@ defmodule Re.BuyerLeads.JobQueue do
     |> EmptySearch.buyer_lead_changeset()
     |> insert_buyer_lead(multi)
     |> Repo.transaction()
-    |> log_error()
+    |> handle_error()
   end
 
   def perform(_multi, job), do: raise("Job type not handled. Job: #{Kernel.inspect(job)}")
@@ -92,14 +92,14 @@ defmodule Re.BuyerLeads.JobQueue do
     |> Repo.transaction()
   end
 
-  defp log_error({:ok, result}), do: {:ok, result}
+  defp handle_error({:ok, result}), do: {:ok, result}
 
-  defp log_error(error) do
+  defp handle_error(error) do
     Sentry.capture_message("error when performing BuyerLeads.JobQueue",
       extra: %{error: error}
     )
 
-    error
+    raise "Error when performing BuyerLeads.JobQueue"
   end
 
   defp insert_buyer_lead(changeset, multi), do: Multi.insert(multi, :insert_buyer_lead, changeset)

--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -28,12 +28,12 @@ defmodule Re.Listings.JobQueue do
       error ->
         error
     end
-    |> log_error()
+    |> handle_error()
   end
 
-  defp log_error({:ok, result}), do: {:ok, result}
+  defp handle_error({:ok, result}), do: {:ok, result}
 
-  defp log_error(error) do
+  defp handle_error(error) do
     Sentry.capture_message("error when performing Listings.JobQueue",
       extra: %{error: error}
     )

--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -1,0 +1,41 @@
+defmodule Re.Listings.JobQueue do
+  @moduledoc """
+  Module for processing listings asynchronously
+  """
+  use EctoJob.JobQueue, table_name: "listings_jobs"
+
+  alias Re.{
+    Listing,
+    PriceSuggestions,
+    Repo
+  }
+
+  alias Ecto.Multi
+
+  def perform(%Multi{} = multi, %{"type" => "save_price_suggestion", "uuid" => uuid}) do
+    listing = Repo.get_by(Listing, uuid: uuid)
+
+    listing
+    |> PriceSuggestions.suggest_price()
+    |> case do
+      {:ok, suggested_price} ->
+        changeset = Listing.changeset(listing, %{suggested_price: suggested_price})
+        Multi.update(multi, :update_suggested_price, changeset)
+
+      _error ->
+        multi
+    end
+    |> Repo.transaction()
+    |> log_error()
+  end
+
+  defp log_error({:ok, result}), do: {:ok, result}
+
+  defp log_error(error) do
+    Sentry.capture_message("error when performing Listings.JobQueue",
+      extra: %{error: error}
+    )
+
+    error
+  end
+end

--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -20,12 +20,14 @@ defmodule Re.Listings.JobQueue do
     |> case do
       {:ok, suggested_price} ->
         changeset = Listing.changeset(listing, %{suggested_price: suggested_price})
-        Multi.update(multi, :update_suggested_price, changeset)
 
-      _error ->
         multi
+        |> Multi.update(:update_suggested_price, changeset)
+        |> Repo.transaction()
+
+      error ->
+        error
     end
-    |> Repo.transaction()
     |> log_error()
   end
 
@@ -36,6 +38,6 @@ defmodule Re.Listings.JobQueue do
       extra: %{error: error}
     )
 
-    error
+    raise "Error when performing Listings.JobQueue"
   end
 end

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -9,6 +9,7 @@ defmodule Re.Listings do
     Listings.Filters,
     Images,
     Listings.DataloaderQueries,
+    Listings.JobQueue,
     Listings.Opts,
     Listings.Queries,
     PubSub,
@@ -16,7 +17,10 @@ defmodule Re.Listings do
     Tags
   }
 
-  alias Ecto.Changeset
+  alias Ecto.{
+    Changeset,
+    Multi
+  }
 
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
@@ -133,9 +137,17 @@ defmodule Re.Listings do
   def activate(listing) do
     changeset = Changeset.change(listing, status: "active")
 
-    changeset
-    |> Repo.update()
-    |> PubSub.publish_update(changeset, "activate_listing")
+    Multi.new()
+    |> Multi.update(:activate_listing, changeset)
+    |> JobQueue.enqueue(:listing_job, %{"type" => "save_price_suggestion", "uuid" => listing.uuid})
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{activate_listing: listing}} ->
+        PubSub.publish_update({:ok, listing}, changeset, "activate_listing")
+
+      error ->
+        error
+    end
   end
 
   def per_user(user) do

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -43,6 +43,7 @@ defmodule Re.Listing do
     field :favorite_count, :integer, virtual: true
     field :interest_count, :integer, virtual: true
     field :in_person_visit_count, :integer, virtual: true
+    field :suggested_price, :float
 
     belongs_to :address, Re.Address
 
@@ -92,7 +93,7 @@ defmodule Re.Listing do
   @optional ~w(complement floor matterport_code is_exclusive status property_tax
                      maintenance_fee balconies restrooms is_release is_exportable
                      orientation floor_count unit_per_floor sun_period elevators
-                     construction_year owner_contact_uuid)a
+                     construction_year owner_contact_uuid suggested_price)a
 
   @attributes @required ++ @optional
   def changeset(struct, params) do

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -33,14 +33,12 @@ defmodule Re.PriceSuggestions do
     end
   end
 
-  def suggest_price(%Listing{suggested_price: nil} = listing) do
+  def suggest_price(%Listing{} = listing) do
     listing
     |> preload_address()
     |> do_suggest_price()
     |> persist_suggested_price(listing)
   end
-
-  def suggest_price(%Listing{suggested_price: suggested_price}), do: {:ok, suggested_price}
 
   def suggest_price(params), do: do_suggest_price(params)
 

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -33,11 +33,26 @@ defmodule Re.PriceSuggestions do
     end
   end
 
-  def suggest_price(params) do
-    params
+  def suggest_price(%Listing{suggested_price: nil} = listing) do
+    listing
     |> preload_address()
     |> do_suggest_price()
+    |> persist_suggested_price(listing)
   end
+
+  def suggest_price(%Listing{suggested_price: suggested_price}), do: {:ok, suggested_price}
+
+  def suggest_price(params), do: do_suggest_price(params)
+
+  defp persist_suggested_price({:ok, suggested_price}, listing) do
+    listing
+    |> Listing.changeset(%{suggested_price: suggested_price})
+    |> Repo.update()
+
+    {:ok, suggested_price}
+  end
+
+  defp persist_suggested_price(response, _), do: response
 
   defp do_suggest_price(params) do
     params

--- a/apps/re/priv/repo/migrations/20190613232155_create_listings_jobs.exs
+++ b/apps/re/priv/repo/migrations/20190613232155_create_listings_jobs.exs
@@ -1,0 +1,13 @@
+defmodule Re.Repo.Migrations.CreateListingsJobs do
+  use Ecto.Migration
+
+  alias EctoJob.Migrations.CreateJobTable
+
+  def up do
+    CreateJobTable.up("listings_jobs")
+  end
+
+  def down do
+    CreateJobTable.up("listings_jobs")
+  end
+end

--- a/apps/re/priv/repo/migrations/20190613232548_add_suggested_price_listing.exs
+++ b/apps/re/priv/repo/migrations/20190613232548_add_suggested_price_listing.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddSuggestedPriceListing do
+  use Ecto.Migration
+
+  def change do
+    alter table(:listings) do
+      add :suggested_price, :float
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -146,8 +146,9 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
       %{uuid: uuid} = insert(:facebook_buyer_lead, phone_number: nil)
 
-      assert {:error, :insert_buyer_lead, _, _} =
-               JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
+      assert_raise RuntimeError, fn ->
+        JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
+      end
 
       refute Repo.one(BuyerLead)
     end
@@ -285,8 +286,9 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
       %{uuid: uuid} = insert(:imovelweb_buyer_lead, phone: nil, listing_id: "#{id}")
 
-      assert {:error, :insert_buyer_lead, _, _} =
-               JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
+      assert_raise RuntimeError, fn ->
+        JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
+      end
 
       refute Repo.one(BuyerLead)
     end
@@ -348,8 +350,9 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
       %{uuid: uuid} = insert(:interest, listing: listing, phone: nil)
 
-      assert {:error, :insert_buyer_lead, _, _} =
-               JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
+      assert_raise RuntimeError, fn ->
+        JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
+      end
 
       refute Repo.one(BuyerLead)
     end

--- a/apps/re/test/listings/job_queue_test.exs
+++ b/apps/re/test/listings/job_queue_test.exs
@@ -1,0 +1,41 @@
+defmodule Re.Listings.JobQueueTest do
+  @moduledoc false
+  use Re.ModelCase
+
+  import Re.Factory
+
+  import Mockery
+
+  alias Re.{
+    Listing,
+    Listings.JobQueue,
+    Repo
+  }
+
+  alias Ecto.Multi
+
+  describe "perform/2" do
+    test "persist suggested price" do
+      mock(
+        HTTPoison,
+        :post,
+        {:ok,
+         %{
+           body:
+             "{\"sale_price_rounded\":575000.0,\"sale_price\":575910.45,\"listing_price_rounded\":635000.0,\"listing_price\":632868.63}"
+         }}
+      )
+
+      %{uuid: listing_uuid} = insert(:listing, address: build(:address))
+
+      assert {:ok, %{update_suggested_price: listing}} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "save_price_suggestion",
+                 "uuid" => listing_uuid
+               })
+
+      assert listing = Repo.get_by(Listing, uuid: listing_uuid)
+      assert listing.suggested_price == 635_000
+    end
+  end
+end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -521,6 +521,7 @@ defmodule Re.ListingsTest do
       Listings.update(listing, %{rooms: 4}, address: address, user: user)
 
       refute Repo.one(Re.Listings.PriceHistory)
+      assert Repo.one(JobQueue)
     end
 
     test "should update owner contact" do
@@ -539,6 +540,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.owner_contact_uuid == updated_owner_contact.uuid
+      assert Repo.one(JobQueue)
     end
 
     test "should update if owner contact is nil" do
@@ -555,6 +557,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.owner_contact_uuid == original_owner_contact.uuid
+      assert Repo.one(JobQueue)
     end
 
     test "should not change user who created listing" do
@@ -569,6 +572,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.user_id == original_user.id
+      assert Repo.one(JobQueue)
     end
   end
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -7,6 +7,7 @@ defmodule Re.ListingsTest do
     Listings.History.Server,
     Listing,
     Listings,
+    Listings.JobQueue,
     Repo
   }
 
@@ -392,6 +393,7 @@ defmodule Re.ListingsTest do
       assert listing.status == "active"
       status_history = Repo.one(Re.Listings.StatusHistory)
       assert "inactive" == status_history.status
+      assert Repo.one(JobQueue)
     end
   end
 

--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -190,6 +190,34 @@ defmodule Re.PriceSuggestionsTest do
       assert listing.suggested_price == 26_279.0
     end
 
+    test "should update suggest price for listing when there's one" do
+      %{uuid: uuid} =
+        listing =
+        insert(
+          :listing,
+          rooms: 2,
+          area: 80,
+          address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+          garage_spots: 1,
+          bathrooms: 1,
+          suggested_price: 1000.0
+        )
+
+      mock(
+        HTTPoison,
+        :post,
+        {:ok,
+         %{
+           body:
+             "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+         }}
+      )
+
+      assert {:ok, 26_279.0} == PriceSuggestions.suggest_price(listing)
+      listing = Repo.get_by(Listing, uuid: uuid)
+      assert listing.suggested_price == 26_279.0
+    end
+
     test "should not suggest for nil values" do
       mock(
         HTTPoison,

--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -8,6 +8,7 @@ defmodule Re.PriceSuggestionsTest do
   import ExUnit.CaptureLog
 
   alias Re.{
+    Listing,
     PriceSuggestions,
     PriceSuggestions.Factors
   }
@@ -158,16 +159,20 @@ defmodule Re.PriceSuggestionsTest do
                }
              ] = Repo.all(Factors)
     end
+  end
 
-    test "should suggest price for listing" do
-      listing =
+  describe "suggest_price/1" do
+    test "should suggest price for listing and persist it" do
+      %{uuid: uuid} =
+        listing =
         insert(
           :listing,
           rooms: 2,
           area: 80,
           address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
           garage_spots: 1,
-          bathrooms: 1
+          bathrooms: 1,
+          suggested_price: nil
         )
 
       mock(
@@ -181,10 +186,10 @@ defmodule Re.PriceSuggestionsTest do
       )
 
       assert {:ok, 26_279.0} == PriceSuggestions.suggest_price(listing)
+      listing = Repo.get_by(Listing, uuid: uuid)
+      assert listing.suggested_price == 26_279.0
     end
-  end
 
-  describe "suggest_price/1" do
     test "should not suggest for nil values" do
       mock(
         HTTPoison,

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -230,12 +230,14 @@ defmodule ReWeb.Resolvers.Listings do
     end
   end
 
-  defp do_suggest_price(listing) do
+  defp do_suggest_price(%{suggested_price: nil} = listing) do
     case PriceSuggestions.suggest_price(listing) do
       {:ok, suggested_price} -> {:ok, suggested_price}
       _error -> {:ok, nil}
     end
   end
+
+  defp do_suggest_price(%{suggested_price: suggested_price}), do: {:ok, suggested_price}
 
   def price_recently_reduced(listing, _, %{context: %{loader: loader}}) do
     params = %{

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -819,7 +819,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           area: 80,
           garage_spots: 1,
           bathrooms: 1,
-          inserted_at: ~N[2018-01-01 10:00:00]
+          inserted_at: ~N[2018-01-01 10:00:00],
+          suggested_price: 1000.00
         )
 
       %{id: related_id1} = insert(:listing, address: address, score: 4)
@@ -921,7 +922,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
                  %{"price" => price2},
                  %{"price" => price3}
                ],
-               "suggestedPrice" => 26_279.0,
+               "suggestedPrice" => 1000.0,
                "related" => %{
                  "listings" => [
                    %{"id" => to_string(related_id1)},
@@ -991,7 +992,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           area: 80,
           garage_spots: 1,
           bathrooms: 1,
-          inserted_at: ~N[2018-01-01 10:00:00]
+          inserted_at: ~N[2018-01-01 10:00:00],
+          suggested_price: nil
         )
 
       %{id: related_id1} = insert(:listing, address: address, score: 4)


### PR DESCRIPTION
Add an `ecto_job` for fetching and persisting suggested price when:
  - Listing is activated
  - Listing is updated

Also fetch and persist when listing is queried but `suggested_price` is `nil`

Listing insertion not handled since, in our current use cases, a listing is added barely empty at first.

This is sort of a middle-of-the-road workaround to avoid doing rate-limited/batch requests to priceteller since it's a lot of work for a one-time use.