### PR TITLE
feature(listings): add static param to development's listings.

### DIFF
--- a/apps/re/lib/developments/listings.ex
+++ b/apps/re/lib/developments/listings.ex
@@ -64,13 +64,15 @@ defmodule Re.Developments.Listings do
 
   @static_attributes %{
     type: "Apartamento",
-    is_release: true
+    is_release: true,
+    is_exportable: false
   }
 
   def listing_params_from_unit(%Re.Unit{} = unit, %Re.Development{} = development) do
-    @static_attributes
+    %{}
     |> merge_with_unit_attributes(unit)
     |> merge_with_development_attributes(development)
+    |> Map.merge(@static_attributes)
   end
 
   defp merge_with_development_attributes(params, development) do

--- a/apps/re/test/developments/listings_test.exs
+++ b/apps/re/test/developments/listings_test.exs
@@ -95,6 +95,7 @@ defmodule Re.Developments.ListingsTest do
 
       assert listing.type == "Apartamento"
       assert listing.is_release == true
+      assert listing.is_exportable == false
     end
   end
 end


### PR DESCRIPTION
On the primary market, we'll add all listings with exportable as `false` by default so it will not to saturate our marketing with similar listings when we add a hundred listings at once. 