### PR TITLE
Fetch typologies

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
 coverage:
   round: nearest
   precision: 3
+  status:
+      project:
+        default:
+          threshold: 0.3

--- a/apps/re/lib/developments/units/unit.ex
+++ b/apps/re/lib/developments/units/unit.ex
@@ -36,7 +36,7 @@ defmodule Re.Unit do
     timestamps()
   end
 
-  @garage_types ~w(contract condominium)
+  @garage_types ~w(contract condominium unknown)
   @statuses ~w(active inactive)
 
   @required ~w(price rooms bathrooms area garage_spots suites development_uuid status)a

--- a/apps/re/mix.exs
+++ b/apps/re/mix.exs
@@ -58,7 +58,7 @@ defmodule Re.Mixfile do
       {:jason, "~> 1.1"},
       {:ecto_job, "~> 2.0"},
       {:prometheus_ecto, "~> 1.4"},
-      {:mockery, "~> 2.3"}
+      {:mockery, "~> 2.3", runtime: false}
     ]
   end
 

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -111,7 +111,7 @@ defmodule Re.UnitTest do
                 [validation: :number, kind: :greater_than_or_equal_to, number: 0]}
 
       assert Keyword.get(changeset.errors, :garage_type) ==
-               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium)]}
+               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium unknown)]}
 
       assert Keyword.get(changeset.errors, :status) ==
                {"is invalid", [validation: :inclusion, enum: ~w(active inactive)]}

--- a/apps/re_integrations/lib/orulo/client.ex
+++ b/apps/re_integrations/lib/orulo/client.ex
@@ -3,8 +3,8 @@ defmodule ReIntegrations.Orulo.Client do
   Module to wripe orulo API logic
   """
 
-  @http_client Application.get_env(:re_integrations, :http_client, HTTPoison)
-  @base_url Application.get_env(:re_integrations, :orulo_url, "")
+  @http_client Application.get_env(:re_integrations, :http, HTTPoison)
+  @base_url Application.get_env(:re_integrations, :orulo_url, "http://localhost:3000")
   @api_token Application.get_env(:re_integrations, :orulo_api_token, "")
 
   @api_headers [{"Authorization", "Bearer #{@api_token}"}]
@@ -12,6 +12,12 @@ defmodule ReIntegrations.Orulo.Client do
   def get_building(id) when is_integer(id) do
     @base_url
     |> build_uri("buildings/#{id}")
+    |> @http_client.get(@api_headers)
+  end
+
+  def get_units(building_id, typology_id) do
+    @base_url
+    |> build_uri("buildings/#{building_id}/typologies/#{typology_id}/units")
     |> @http_client.get(@api_headers)
   end
 

--- a/apps/re_integrations/lib/orulo/client.ex
+++ b/apps/re_integrations/lib/orulo/client.ex
@@ -4,7 +4,7 @@ defmodule ReIntegrations.Orulo.Client do
   """
 
   @http_client Application.get_env(:re_integrations, :http, HTTPoison)
-  @base_url Application.get_env(:re_integrations, :orulo_url, "http://localhost:3000")
+  @base_url Application.get_env(:re_integrations, :orulo_url, "")
   @api_token Application.get_env(:re_integrations, :orulo_api_token, "")
 
   @api_headers [{"Authorization", "Bearer #{@api_token}"}]

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -10,7 +10,8 @@ defmodule ReIntegrations.Orulo.JobQueue do
   alias ReIntegrations.{
     Orulo,
     Orulo.Client,
-    Orulo.PayloadProcessor
+    Orulo.PayloadProcessor,
+    Orulo.TypologyPayload
   }
 
   alias Ecto.Multi
@@ -68,7 +69,7 @@ defmodule ReIntegrations.Orulo.JobQueue do
   end
 
   def perform(%Multi{} = multi, %{
-        "type" => "process_typologies",
+        "type" => "process_units",
         "uuid" => uuid
       }) do
     PayloadProcessor.process_typologies(multi, uuid)

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -87,6 +87,6 @@ defmodule ReIntegrations.Orulo.JobQueue do
       |> Enum.map(fn %{"id" => id} -> id end)
 
     responses = Orulo.get_units(building_id, typology_ids)
-    Orulo.bulk_insert_unit_payload_forking_multi(multi, building_id, responses)
+    Orulo.bulk_insert_unit_payloads(multi, building_id, responses)
   end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -86,6 +86,6 @@ defmodule ReIntegrations.Orulo.JobQueue do
       |> Enum.map(fn %{"id" => id} -> id end)
 
     responses = Orulo.get_units(building_id, typology_ids)
-    Orulo.bulk_insert_unit_payload_forking_multi(multi, responses)
+    Orulo.bulk_insert_unit_payload_forking_multi(multi, building_id, responses)
   end
 end

--- a/apps/re_integrations/lib/orulo/job_queue.ex
+++ b/apps/re_integrations/lib/orulo/job_queue.ex
@@ -35,7 +35,7 @@ defmodule ReIntegrations.Orulo.JobQueue do
     end
   end
 
-  def perform(%Multi{} = multi, %{"type" => "fetch_typology", "building_id" => id}) do
+  def perform(%Multi{} = multi, %{"type" => "fetch_typologies", "building_id" => id}) do
     with {:ok, %{body: body}} <- Client.get_typologies(id),
          {:ok, payload} <- Jason.decode(body),
          {:ok, new_typology_payload} <-
@@ -65,5 +65,12 @@ defmodule ReIntegrations.Orulo.JobQueue do
         "uuid" => uuid
       }) do
     PayloadProcessor.process_orulo_tags(multi, uuid)
+  end
+
+  def perform(%Multi{} = multi, %{
+        "type" => "process_typologies",
+        "uuid" => uuid
+      }) do
+    PayloadProcessor.process_typologies(multi, uuid)
   end
 end

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -82,18 +82,19 @@ defmodule ReIntegrations.Orulo do
   def bulk_insert_unit_payload_forking_multi(%Multi{} = multi, building_id, responses) do
     unit_multies =
       Enum.map(responses, fn response ->
-        with {typology_id, {:ok, %{body: payload}}} <- response do
-          #  {:ok, payload} <- Jason.decode(body),
+        with {typology_id, {:ok, %{body: body}}} <- response,
+             {:ok, payload} <- Jason.decode(body) do
           insert_unit_payload(
             Multi.new(),
             %{
               building_id: building_id,
-              typology_id: Integer.to_string(typology_id),
+              typology_id: typology_id,
               payload: payload
             }
           )
         else
-          error -> Logger.error("Error on units request:  #{Kernel.inspect(error)}")
+          error ->
+            Logger.error("Error on units request:  #{Kernel.inspect(error)}")
         end
       end)
 

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -88,7 +88,7 @@ defmodule ReIntegrations.Orulo do
     |> ReIntegrations.Repo.transaction()
   end
 
-  def generate_unit_multies(building_id, responses) do
+  defp generate_unit_multies(building_id, responses) do
     Enum.map(responses, fn response ->
       case extract_response_attributes(response) do
         {:ok, typology_id, payload} ->
@@ -112,8 +112,8 @@ defmodule ReIntegrations.Orulo do
   end
 
   defp unit_process_multi(%{typology_id: typology_id} = params) do
-    insert_key = "insert_units_for_typology_#{typology_id}" |> String.to_atom()
-    process_key = "process_units_for_typology_#{typology_id}" |> String.to_atom()
+    insert_key = "insert_units_for_typology_#{typology_id}"
+    process_key = "process_units_for_typology_#{typology_id}"
 
     changeset =
       %UnitPayload{}

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -80,10 +80,10 @@ defmodule ReIntegrations.Orulo do
   end
 
   def bulk_insert_unit_payload_forking_multi(%Multi{} = multi, responses) do
-    multies =
+    unit_multies =
       Enum.map(responses, fn response ->
-        #  {:ok, payload} <- Jason.decode(body),
         with {typology_id, {:ok, %{body: payload}}} <- response do
+          #  {:ok, payload} <- Jason.decode(body),
           insert_unit_payload(
             Multi.new(),
             %{
@@ -97,7 +97,8 @@ defmodule ReIntegrations.Orulo do
         end
       end)
 
-    Enum.reduce(multies, multi, fn unit_multi, acc ->
+    unit_multies
+    |> Enum.reduce(multi, fn unit_multi, acc ->
       Multi.prepend(acc, unit_multi)
     end)
     |> ReIntegrations.Repo.transaction()

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -65,8 +65,14 @@ defmodule ReIntegrations.Orulo do
       %TypologyPayload{}
       |> TypologyPayload.changeset(params)
 
+    uuid = Changeset.get_field(changeset, :uuid)
+
     multi
     |> Multi.insert(:insert_typologies_payload, changeset)
+    |> JobQueue.enqueue(:parse_typologies, %{
+      "type" => "process_typologies",
+      "uuid" => uuid
+    })
     |> Repo.transaction()
   end
 

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -79,7 +79,7 @@ defmodule ReIntegrations.Orulo do
     |> Repo.transaction()
   end
 
-  def bulk_insert_unit_payload_forking_multi(%Multi{} = multi, responses) do
+  def bulk_insert_unit_payload_forking_multi(%Multi{} = multi, building_id, responses) do
     unit_multies =
       Enum.map(responses, fn response ->
         with {typology_id, {:ok, %{body: payload}}} <- response do
@@ -87,7 +87,7 @@ defmodule ReIntegrations.Orulo do
           insert_unit_payload(
             Multi.new(),
             %{
-              building_id: "1",
+              building_id: building_id,
               typology_id: Integer.to_string(typology_id),
               payload: payload
             }

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -7,6 +7,7 @@ defmodule ReIntegrations.Orulo do
 
   alias ReIntegrations.{
     Orulo.BuildingPayload,
+    Orulo.Client,
     Orulo.ImagePayload,
     Orulo.TypologyPayload,
     Orulo.JobQueue,
@@ -69,8 +70,8 @@ defmodule ReIntegrations.Orulo do
 
     multi
     |> Multi.insert(:insert_typologies_payload, changeset)
-    |> JobQueue.enqueue(:parse_typologies, %{
-      "type" => "process_typologies",
+    |> JobQueue.enqueue(:fetch_units, %{
+      "type" => "fetch_units",
       "uuid" => uuid
     })
     |> Repo.transaction()
@@ -80,5 +81,13 @@ defmodule ReIntegrations.Orulo do
     BuildingPayload
     |> where(external_id: ^external_id)
     |> Repo.exists?()
+  end
+
+  def get_units(building_id, typology_ids) do
+    typology_ids
+    |> Enum.reduce(%{}, fn typology_id, responses ->
+      response = Client.get_units(building_id, typology_id)
+      Map.put(responses, typology_id, response)
+    end)
   end
 end

--- a/apps/re_integrations/lib/orulo/orulo.ex
+++ b/apps/re_integrations/lib/orulo/orulo.ex
@@ -92,7 +92,7 @@ defmodule ReIntegrations.Orulo do
     Enum.map(responses, fn response ->
       case extract_response_attributes(response) do
         {:ok, typology_id, payload} ->
-          insert_unit_payload(%{
+          unit_process_multi(%{
             building_id: building_id,
             typology_id: typology_id,
             payload: payload
@@ -111,7 +111,7 @@ defmodule ReIntegrations.Orulo do
     end
   end
 
-  def insert_unit_payload(%{typology_id: typology_id} = params) do
+  defp unit_process_multi(%{typology_id: typology_id} = params) do
     insert_key = "insert_units_for_typology_#{typology_id}" |> String.to_atom()
     process_key = "process_units_for_typology_#{typology_id}" |> String.to_atom()
 

--- a/apps/re_integrations/lib/orulo/payload_processor.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor.ex
@@ -6,10 +6,12 @@ defmodule ReIntegrations.Orulo.PayloadProcessor do
   alias __MODULE__.Buildings, as: BuildingProcessor
   alias __MODULE__.Images, as: ImageProcessor
   alias __MODULE__.Tags, as: TagsProcessor
+  alias __MODULE__.Typologies, as: TypologiesProcessor
 
   defdelegate insert_development_from_building_payload(multi, building_uuid),
     to: BuildingProcessor
 
   defdelegate insert_images_from_image_payload(multi, payload_uuid), to: ImageProcessor
   defdelegate process_orulo_tags(multi, payload_uuid), to: TagsProcessor
+  defdelegate process_typologies(multi, payload_uuid), to: TypologiesProcessor
 end

--- a/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
@@ -49,14 +49,14 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
   defp enqueue_tag_job(multi, building) do
     JobQueue.enqueue(multi, :process_tags, %{
       "type" => "process_orulo_tags",
-      "external_id" => building.uuid
+      "uuid" => building.uuid
     })
   end
 
   defp enqueue_typology_job(multi, building) do
     JobQueue.enqueue(multi, :fetch_typologies, %{
       "type" => "fetch_typologies",
-      "external_id" => building.external_id
+      "building_id" => building.external_id
     })
   end
 end

--- a/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
@@ -1,0 +1,46 @@
+defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
+  @moduledoc """
+  Module to process typologies payloads into units.
+  """
+  alias Ecto.Multi
+
+  alias Re.Developments
+
+  alias ReIntegrations.{
+    Orulo.TypologyPayload,
+    Orulo.TypologyMapper,
+    Repo
+  }
+
+  def process_typologies(multi, topology_uuid) do
+    typology_payload = Repo.get(TypologyPayload, topology_uuid)
+    {:ok, development} = Developments.get_by_orulo_id(typology_payload.building_id)
+
+    %{payload: %{"typologies" => payload}} = typology_payload
+
+    multi
+    |> insert_units(payload, development)
+    |> Repo.transaction()
+  end
+
+  @static_params %{
+    status: "inactive"
+  }
+
+  defp insert_units(multi, typologies, development) do
+    Multi.run(multi, :insert_units, fn _repo, _changes ->
+      insertion_results =
+        Enum.map(typologies, fn typology ->
+          params =
+            typology
+            |> TypologyMapper.typology_payload_into_unit_params()
+
+          params
+          |> Map.merge(@static_params)
+          |> Re.Units.insert(development)
+        end)
+
+      {:ok, insertion_results}
+    end)
+  end
+end

--- a/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
@@ -10,9 +10,9 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
   }
 
   alias ReIntegrations.{
+    Orulo.TypologyMapper,
     Orulo.TypologyPayload,
     Orulo.UnitPayload,
-    Orulo.TypologyMapper,
     Repo
   }
 
@@ -54,7 +54,8 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
   end
 
   defp extract_typology_info_from_payload(id, %{"typologies" => typologies}) do
-    Enum.filter(typologies, fn typology ->
+    typologies
+    |> Enum.filter(fn typology ->
       Map.get(typology, "id") == id
     end)
     |> List.first()

--- a/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
@@ -15,8 +15,8 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
     Repo
   }
 
-  def process_typologies(multi, topology_uuid) do
-    typology_payload = Repo.get(TypologyPayload, topology_uuid)
+  def process_typologies(multi, typology_uuid) do
+    typology_payload = Repo.get(TypologyPayload, typology_uuid)
     {:ok, development} = Developments.get_by_orulo_id(typology_payload.building_id)
 
     %{payload: %{"typologies" => typologies}} = typology_payload

--- a/apps/re_integrations/lib/orulo/typology_mapper.ex
+++ b/apps/re_integrations/lib/orulo/typology_mapper.ex
@@ -3,15 +3,23 @@ defmodule ReIntegrations.Orulo.TypologyMapper do
   Module to map orulo's typology into units.
   """
 
-  @typology_attributes ~w(discount_price private_area bedrooms bathrooms suites parking)
+  @typology_attributes ~w(bedrooms bathrooms suites parking)
+  @unit_attributes ~w(price private_area reference)
 
-  def typology_payload_into_unit_params(typology) do
+  def typology_payload_into_unit_params(typology, unit) do
     typology
-    |> Map.take(@typology_attributes)
+    |> fetch_attributes(unit)
     |> Enum.reduce(%{}, &convert_typology_attribute(&1, &2))
   end
 
-  defp convert_typology_attribute({"discount_price", price}, acc) do
+  defp fetch_attributes(typology, unit) do
+    typology_attributes = Map.take(typology, @typology_attributes)
+    unit_attributes = Map.take(unit, @unit_attributes)
+
+    Map.merge(typology_attributes, unit_attributes)
+  end
+
+  defp convert_typology_attribute({"price", price}, acc) do
     Map.put(acc, :price, round(price))
   end
 
@@ -33,6 +41,10 @@ defmodule ReIntegrations.Orulo.TypologyMapper do
 
   defp convert_typology_attribute({"suites", suites}, acc) do
     Map.put(acc, :suites, suites)
+  end
+
+  defp convert_typology_attribute({"reference", complement}, acc) do
+    Map.put(acc, :complement, complement)
   end
 
   defp convert_typology_attribute(_, acc), do: acc

--- a/apps/re_integrations/lib/orulo/typology_mapper.ex
+++ b/apps/re_integrations/lib/orulo/typology_mapper.ex
@@ -1,0 +1,40 @@
+defmodule ReIntegrations.Orulo.TypologyMapper do
+  @moduledoc """
+  Module to map orulo's typology into units.
+  """
+  alias ReIntegrations.Orulo.TypologyPayload
+
+  @typology_attributes ~w(discount_price private_area bedrooms bathrooms suites parking)
+
+  def typology_payload_into_unit_params(typology) do
+    typology
+    |> Map.take(@typology_attributes)
+    |> Enum.reduce(%{}, &convert_typology_attribute(&1, &2))
+  end
+
+  defp convert_typology_attribute({"discount_price", price}, acc) do
+    Map.put(acc, :price, price)
+  end
+
+  defp convert_typology_attribute({"private_area", area}, acc) do
+    Map.put(acc, :area, area)
+  end
+
+  defp convert_typology_attribute({"bedrooms", rooms}, acc) do
+    Map.put(acc, :rooms, rooms)
+  end
+
+  defp convert_typology_attribute({"bathrooms", bathrooms}, acc) do
+    Map.put(acc, :bathrooms, bathrooms)
+  end
+
+  defp convert_typology_attribute({"parking", garage_spots}, acc) do
+    Map.put(acc, :garage_spots, garage_spots)
+  end
+
+  defp convert_typology_attribute({"suites", suites}, acc) do
+    Map.put(acc, :suites, suites)
+  end
+
+  defp convert_typology_attribute(_, acc), do: acc
+end

--- a/apps/re_integrations/lib/orulo/typology_mapper.ex
+++ b/apps/re_integrations/lib/orulo/typology_mapper.ex
@@ -2,7 +2,6 @@ defmodule ReIntegrations.Orulo.TypologyMapper do
   @moduledoc """
   Module to map orulo's typology into units.
   """
-  alias ReIntegrations.Orulo.TypologyPayload
 
   @typology_attributes ~w(discount_price private_area bedrooms bathrooms suites parking)
 
@@ -13,11 +12,11 @@ defmodule ReIntegrations.Orulo.TypologyMapper do
   end
 
   defp convert_typology_attribute({"discount_price", price}, acc) do
-    Map.put(acc, :price, price)
+    Map.put(acc, :price, round(price))
   end
 
   defp convert_typology_attribute({"private_area", area}, acc) do
-    Map.put(acc, :area, area)
+    Map.put(acc, :area, round(area))
   end
 
   defp convert_typology_attribute({"bedrooms", rooms}, acc) do

--- a/apps/re_integrations/lib/orulo/unit_payload.ex
+++ b/apps/re_integrations/lib/orulo/unit_payload.ex
@@ -1,0 +1,30 @@
+defmodule ReIntegrations.Orulo.UnitPayload do
+  @moduledoc """
+  Schema for Orulo units sincronization
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @schema_prefix "re_integrations"
+  @primary_key {:uuid, :binary_id, autogenerate: false}
+
+  schema "orulo_unit_payloads" do
+    field :building_id, :string
+    field :typology_id, :string
+    field :payload, :map
+
+    timestamps()
+  end
+
+  @required ~w(building_id typology_id payload)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required)
+    |> validate_required(@required)
+    |> generate_uuid()
+  end
+
+  defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
+end

--- a/apps/re_integrations/lib/orulo/unit_payload.ex
+++ b/apps/re_integrations/lib/orulo/unit_payload.ex
@@ -14,7 +14,7 @@ defmodule ReIntegrations.Orulo.UnitPayload do
     field :typology_id, :string
     field :payload, :map
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required ~w(building_id typology_id payload)a

--- a/apps/re_integrations/priv/repo/migrations/20190614180206_create_orulo_unit_payloads.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190614180206_create_orulo_unit_payloads.exs
@@ -7,7 +7,7 @@ defmodule ReIntegrations.Repo.Migrations.CreateOruloUnitPayloads do
       add :building_id, :string
       add :typology_id, :string
       add :payload, :map, null: false, default: %{}
-      timestamps()
+      timestamps(type: :timestamptz)
     end
   end
 end

--- a/apps/re_integrations/priv/repo/migrations/20190614180206_create_orulo_unit_payloads.exs
+++ b/apps/re_integrations/priv/repo/migrations/20190614180206_create_orulo_unit_payloads.exs
@@ -1,0 +1,13 @@
+defmodule ReIntegrations.Repo.Migrations.CreateOruloUnitPayloads do
+  use Ecto.Migration
+
+  def change do
+    create table(:orulo_unit_payloads, primary_key: false) do
+      add :uuid, :uuid, primary_key: true
+      add :building_id, :string
+      add :typology_id, :string
+      add :payload, :map, null: false, default: %{}
+      timestamps()
+    end
+  end
+end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -83,28 +83,6 @@ defmodule ReIntegrations.OruloTest do
     end
   end
 
-  describe "insert_unit_payloads/2" do
-    test "create new unit payloads" do
-      params = %{
-        building_id: "666",
-        typology_id: "1",
-        payload: %{test: "typology_payload"}
-      }
-
-      assert {:ok, %{insert_units_for_typology_1: payload}} =
-               Multi.new() |> Orulo.insert_unit_payload(params) |> Repo.transaction()
-
-      assert payload.uuid
-      assert payload.building_id == "666"
-      assert payload.typology_id == "1"
-      assert payload.payload == %{test: "typology_payload"}
-
-      JobQueue
-      |> Repo.all()
-      |> assert_enqueued_job("process_units")
-    end
-  end
-
   describe "get_units/2" do
     test "get units for all typologies" do
       building_id = "1"
@@ -118,8 +96,7 @@ defmodule ReIntegrations.OruloTest do
     end
   end
 
-  describe "bulk_insert_unit_payload_forking_multi/2" do
-    @tag dev: true
+  describe "bulk_insert_unit_payloads/2" do
     test "get units for all typologies" do
       responses = %{
         "1" => {:ok, %{body: "{\"units\": []}"}},
@@ -132,7 +109,7 @@ defmodule ReIntegrations.OruloTest do
        %{
          insert_units_for_typology_1: unit_payload_1,
          insert_units_for_typology_2: unit_payload_2
-       }} = Orulo.bulk_insert_unit_payload_forking_multi(Multi.new(), building_id, responses)
+       }} = Orulo.bulk_insert_unit_payloads(Multi.new(), building_id, responses)
 
       assert unit_payload_1.uuid
       assert unit_payload_1.building_id == "1"

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -119,18 +119,19 @@ defmodule ReIntegrations.OruloTest do
   end
 
   describe "bulk_insert_unit_payload_forking_multi/2" do
-    @tag dev: true
     test "get units for all typologies" do
-      response = %{
+      responses = %{
         1 => {:ok, %{body: %{"units" => []}}},
         2 => {:ok, %{body: %{"units" => []}}}
       }
+
+      building_id = "1"
 
       {:ok,
        %{
          insert_units_for_typology_1: unit_payload_1,
          insert_units_for_typology_2: unit_payload_2
-       }} = Orulo.bulk_insert_unit_payload_forking_multi(Multi.new(), response)
+       }} = Orulo.bulk_insert_unit_payload_forking_multi(Multi.new(), building_id, responses)
 
       assert unit_payload_1.uuid
       assert unit_payload_1.building_id == "1"

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -91,8 +91,8 @@ defmodule ReIntegrations.OruloTest do
         payload: %{test: "typology_payload"}
       }
 
-      assert {:ok, %{insert_unit_payload_1: payload}} =
-               Orulo.insert_unit_payload(Multi.new(), params)
+      assert {:ok, %{insert_units_for_typology_1: payload}} =
+               Multi.new() |> Orulo.insert_unit_payload(params) |> Repo.transaction()
 
       assert payload.uuid
       assert payload.building_id == "666"
@@ -139,7 +139,7 @@ defmodule ReIntegrations.OruloTest do
 
       assert unit_payload_2.uuid
       assert unit_payload_2.building_id == "1"
-      assert unit_payload_2.typology_id == "2`"
+      assert unit_payload_2.typology_id == "2"
       assert unit_payload_2.payload == %{"units" => []}
 
       JobQueue

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -107,8 +107,8 @@ defmodule ReIntegrations.OruloTest do
 
       {:ok,
        %{
-         insert_units_for_typology_1: unit_payload_1,
-         insert_units_for_typology_2: unit_payload_2
+         "insert_units_for_typology_1" => unit_payload_1,
+         "insert_units_for_typology_2" => unit_payload_2
        }} = Orulo.bulk_insert_unit_payloads(Multi.new(), building_id, responses)
 
       assert unit_payload_1.uuid

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -107,22 +107,23 @@ defmodule ReIntegrations.OruloTest do
 
   describe "get_units/2" do
     test "get units for all typologies" do
-      building_id = 1
-      typology_ids = [1, 2]
+      building_id = "1"
+      typology_ids = ["1", "2"]
 
       assert %{
-               1 => {:ok, %{body: %{"units" => []}}},
-               2 => {:ok, %{body: %{"units" => []}}}
+               "1" => {:ok, %{body: "{\"units\": []}"}},
+               "2" => {:ok, %{body: "{\"units\": []}"}}
              } ==
                Orulo.get_units(building_id, typology_ids)
     end
   end
 
   describe "bulk_insert_unit_payload_forking_multi/2" do
+    @tag dev: true
     test "get units for all typologies" do
       responses = %{
-        1 => {:ok, %{body: %{"units" => []}}},
-        2 => {:ok, %{body: %{"units" => []}}}
+        "1" => {:ok, %{body: "{\"units\": []}"}},
+        "2" => {:ok, %{body: "{\"units\": []}"}}
       }
 
       building_id = "1"

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -1,6 +1,7 @@
 defmodule ReIntegrations.OruloTest do
   @moduledoc false
 
+  import Re.CustomAssertion
   import ReIntegrations.Factory
 
   use ReIntegrations.ModelCase
@@ -75,6 +76,75 @@ defmodule ReIntegrations.OruloTest do
       assert payload.uuid
       assert payload.building_id == "666"
       assert payload.payload == %{test: "typology_payload"}
+
+      JobQueue
+      |> Repo.all()
+      |> assert_enqueued_job("fetch_units")
+    end
+  end
+
+  describe "insert_unit_payloads/2" do
+    test "create new unit payloads" do
+      params = %{
+        building_id: "666",
+        typology_id: "1",
+        payload: %{test: "typology_payload"}
+      }
+
+      assert {:ok, %{insert_unit_payload_1: payload}} =
+               Orulo.insert_unit_payload(Multi.new(), params)
+
+      assert payload.uuid
+      assert payload.building_id == "666"
+      assert payload.typology_id == "1"
+      assert payload.payload == %{test: "typology_payload"}
+
+      JobQueue
+      |> Repo.all()
+      |> assert_enqueued_job("process_units")
+    end
+  end
+
+  describe "get_units/2" do
+    test "get units for all typologies" do
+      building_id = 1
+      typology_ids = [1, 2]
+
+      assert %{
+               1 => {:ok, %{body: %{"units" => []}}},
+               2 => {:ok, %{body: %{"units" => []}}}
+             } ==
+               Orulo.get_units(building_id, typology_ids)
+    end
+  end
+
+  describe "bulk_insert_unit_payload_forking_multi/2" do
+    @tag dev: true
+    test "get units for all typologies" do
+      response = %{
+        1 => {:ok, %{body: %{"units" => []}}},
+        2 => {:ok, %{body: %{"units" => []}}}
+      }
+
+      {:ok,
+       %{
+         insert_units_for_typology_1: unit_payload_1,
+         insert_units_for_typology_2: unit_payload_2
+       }} = Orulo.bulk_insert_unit_payload_forking_multi(Multi.new(), response)
+
+      assert unit_payload_1.uuid
+      assert unit_payload_1.building_id == "1"
+      assert unit_payload_1.typology_id == "1"
+      assert unit_payload_1.payload == %{"units" => []}
+
+      assert unit_payload_2.uuid
+      assert unit_payload_2.building_id == "1"
+      assert unit_payload_2.typology_id == "2`"
+      assert unit_payload_2.payload == %{"units" => []}
+
+      JobQueue
+      |> Repo.all()
+      |> assert_enqueued_job("process_units", 2)
     end
   end
 

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -82,7 +82,6 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
   end
 
   describe "process_typologies/2" do
-    @tag dev: true
     test "create new units from typology_payload" do
       %{uuid: payload_uuid} =
         insert(:typology_payload,

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -84,7 +84,35 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
   describe "process_typologies/2" do
     @tag dev: true
     test "create new units from typology_payload" do
-      %{uuid: payload_uuid} = insert(:typology_payload)
+      %{uuid: payload_uuid} =
+        insert(:typology_payload,
+          payload: %{
+            "typologies" => [
+              %{
+                "id" => "1",
+                "type" => "Apartamento",
+                "original_price" => 1_000_00.0,
+                "discount_price" => 950_000.0,
+                "private_area" => 100.0,
+                "bedrooms" => 1,
+                "bathrooms" => 1,
+                "suites" => 1,
+                "parking" => 1
+              },
+              %{
+                "id" => "2",
+                "type" => "Apartamento",
+                "original_price" => 2_000_000.0,
+                "discount_price" => 1_900_000.0,
+                "private_area" => 200.0,
+                "bedrooms" => 2,
+                "bathrooms" => 2,
+                "suites" => 2,
+                "parking" => 2
+              }
+            ]
+          }
+        )
 
       Re.Factory.insert(:development, orulo_id: "999")
 
@@ -101,7 +129,22 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
         )
 
       assert inserted_unit_1.uuid
+      assert inserted_unit_1.price == 950_000
+      assert inserted_unit_1.area == 100
+      assert inserted_unit_1.rooms == 1
+      assert inserted_unit_1.bathrooms == 1
+      assert inserted_unit_1.suites == 1
+      assert inserted_unit_1.garage_spots == 1
+      assert inserted_unit_1.garage_type == "unknown"
+
       assert inserted_unit_2.uuid
+      assert inserted_unit_2.price == 1_900_000
+      assert inserted_unit_2.area == 200
+      assert inserted_unit_2.rooms == 2
+      assert inserted_unit_2.bathrooms == 2
+      assert inserted_unit_2.suites == 2
+      assert inserted_unit_2.garage_spots == 2
+      assert inserted_unit_2.garage_type == "unknown"
     end
   end
 

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -82,36 +82,26 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
   end
 
   describe "process_typologies/2" do
-    test "create new units from typology_payload" do
-      %{uuid: payload_uuid} =
-        insert(:typology_payload,
-          payload: %{
-            "typologies" => [
-              %{
-                "id" => "1",
-                "type" => "Apartamento",
-                "original_price" => 1_000_00.0,
-                "discount_price" => 950_000.0,
-                "private_area" => 100.0,
-                "bedrooms" => 1,
-                "bathrooms" => 1,
-                "suites" => 1,
-                "parking" => 1
-              },
-              %{
-                "id" => "2",
-                "type" => "Apartamento",
-                "original_price" => 2_000_000.0,
-                "discount_price" => 1_900_000.0,
-                "private_area" => 200.0,
-                "bedrooms" => 2,
-                "bathrooms" => 2,
-                "suites" => 2,
-                "parking" => 2
-              }
-            ]
-          }
-        )
+    test "create new units from both typology and unit payloads merge" do
+      insert(:typology_payload,
+        payload: %{
+          "typologies" => [
+            %{
+              "id" => "1",
+              "type" => "Apartamento",
+              "original_price" => 1_000_000.0,
+              "discount_price" => 1_000_000.0,
+              "private_area" => 100.0,
+              "bedrooms" => 3,
+              "bathrooms" => 2,
+              "suites" => 1,
+              "parking" => 2
+            }
+          ]
+        }
+      )
+
+      %{uuid: payload_uuid} = insert(:units_payload, building_id: "999", typology_id: "1")
 
       Re.Factory.insert(:development, orulo_id: "999")
 
@@ -128,22 +118,24 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
         )
 
       assert inserted_unit_1.uuid
-      assert inserted_unit_1.price == 950_000
+      assert inserted_unit_1.price == 1_000_000
       assert inserted_unit_1.area == 100
-      assert inserted_unit_1.rooms == 1
-      assert inserted_unit_1.bathrooms == 1
+      assert inserted_unit_1.rooms == 3
+      assert inserted_unit_1.bathrooms == 2
       assert inserted_unit_1.suites == 1
-      assert inserted_unit_1.garage_spots == 1
+      assert inserted_unit_1.garage_spots == 2
       assert inserted_unit_1.garage_type == "unknown"
+      assert inserted_unit_1.complement == "50"
 
       assert inserted_unit_2.uuid
-      assert inserted_unit_2.price == 1_900_000
-      assert inserted_unit_2.area == 200
-      assert inserted_unit_2.rooms == 2
+      assert inserted_unit_2.price == 2_000_000
+      assert inserted_unit_2.area == 100
+      assert inserted_unit_2.rooms == 3
       assert inserted_unit_2.bathrooms == 2
-      assert inserted_unit_2.suites == 2
+      assert inserted_unit_2.suites == 1
       assert inserted_unit_2.garage_spots == 2
       assert inserted_unit_2.garage_type == "unknown"
+      assert inserted_unit_2.complement == "100"
     end
   end
 

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -6,6 +6,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
   alias ReIntegrations.{
     Orulo.BuildingPayload,
     Orulo.ImagePayload,
+    Orulo.TypologyPayload,
     Orulo.JobQueue,
     Orulo.PayloadProcessor,
     Repo
@@ -92,6 +93,33 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
         )
 
       assert inserted_image.filename == "qxo1cimsxmb2vnu5kcxw.jpg"
+    end
+  end
+
+  describe "process_typologies/2" do
+    @tag dev: true
+    test "create new units from typology_payload" do
+      %{uuid: payload_uuid} =
+        build(:typology_payload)
+        |> TypologyPayload.changeset()
+        |> Repo.insert!()
+
+      Re.Factory.insert(:development, orulo_id: "999")
+
+      {:ok,
+       %{
+         insert_units: [
+           ok: %{add_unit: inserted_unit_1},
+           ok: %{add_unit: inserted_unit_2}
+         ]
+       }} =
+        PayloadProcessor.process_typologies(
+          Multi.new(),
+          payload_uuid
+        )
+
+      assert inserted_unit_1.uuid
+      assert inserted_unit_2.uuid
     end
   end
 

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -5,8 +5,6 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
 
   alias ReIntegrations.{
     Orulo.BuildingPayload,
-    Orulo.ImagePayload,
-    Orulo.TypologyPayload,
     Orulo.JobQueue,
     Orulo.PayloadProcessor,
     Repo
@@ -38,12 +36,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
     end
 
     test "create new development from building" do
-      %{payload: payload = %{"developer" => developer}} = building = build(:building_payload)
-
-      %{uuid: uuid} =
-        building
-        |> BuildingPayload.changeset()
-        |> Repo.insert!()
+      %{uuid: uuid, payload: payload = %{"developer" => developer}} = insert(:building_payload)
 
       assert {:ok, %{insert_development: development}} =
                PayloadProcessor.insert_development_from_building_payload(Multi.new(), uuid)
@@ -59,12 +52,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
     end
 
     test "enqueue fetch images, fetch typologies and process tag jobs" do
-      building = build(:building_payload)
-
-      %{uuid: uuid} =
-        building
-        |> BuildingPayload.changeset()
-        |> Repo.insert!()
+      %{uuid: uuid} = insert(:building_payload)
 
       assert {:ok, _} =
                PayloadProcessor.insert_development_from_building_payload(Multi.new(), uuid)
@@ -79,10 +67,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
 
   describe "insert_images_from_image_payload/3" do
     test "create new images from image payload" do
-      %{uuid: payload_uuid} =
-        build(:images_payload)
-        |> ImagePayload.changeset()
-        |> Repo.insert!()
+      %{uuid: payload_uuid} = insert(:images_payload)
 
       Re.Factory.insert(:development, orulo_id: "999")
 
@@ -99,10 +84,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
   describe "process_typologies/2" do
     @tag dev: true
     test "create new units from typology_payload" do
-      %{uuid: payload_uuid} =
-        build(:typology_payload)
-        |> TypologyPayload.changeset()
-        |> Repo.insert!()
+      %{uuid: payload_uuid} = insert(:typology_payload)
 
       Re.Factory.insert(:development, orulo_id: "999")
 

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -14,7 +14,7 @@ defmodule ReIntegrations.Orulo.TypologyMapperTest do
 
       assert params == %{
                price: Map.get(typology, "discount_price") |> round(),
-               area: Map.get(typology, "private_area"),
+               area: Map.get(typology, "private_area") |> round(),
                rooms: Map.get(typology, "bedrooms"),
                bathrooms: Map.get(typology, "bathrooms"),
                suites: Map.get(typology, "suites"),

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -25,13 +25,13 @@ defmodule ReIntegrations.Orulo.TypologyMapperTest do
       params = TypologyMapper.typology_payload_into_unit_params(typology, unit)
 
       assert params == %{
-               price: unit |> Map.get("price") |> round(),
-               area: unit |> Map.get("private_area") |> round(),
-               rooms: Map.get(typology, "bedrooms"),
-               bathrooms: Map.get(typology, "bathrooms"),
-               suites: Map.get(typology, "suites"),
-               garage_spots: Map.get(typology, "parking"),
-               complement: Map.get(unit, "reference")
+               price: 1_000_000,
+               area: 84,
+               rooms: 3,
+               bathrooms: 2,
+               suites: 1,
+               garage_spots: 2,
+               complement: "51"
              }
     end
   end

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -13,8 +13,8 @@ defmodule ReIntegrations.Orulo.TypologyMapperTest do
       params = TypologyMapper.typology_payload_into_unit_params(typology)
 
       assert params == %{
-               price: Map.get(typology, "discount_price") |> round(),
-               area: Map.get(typology, "private_area") |> round(),
+               price: typology |> Map.get("discount_price") |> round(),
+               area: typology |> Map.get("private_area") |> round(),
                rooms: Map.get(typology, "bedrooms"),
                bathrooms: Map.get(typology, "bathrooms"),
                suites: Map.get(typology, "suites"),

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -5,8 +5,6 @@ defmodule ReIntegrations.Orulo.TypologyMapperTest do
 
   alias ReIntegrations.Orulo.TypologyMapper
 
-  import ReIntegrations.Factory
-
   describe "typology_into_units_params" do
     test "parse typology payload into units" do
       typology = %{

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -1,0 +1,25 @@
+defmodule ReIntegrations.Orulo.TypologyMapperTest do
+  @moduledoc false
+
+  use ReIntegrations.ModelCase
+
+  alias ReIntegrations.Orulo.TypologyMapper
+
+  import ReIntegrations.Factory
+
+  describe "typology_into_units_params" do
+    test "parse typology payload into units" do
+      %{payload: %{"typologies" => [typology, _]}} = build(:typology_payload)
+      params = TypologyMapper.typology_payload_into_unit_params(typology)
+
+      assert params == %{
+               price: Map.get(typology, "discount_price") |> round(),
+               area: Map.get(typology, "private_area"),
+               rooms: Map.get(typology, "bedrooms"),
+               bathrooms: Map.get(typology, "bathrooms"),
+               suites: Map.get(typology, "suites"),
+               garage_spots: Map.get(typology, "parking")
+             }
+    end
+  end
+end

--- a/apps/re_integrations/test/orulo/typology_mapper_test.exs
+++ b/apps/re_integrations/test/orulo/typology_mapper_test.exs
@@ -9,16 +9,31 @@ defmodule ReIntegrations.Orulo.TypologyMapperTest do
 
   describe "typology_into_units_params" do
     test "parse typology payload into units" do
-      %{payload: %{"typologies" => [typology, _]}} = build(:typology_payload)
-      params = TypologyMapper.typology_payload_into_unit_params(typology)
+      typology = %{
+        "id" => "9544",
+        "type" => "Apartamento",
+        "bedrooms" => 3,
+        "bathrooms" => 2,
+        "suites" => 1,
+        "parking" => 2
+      }
+
+      unit = %{
+        "reference" => "51",
+        "price" => 1_000_000.0,
+        "private_area" => 84.0
+      }
+
+      params = TypologyMapper.typology_payload_into_unit_params(typology, unit)
 
       assert params == %{
-               price: typology |> Map.get("discount_price") |> round(),
-               area: typology |> Map.get("private_area") |> round(),
+               price: unit |> Map.get("price") |> round(),
+               area: unit |> Map.get("private_area") |> round(),
                rooms: Map.get(typology, "bedrooms"),
                bathrooms: Map.get(typology, "bathrooms"),
                suites: Map.get(typology, "suites"),
-               garage_spots: Map.get(typology, "parking")
+               garage_spots: Map.get(typology, "parking"),
+               complement: Map.get(unit, "reference")
              }
     end
   end

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -46,6 +46,7 @@ defmodule ReIntegrations.Factory do
 
   def images_payload_factory do
     %ReIntegrations.Orulo.ImagePayload{
+      uuid: UUID.uuid4(),
       external_id: 999,
       payload: %{
         "images" => [
@@ -68,6 +69,7 @@ defmodule ReIntegrations.Factory do
 
   def typology_payload_factory do
     %ReIntegrations.Orulo.TypologyPayload{
+      uuid: UUID.uuid4(),
       building_id: "999",
       payload: %{
         "typologies" => [

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -65,4 +65,36 @@ defmodule ReIntegrations.Factory do
       }
     }
   end
+
+  def typology_payload_factory do
+    %ReIntegrations.Orulo.TypologyPayload{
+      building_id: "999",
+      payload: %{
+        "typologies" => [
+          %{
+            "id" => "9544",
+            "type" => "Apartamento",
+            "original_price" => 988_084.0,
+            "discount_price" => 910_000.0,
+            "private_area" => 84.0,
+            "bedrooms" => 3,
+            "bathrooms" => 2,
+            "suites" => 1,
+            "parking" => 2
+          },
+          %{
+            "id" => "9545",
+            "type" => "Apartamento",
+            "original_price" => 1_710_175.0,
+            "discount_price" => 1_710_175.0,
+            "private_area" => 160.0,
+            "bedrooms" => 3,
+            "bathrooms" => 2,
+            "suites" => 1,
+            "parking" => 2
+          }
+        ]
+      }
+    }
+  end
 end

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -99,4 +99,26 @@ defmodule ReIntegrations.Factory do
       }
     }
   end
+
+  def units_payload_factory do
+    %ReIntegrations.Orulo.UnitPayload{
+      uuid: UUID.uuid4(),
+      building_id: "999",
+      typology_id: "1",
+      payload: %{
+        "units" => [
+          %{
+            "reference" => "51",
+            "price" => 1_000_000.0,
+            "private_area" => 84.0
+          },
+          %{
+            "reference" => "72",
+            "price" => 1_100_000.0,
+            "private_area" => 84.0
+          }
+        ]
+      }
+    }
+  end
 end

--- a/apps/re_integrations/test/support/factory.ex
+++ b/apps/re_integrations/test/support/factory.ex
@@ -108,14 +108,14 @@ defmodule ReIntegrations.Factory do
       payload: %{
         "units" => [
           %{
-            "reference" => "51",
+            "reference" => "50",
             "price" => 1_000_000.0,
-            "private_area" => 84.0
+            "private_area" => 100.0
           },
           %{
-            "reference" => "72",
-            "price" => 1_100_000.0,
-            "private_area" => 84.0
+            "reference" => "100",
+            "price" => 2_000_000.0,
+            "private_area" => 100.0
           }
         ]
       }

--- a/apps/re_integrations/test/support/test_http.ex
+++ b/apps/re_integrations/test/support/test_http.ex
@@ -5,11 +5,11 @@ defmodule ReIntegrations.TestHTTP do
     do: {:ok, %{body: filename}}
 
   def get(%URI{path: "/buildings/1/typologies/1/units"}, _) do
-    {:ok, %{body: %{"units" => []}}}
+    {:ok, %{body: "{\"units\": []}"}}
   end
 
   def get(%URI{path: "/buildings/1/typologies/2/units"}, _) do
-    {:ok, %{body: %{"units" => []}}}
+    {:ok, %{body: "{\"units\": []}"}}
   end
 
   def get(%URI{path: "/simulator"}, [], _opts),

--- a/apps/re_integrations/test/support/test_http.ex
+++ b/apps/re_integrations/test/support/test_http.ex
@@ -4,6 +4,14 @@ defmodule ReIntegrations.TestHTTP do
   def get("https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385/" <> filename),
     do: {:ok, %{body: filename}}
 
+  def get(%URI{path: "/buildings/1/typologies/1/units"}, _) do
+    {:ok, %{body: %{"units" => []}}}
+  end
+
+  def get(%URI{path: "/buildings/1/typologies/2/units"}, _) do
+    {:ok, %{body: %{"units" => []}}}
+  end
+
   def get(%URI{path: "/simulator"}, [], _opts),
     do: {:ok, %{body: "{\"cem\":\"10,8%\",\"cet\":\"11,3%\"}"}}
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -132,7 +132,7 @@ defmodule ReWeb.Types.Listing do
     field :owner_contact, :owner_contact_input
   end
 
-  enum :garage_type, values: ~w(contract condominium)
+  enum :garage_type, values: ~w(contract condominium unknown)
 
   enum :orientation_type, values: ~w(frontside backside lateral inside)
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -78,7 +78,8 @@ config :re_integrations,
   priceteller_url: "http://www.emcasa.com/priceteller",
   priceteller_token: "mahtoken",
   cloudinary_client: ReIntegrations.TestCloudex,
-  retry_expiry: 100
+  retry_expiry: 100,
+  orulo_url: "http://www.emcasa.com/orulo"
 
 config :junit_formatter,
   report_file: "report_file_test.xml",


### PR DESCRIPTION
This is the very last pass to have all workflow running and up. 

### Fixes: 

- Keys for `tags_process` job was adjusted do create a job with `uuid` instead `external_id`.

### Some context: 

To create one unit/listing we need information which is both on typology and unit payload, so we need first get them and after merge. Typologies contain some info as rooms, bathrooms and garage spots, while one typology can contain multiple units which keep complement and price information. 

### Feature: 

This is the very first step to the end of the process: Here we need to fetch typologies and units to create our listings, by this very first moment I'm only using typology to validate the steps and simplify the implementation (only as a mid-step). 

So it's creating our units from typologies, what isn't the correct map (need to fetch and merge units info). 
In the final version, we'll fetch all units for each typology and these ones will create our `units/listings`. 

### Workflow overview:

![Orulo sync diagram (3)](https://user-images.githubusercontent.com/9089847/59518625-601bfc80-8e9c-11e9-824f-b1d7d0c13f96.png)

---
- Green points are ones who are already implemented. 
- blue is what happens on the current point of this PR.  
- red includes what should happen at the end of this PR. 
