### PR TITLE
Add retry logic to handle priceteller timeouts

### DIFF
--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -119,5 +119,26 @@ defmodule Re.PriceSuggestionsTest do
              end) =~
                ":invalid_input in priceteller"
     end
+
+    @tag capture_log: true
+    test "should handle timeout error" do
+      %{uuid: uuid} =
+        listing =
+        insert(
+          :listing,
+          rooms: 2,
+          area: 80,
+          address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+          garage_spots: 1,
+          bathrooms: 1,
+          suggested_price: nil
+        )
+
+      mock(HTTPoison, :post, {:error, %{reason: :timeout}})
+
+      assert {:error, %{reason: :timeout}} == PriceSuggestions.suggest_price(listing)
+      listing = Repo.get_by(Listing, uuid: uuid)
+      refute listing.suggested_price
+    end
   end
 end

--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -20,7 +20,7 @@ defmodule Re.PriceSuggestionsTest do
           :listing,
           rooms: 2,
           area: 80,
-          address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+          address: build(:address),
           garage_spots: 1,
           bathrooms: 1,
           suggested_price: nil
@@ -48,7 +48,7 @@ defmodule Re.PriceSuggestionsTest do
           :listing,
           rooms: 2,
           area: 80,
-          address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+          address: build(:address),
           garage_spots: 1,
           bathrooms: 1,
           suggested_price: 1000.0
@@ -83,8 +83,7 @@ defmodule Re.PriceSuggestionsTest do
       assert capture_log(fn ->
                assert {:error, changeset} =
                         PriceSuggestions.suggest_price(%{
-                          address:
-                            build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+                          address: build(:address),
                           rooms: nil,
                           area: nil,
                           bathrooms: nil,
@@ -128,7 +127,7 @@ defmodule Re.PriceSuggestionsTest do
           :listing,
           rooms: 2,
           area: 80,
-          address: build(:address, state: "MS", city: "Mah City", street: "Mah Street"),
+          address: build(:address),
           garage_spots: 1,
           bathrooms: 1,
           suggested_price: nil

--- a/apps/re_integrations/lib/priceteller/price_teller.ex
+++ b/apps/re_integrations/lib/priceteller/price_teller.ex
@@ -2,6 +2,8 @@ defmodule ReIntegrations.PriceTeller do
   @moduledoc """
   Context module for price suggestion
   """
+  use Retry
+
   require Logger
 
   alias __MODULE__.{
@@ -10,9 +12,11 @@ defmodule ReIntegrations.PriceTeller do
     Client
   }
 
+  @retry_expiry Application.get_env(:re_integrations, :retry_expiry, 30_000)
+
   def ask(params) do
     with {:ok, params} <- Input.validate(params),
-         {:ok, %{body: body}} <- Client.post(params),
+         {:ok, %{body: body}} <- do_post(params),
          {:ok, payload} <- Poison.decode(body),
          {:ok, response} <- Output.validate(payload) do
       {:ok, response}
@@ -31,6 +35,17 @@ defmodule ReIntegrations.PriceTeller do
         Logger.warn("Something went wrong. Error: #{Kernel.inspect(error)}")
 
         error
+    end
+  end
+
+  defp do_post(params) do
+    retry with: exp_backoff() |> randomize() |> expiry(@retry_expiry),
+          rescue_only: [TimeoutError] do
+      Client.post(params)
+    after
+      {:ok, response} -> {:ok, response}
+    else
+      error -> error
     end
   end
 end

--- a/apps/re_web/lib/graphql/middlewares/error_handler.ex
+++ b/apps/re_web/lib/graphql/middlewares/error_handler.ex
@@ -29,8 +29,8 @@ defmodule ReWeb.GraphQL.Middlewares.ErrorHandler do
 
   defp handle_error(:forbidden, errors), do: [%{message: "Forbidden", code: 403} | errors]
 
-  defp handle_error(:street_not_covered, errors),
-    do: [%{message: "Street not covered", code: 422} | errors]
+  defp handle_error(%{reason: :timeout}, errors),
+    do: [%{message: "Timeout", code: 408} | errors]
 
   defp handle_error(error, errors), do: [error | errors]
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -77,7 +77,8 @@ config :re_integrations,
   zapier_webhook_pass: "testpass",
   priceteller_url: "http://www.emcasa.com/priceteller",
   priceteller_token: "mahtoken",
-  cloudinary_client: ReIntegrations.TestCloudex
+  cloudinary_client: ReIntegrations.TestCloudex,
+  retry_expiry: 100
 
 config :junit_formatter,
   report_file: "report_file_test.xml",


### PR DESCRIPTION
Use `retry` when requesting price suggestions.
We still didn't decide how to handle when the service is not accessible, so I'll return a `Timeout` message for now.