### PR TITLE
Create salesforce lead on buyer lead insertion

### DIFF
--- a/apps/re/lib/buyer_leads/buyer_lead.ex
+++ b/apps/re/lib/buyer_leads/buyer_lead.ex
@@ -8,9 +8,6 @@ defmodule Re.BuyerLead do
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
-  @derive {Jason.Encoder,
-           only:
-             ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a}
   schema "buyer_leads" do
     field :name, :string
     field :phone_number, :string

--- a/apps/re/lib/buyer_leads/buyer_leads.ex
+++ b/apps/re/lib/buyer_leads/buyer_leads.ex
@@ -5,6 +5,7 @@ defmodule Re.BuyerLeads do
   require Logger
 
   alias Re.{
+    BuyerLead,
     BuyerLeads.Budget,
     BuyerLeads.EmptySearch,
     BuyerLeads.JobQueue,
@@ -32,6 +33,13 @@ defmodule Re.BuyerLeads do
     %EmptySearch{}
     |> EmptySearch.changeset(params)
     |> insert_with_job("process_empty_search_buyer_lead")
+  end
+
+  def get(uuid) do
+    case Repo.get(BuyerLead, uuid) do
+      nil -> {:error, :not_found}
+      buyer_lead -> {:ok, buyer_lead}
+    end
   end
 
   defp insert_with_job(%{valid?: true} = changeset, type) do

--- a/apps/re/lib/buyer_leads/buyer_leads.ex
+++ b/apps/re/lib/buyer_leads/buyer_leads.ex
@@ -3,6 +3,7 @@ defmodule Re.BuyerLeads do
   Context boundary to Buyer Leads
   """
   require Logger
+  require Ecto.Query
 
   alias Re.{
     BuyerLead,
@@ -14,7 +15,8 @@ defmodule Re.BuyerLeads do
 
   alias Ecto.{
     Changeset,
-    Multi
+    Multi,
+    Query
   }
 
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
@@ -35,8 +37,16 @@ defmodule Re.BuyerLeads do
     |> insert_with_job("process_empty_search_buyer_lead")
   end
 
-  def get(uuid) do
-    case Repo.get(BuyerLead, uuid) do
+  def get(uuid), do: do_get(BuyerLead, uuid)
+
+  def get_preloaded(uuid, preloads) do
+    BuyerLead
+    |> Query.preload(^preloads)
+    |> do_get(uuid)
+  end
+
+  defp do_get(query, uuid) do
+    case Repo.get(query, uuid) do
       nil -> {:error, :not_found}
       buyer_lead -> {:ok, buyer_lead}
     end

--- a/apps/re/lib/buyer_leads/job_queue.ex
+++ b/apps/re/lib/buyer_leads/job_queue.ex
@@ -84,7 +84,7 @@ defmodule Re.BuyerLeads.JobQueue do
   end
 
   def perform(%Multi{} = multi, %{"type" => "create_lead_salesforce", "uuid" => uuid}) do
-    {:ok, buyer_lead} = BuyerLeads.get(uuid)
+    {:ok, buyer_lead} = BuyerLeads.get_preloaded(uuid, listing: :address)
 
     multi
     |> Multi.run(:create_salesforce_lead, fn _repo, _changes ->

--- a/apps/re/lib/buyer_leads/salesforce/client.ex
+++ b/apps/re/lib/buyer_leads/salesforce/client.ex
@@ -5,17 +5,19 @@ defmodule Re.BuyerLeads.Salesforce.Client do
 
   alias Re.BuyerLeads.Salesforce.ZapierClient
 
+  @exported ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
+
   def create_lead(%Re.BuyerLead{} = lead) do
-    with lead <- take_params(lead),
-         {:ok, payload} <- Jason.encode(lead),
-         {:ok, %{status_code: 200, body: body}} <- ZapierClient.post(payload) do
-      Jason.decode(body)
+    lead
+    |> Map.take(@exported)
+    |> Map.update(:phone_number, "", fn phone -> String.replace(phone, "+", "") end)
+    |> Jason.encode!()
+    |> ZapierClient.post()
+    |> case do
+      {:ok, %{status_code: 200, body: body}} -> Jason.decode(body)
+      error -> error
     end
   end
 
   def create_lead(_lead), do: {:error, :lead_type_not_handled}
-
-  @exported ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
-
-  defp take_params(lead), do: Map.take(lead, @exported)
 end

--- a/apps/re/lib/buyer_leads/salesforce/client.ex
+++ b/apps/re/lib/buyer_leads/salesforce/client.ex
@@ -6,11 +6,16 @@ defmodule Re.BuyerLeads.Salesforce.Client do
   alias Re.BuyerLeads.Salesforce.ZapierClient
 
   def create_lead(%Re.BuyerLead{} = lead) do
-    with {:ok, payload} <- Jason.encode(lead),
+    with lead <- take_params(lead),
+         {:ok, payload} <- Jason.encode(lead),
          {:ok, %{status_code: 200, body: body}} <- ZapierClient.post(payload) do
       Jason.decode(body)
     end
   end
 
   def create_lead(_lead), do: {:error, :lead_type_not_handled}
+
+  @exported ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
+
+  defp take_params(lead), do: Map.take(lead, @exported)
 end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -1,9 +1,8 @@
 defmodule Re.BuyerLeads.JobQueueTest do
   use Re.ModelCase
+  use Mockery
 
   import Re.Factory
-
-  import Mockery
 
   alias Re.{
     BuyerLead,
@@ -27,6 +26,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -44,6 +44,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -60,6 +61,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -76,6 +78,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.phone_number == "not informed"
@@ -93,6 +96,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -111,6 +115,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -136,6 +141,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -173,6 +179,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -194,6 +201,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -217,6 +225,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -241,6 +250,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -265,6 +275,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -287,6 +298,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -315,6 +327,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -332,6 +345,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -353,6 +367,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert {:ok, _} = JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -382,6 +397,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert {:ok, _} = JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.phone_number == "011999999999"
@@ -411,6 +427,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"
@@ -439,6 +456,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"
@@ -466,6 +484,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
+      assert Repo.one(JobQueue)
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"
@@ -488,6 +507,45 @@ defmodule Re.BuyerLeads.JobQueueTest do
       refute Repo.get_by(JobQueue, state: "FAILED")
       assert job = Repo.get(JobQueue, id)
       assert job.state == "SCHEDULED"
+    end
+  end
+
+  describe "create_lead_salesforce" do
+    test "create lead" do
+      lead = insert(:buyer_lead)
+
+      mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "create_lead_salesforce",
+                 "uuid" => lead.uuid
+               })
+
+      refute Repo.one(JobQueue)
+      {:ok, encoded_lead} = Jason.encode(lead)
+      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
+    end
+
+    test "raise when there's a timeout" do
+      lead = insert(:buyer_lead)
+
+      mock(HTTPoison, :post, {:error, %{reason: :timeout}})
+
+      assert_raise RuntimeError, fn ->
+        assert {:error, _} =
+                 JobQueue.perform(Multi.new(), %{
+                   "type" => "create_lead_salesforce",
+                   "uuid" => lead.uuid
+                 })
+      end
+
+      {:ok, encoded_lead} = Jason.encode(lead)
+      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
     end
   end
 end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -512,7 +512,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
 
   describe "create_lead_salesforce" do
     test "create lead" do
-      lead = insert(:buyer_lead)
+      lead = insert(:buyer_lead, listing: build(:listing, address: build(:address)))
 
       mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
 
@@ -530,7 +530,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
     end
 
     test "raise when there's a timeout" do
-      lead = insert(:buyer_lead)
+      lead = insert(:buyer_lead, listing: build(:listing, address: build(:address)))
 
       mock(HTTPoison, :post, {:error, %{reason: :timeout}})
 

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -523,14 +523,23 @@ defmodule Re.BuyerLeads.JobQueueTest do
     }
 
     setup do
-      buyer_lead = insert(:buyer_lead)
+      buyer_lead = insert(:buyer_lead, phone_number: "+5511999999999")
 
       {:ok, encoded_buyer_lead} =
-        buyer_lead
-        |> Map.take(
-          ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
-        )
-        |> Jason.encode()
+        Jason.encode(%{
+          uuid: buyer_lead.uuid,
+          name: buyer_lead.name,
+          phone_number: "5511999999999",
+          origin: buyer_lead.origin,
+          email: buyer_lead.email,
+          location: buyer_lead.location,
+          listing_uuid: buyer_lead.listing_uuid,
+          user_uuid: buyer_lead.user_uuid,
+          budget: buyer_lead.budget,
+          neighborhood: buyer_lead.neighborhood,
+          url: buyer_lead.url,
+          user_url: buyer_lead.user_url
+        })
 
       {:ok, buyer_lead: buyer_lead, encoded_buyer_lead: encoded_buyer_lead}
     end

--- a/apps/re/test/buyer_leads/salesforce/client_test.exs
+++ b/apps/re/test/buyer_leads/salesforce/client_test.exs
@@ -1,4 +1,4 @@
-defmodule Re.BuyerLeads.SalesforceTest do
+defmodule Re.BuyerLeads.Salesforce.ClientTest do
   use Re.ModelCase
   use Mockery
 

--- a/apps/re/test/buyer_leads/salesforce/client_test.exs
+++ b/apps/re/test/buyer_leads/salesforce/client_test.exs
@@ -19,14 +19,23 @@ defmodule Re.BuyerLeads.Salesforce.ClientTest do
     }
 
     setup do
-      buyer_lead = insert(:buyer_lead)
+      buyer_lead = insert(:buyer_lead, phone_number: "+5511999999999")
 
       {:ok, encoded_buyer_lead} =
-        buyer_lead
-        |> Map.take(
-          ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
-        )
-        |> Jason.encode()
+        Jason.encode(%{
+          uuid: buyer_lead.uuid,
+          name: buyer_lead.name,
+          phone_number: "5511999999999",
+          origin: buyer_lead.origin,
+          email: buyer_lead.email,
+          location: buyer_lead.location,
+          listing_uuid: buyer_lead.listing_uuid,
+          user_uuid: buyer_lead.user_uuid,
+          budget: buyer_lead.budget,
+          neighborhood: buyer_lead.neighborhood,
+          url: buyer_lead.url,
+          user_url: buyer_lead.user_url
+        })
 
       {:ok, buyer_lead: buyer_lead, encoded_buyer_lead: encoded_buyer_lead}
     end

--- a/apps/re/test/buyer_leads/salesforce/client_test.exs
+++ b/apps/re/test/buyer_leads/salesforce/client_test.exs
@@ -7,17 +7,40 @@ defmodule Re.BuyerLeads.Salesforce.ClientTest do
   alias Re.BuyerLeads.Salesforce.Client
 
   describe "create_lead/1" do
-    test "should send a request to create a lead" do
-      lead = insert(:buyer_lead)
+    @uri %URI{
+      authority: "www.emcasa.com",
+      fragment: nil,
+      host: "www.emcasa.com",
+      path: "/salesforce_zapier",
+      port: 80,
+      query: nil,
+      scheme: "http",
+      userinfo: nil
+    }
 
+    setup do
+      buyer_lead = insert(:buyer_lead)
+
+      {:ok, encoded_buyer_lead} =
+        buyer_lead
+        |> Map.take(
+          ~w(uuid name phone_number origin email location listing_uuid user_uuid budget neighborhood url user_url)a
+        )
+        |> Jason.encode()
+
+      {:ok, buyer_lead: buyer_lead, encoded_buyer_lead: encoded_buyer_lead}
+    end
+
+    test "should send a request to create a lead", %{
+      buyer_lead: buyer_lead,
+      encoded_buyer_lead: encoded_buyer_lead
+    } do
       mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
 
-      assert {:ok, %{"status" => "success"}} = Client.create_lead(lead)
+      assert {:ok, %{"status" => "success"}} = Client.create_lead(buyer_lead)
 
-      {:ok, encoded_lead} = Jason.encode(lead)
-      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
-
-      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
+      uri = @uri
+      assert_called(HTTPoison, :post, [^uri, ^encoded_buyer_lead])
     end
 
     test "should not send a request on not handled lead type" do
@@ -25,22 +48,20 @@ defmodule Re.BuyerLeads.Salesforce.ClientTest do
 
       assert {:error, :lead_type_not_handled} = Client.create_lead(%{})
 
-      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
-
+      uri = @uri
       refute_called(HTTPoison, :post, [^uri, "{}"])
     end
 
-    test "should handle request error" do
-      lead = insert(:buyer_lead)
-
+    test "should handle request error", %{
+      buyer_lead: buyer_lead,
+      encoded_buyer_lead: encoded_buyer_lead
+    } do
       mock(HTTPoison, :post, {:error, %HTTPoison.Error{id: nil, reason: :timeout}})
 
-      assert {:error, %{reason: :timeout}} = Client.create_lead(lead)
+      assert {:error, %{reason: :timeout}} = Client.create_lead(buyer_lead)
 
-      {:ok, encoded_lead} = Jason.encode(lead)
-      uri = URI.parse("http://www.emcasa.com/salesforce_zapier")
-
-      assert_called(HTTPoison, :post, [^uri, ^encoded_lead])
+      uri = @uri
+      assert_called(HTTPoison, :post, [^uri, ^encoded_buyer_lead])
     end
   end
 end


### PR DESCRIPTION
Add an `ecto_job` for a job to send a lead to salesforce+zapier.
This will replace the insert sync skyvia is doing.
It requires some testing in staging environment and setup the production integration as well, so will keep in draft until tested.