### PR TITLE
Add Salesforce+Zapier integration client

### DIFF
--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -8,6 +8,9 @@ defmodule Re.BuyerLead do
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
+  @derive {Jason.Encoder,
+           only:
+             ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a}
   schema "buyer_leads" do
     field :name, :string
     field :phone_number, :string

--- a/apps/re/lib/buyer_leads/salesforce/client.ex
+++ b/apps/re/lib/buyer_leads/salesforce/client.ex
@@ -1,0 +1,16 @@
+defmodule Re.BuyerLeads.Salesforce.Client do
+  @moduledoc """
+  Module to interface with salesforce
+  """
+
+  alias Re.BuyerLeads.Salesforce.ZapierClient
+
+  def create_lead(%Re.BuyerLead{} = lead) do
+    with {:ok, payload} <- Jason.encode(lead),
+         {:ok, %{status_code: 200, body: body}} <- ZapierClient.post(payload) do
+      Jason.decode(body)
+    end
+  end
+
+  def create_lead(_lead), do: {:error, :lead_type_not_handled}
+end

--- a/apps/re/lib/buyer_leads/salesforce/zapier_client.ex
+++ b/apps/re/lib/buyer_leads/salesforce/zapier_client.ex
@@ -1,0 +1,17 @@
+defmodule Re.BuyerLeads.Salesforce.ZapierClient do
+  @moduledoc """
+  Module for zapier webhook trigger
+  """
+  require Mockery.Macro
+
+  @url Application.get_env(:re, :zapier_create_salesforce_lead_url, "")
+
+  def post(payload) do
+    @url
+    |> IO.inspect(label: "url")
+    |> URI.parse()
+    |> http_client().post(payload)
+  end
+
+  defp http_client, do: Mockery.Macro.mockable(HTTPoison)
+end

--- a/apps/re/lib/buyer_leads/salesforce/zapier_client.ex
+++ b/apps/re/lib/buyer_leads/salesforce/zapier_client.ex
@@ -8,7 +8,6 @@ defmodule Re.BuyerLeads.Salesforce.ZapierClient do
 
   def post(payload) do
     @url
-    |> IO.inspect(label: "url")
     |> URI.parse()
     |> http_client().post(payload)
   end

--- a/apps/re/test/buyer_leads/salesforce_test.exs
+++ b/apps/re/test/buyer_leads/salesforce_test.exs
@@ -1,0 +1,46 @@
+defmodule Re.BuyerLeads.SalesforceTest do
+  use Re.ModelCase
+  use Mockery
+
+  import Re.Factory
+
+  alias Re.BuyerLeads.Salesforce.Client
+
+  describe "create_lead/1" do
+    test "should send a request to create a lead" do
+      lead = insert(:buyer_lead)
+
+      mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
+
+      assert {:ok, %{"status" => "success"}} = Client.create_lead(lead)
+
+      {:ok, encoded_lead} = Jason.encode(lead)
+      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
+    end
+
+    test "should not send a request on not handled lead type" do
+      mock(HTTPoison, :post, {:ok, %{body: ~s({"status":"success"})}})
+
+      assert {:error, :lead_type_not_handled} = Client.create_lead(%{})
+
+      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
+
+      refute_called(HTTPoison, :post, [^uri, "{}"])
+    end
+
+    test "should handle request error" do
+      lead = insert(:buyer_lead)
+
+      mock(HTTPoison, :post, {:error, %HTTPoison.Error{id: nil, reason: :timeout}})
+
+      assert {:error, %{reason: :timeout}} = Client.create_lead(lead)
+
+      {:ok, encoded_lead} = Jason.encode(lead)
+      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
+    end
+  end
+end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -248,6 +248,21 @@ defmodule Re.Factory do
     }
   end
 
+  def buyer_lead_factory do
+    %Re.BuyerLead{
+      uuid: UUID.uuid4(),
+      name: Name.name(),
+      phone_number: Phone.EnUs.phone(),
+      email: Enum.random([nil, Internet.email()]),
+      origin: Enum.random(~w(vivareal zap facebook imovelweb site)),
+      location: Enum.random(~w(sao-paulo|sp rio-de-janeiro|rj)),
+      budget: "$100 to $1000",
+      neighborhood: Pokemon.location(),
+      url: Internet.url(),
+      user_url: Internet.url()
+    }
+  end
+
   def grupozap_buyer_lead_factory do
     %Re.BuyerLeads.Grupozap{
       uuid: UUID.uuid4(),

--- a/config/dev.secret-example.exs
+++ b/config/dev.secret-example.exs
@@ -53,7 +53,8 @@ config :re,
   imovelweb_super_highlights_size_sao_paulo: 10,
   imovelweb_identity: "1",
   facebook_access_token: "FACEBOOK_ACCESS_TOKEN",
-  garagem_url: "localhost"
+  garagem_url: "localhost",
+  zapier_create_salesforce_lead_url: "SALESFORCE_ZAPIER_URL"
 
 config :account_kit,
   app_id: "your_dev_app_id",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,7 +63,8 @@ config :re,
     String.to_integer(System.get_env("IMOVELWEB_SUPER_HIGHLIGHTS_SIZE_SAO_PAULO")),
   imovelweb_identity: System.get_env("IMOVELWEB_IDENTITY"),
   facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN"),
-  garagem_url: System.get_env("GARAGEM_URL")
+  garagem_url: System.get_env("GARAGEM_URL"),
+  zapier_create_salesforce_lead_url: System.get_env("SALESFORCE_ZAPIER_URL")
 
 config :re_integrations,
   to: System.get_env("INTEREST_NOTIFICATION_EMAILS"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -64,7 +64,8 @@ config :re,
   imovelweb_super_highlights_size_sao_paulo: 5,
   imovelweb_identity: "1",
   facebook_access_token: "testsecret",
-  garagem_url: "http://localhost:3000"
+  garagem_url: "http://localhost:3000",
+  zapier_create_salesforce_lead_url: "http://www.emcasa.com/salesforce_zapier"
 
 config :re_integrations,
   http: ReIntegrations.TestHTTP,


### PR DESCRIPTION
To be able to replace skyvia's integration (which has some limitations), we'll be adding a zap that easily integrates with salesforce.

This code is a client for zapier's `create_salesforce_lead` webhook.