### PR TITLE
Add cache version per environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,30 @@ jobs:
 
       - restore_cache:
           keys:
-            - {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}
-            - {{ CACHE_VERSION }}-mix-cache
+            - mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}
+            - mix-{{ CACHE_VERSION }}-cache
       - restore_cache:
           keys:
-            - {{ CACHE_VERSION }}-build-cache-{{ .Branch }}
-            - {{ CACHE_VERSION }}-build-cache
+            - build-{{ CACHE_VERSION }}-cache-{{ .Branch }}
+            - build-{{ CACHE_VERSION }}-cache
       - run: mix deps.get
       - run: mix compile --warnings-as-errors --force
       - run: mix format --check-formatted --dry-run
       - save_cache:
-          key: {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}
+          key: mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: {{ CACHE_VERSION }}-mix-cache
+          key: mix-{{ CACHE_VERSION }}-cache
           paths: "deps"
       - save_cache:
-          key: {{ CACHE_VERSION }}-build-cache-{{ .Branch }}
+          key: build-{{ CACHE_VERSION }}-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: {{ CACHE_VERSION }}-build-cache
+          key: build-{{ CACHE_VERSION }}-cache
           paths: "_build"
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,30 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - v1-mix-cache-{{ .Branch }}
-            - v1-mix-cache
+            - {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}
+            - {{ CACHE_VERSION }}-mix-cache
       - restore_cache:
           keys:
-            - v1-build-cache-{{ .Branch }}
-            - v1-build-cache
+            - {{ CACHE_VERSION }}-build-cache-{{ .Branch }}
+            - {{ CACHE_VERSION }}-build-cache
       - run: mix deps.get
       - run: mix compile --warnings-as-errors --force
       - run: mix format --check-formatted --dry-run
       - save_cache:
-          key: v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: v1-mix-cache-{{ .Branch }}
+          key: {{ CACHE_VERSION }}-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: v1-mix-cache
+          key: {{ CACHE_VERSION }}-mix-cache
           paths: "deps"
       - save_cache:
-          key: v1-build-cache-{{ .Branch }}
+          key: {{ CACHE_VERSION }}-build-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: v1-build-cache
+          key: {{ CACHE_VERSION }}-build-cache
           paths: "_build"
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,30 +22,30 @@ jobs:
 
       - restore_cache:
           keys:
-            - mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-            - mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}
-            - mix-{{ CACHE_VERSION }}-cache
+            - $CACHE_VERSION-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - $CACHE_VERSION-mix-cache-{{ .Branch }}
+            - $CACHE_VERSION-mix-cache
       - restore_cache:
           keys:
-            - build-{{ CACHE_VERSION }}-cache-{{ .Branch }}
-            - build-{{ CACHE_VERSION }}-cache
+            - $CACHE_VERSION-build-cache-{{ .Branch }}
+            - $CACHE_VERSION-build-cache
       - run: mix deps.get
       - run: mix compile --warnings-as-errors --force
       - run: mix format --check-formatted --dry-run
       - save_cache:
-          key: mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: $CACHE_VERSION-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: mix-{{ CACHE_VERSION }}-cache-{{ .Branch }}
+          key: $CACHE_VERSION-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: mix-{{ CACHE_VERSION }}-cache
+          key: $CACHE_VERSION-mix-cache
           paths: "deps"
       - save_cache:
-          key: build-{{ CACHE_VERSION }}-cache-{{ .Branch }}
+          key: $CACHE_VERSION-build-cache-{{ .Branch }}
           paths: "_build"
       - save_cache:
-          key: build-{{ CACHE_VERSION }}-cache
+          key: $CACHE_VERSION-build-cache
           paths: "_build"
 
       - run:

--- a/apps/re/lib/images/images.ex
+++ b/apps/re/lib/images/images.ex
@@ -14,7 +14,7 @@ defmodule Re.Images do
 
   alias Ecto.Changeset
 
-  @http Application.get_env(:re_integrations, :http, HTTPoison)
+  @http Application.get_env(:re, :http, HTTPoison)
 
   defdelegate authorize(action, user, params), to: Re.Images.Policy
 

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -7,11 +7,10 @@ defmodule Re.PriceSuggestions do
   alias Re.{
     Listing,
     PriceSuggestions.Request,
+    PriceTeller,
     Repo,
     User
   }
-
-  alias ReIntegrations.PriceTeller
 
   alias Ecto.Changeset
 

--- a/apps/re/lib/price_suggestions/priceteller/client.ex
+++ b/apps/re/lib/price_suggestions/priceteller/client.ex
@@ -1,11 +1,11 @@
-defmodule ReIntegrations.PriceTeller.Client do
+defmodule Re.PriceTeller.Client do
   @moduledoc """
   Module to wrap priceteller API logic
   """
   require Mockery.Macro
 
-  @url Application.get_env(:re_integrations, :priceteller_url, "")
-  @token Application.get_env(:re_integrations, :priceteller_token, "")
+  @url Application.get_env(:re, :priceteller_url, "")
+  @token Application.get_env(:re, :priceteller_token, "")
 
   def post(params) do
     {:ok, payload} = Poison.encode(%{payload: params})

--- a/apps/re/lib/price_suggestions/priceteller/input.ex
+++ b/apps/re/lib/price_suggestions/priceteller/input.ex
@@ -1,4 +1,4 @@
-defmodule ReIntegrations.PriceTeller.Input do
+defmodule Re.PriceTeller.Input do
   @moduledoc """
   Module for validating priceteller input parameters
   """

--- a/apps/re/lib/price_suggestions/priceteller/output.ex
+++ b/apps/re/lib/price_suggestions/priceteller/output.ex
@@ -1,4 +1,4 @@
-defmodule ReIntegrations.PriceTeller.Output do
+defmodule Re.PriceTeller.Output do
   @moduledoc """
   Module for validating priceteller output payload
   """

--- a/apps/re/lib/price_suggestions/priceteller/price_teller.ex
+++ b/apps/re/lib/price_suggestions/priceteller/price_teller.ex
@@ -1,4 +1,4 @@
-defmodule ReIntegrations.PriceTeller do
+defmodule Re.PriceTeller do
   @moduledoc """
   Context module for price suggestion
   """
@@ -12,7 +12,7 @@ defmodule ReIntegrations.PriceTeller do
     Client
   }
 
-  @retry_expiry Application.get_env(:re_integrations, :retry_expiry, 30_000)
+  @retry_expiry Application.get_env(:re, :retry_expiry, 30_000)
 
   def ask(params) do
     with {:ok, params} <- Input.validate(params),

--- a/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
+++ b/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
@@ -1,9 +1,9 @@
-defmodule ReIntegrations.PriceTellerTest do
+defmodule Re.PriceTellerTest do
   use Re.ModelCase
 
   import Mockery
 
-  alias ReIntegrations.PriceTeller
+  alias Re.PriceTeller
 
   @valid_payload %{
     type: "APARTMENT",

--- a/apps/re/test/support/test_http.ex
+++ b/apps/re/test/support/test_http.ex
@@ -8,4 +8,7 @@ defmodule Re.TestHTTP do
          body:
            "{\"created_time\":\"2010-01-01T10:00:00+0000\",\"id\":\"12345\",\"field_data\":[{\"name\":\"full_name\",\"values\":[\"mah name\"]},{\"name\":\"phone_number\",\"values\":[\"+5511999999999\"]},{\"name\":\"qual_o_seu_objetivo?\",\"values\":[\"quero_comprar_um_imóvel\"]},{\"name\":\"qual_região_vocêa_tem_interesse?\",\"values\":[\"outros_(zona_norte)\"]},{\"name\":\"email\",\"values\":[\"admin@emcasa.com\"]}],\"retailer_item_id\":\"1\"}"
        }}
+
+  def get("https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385/" <> filename),
+    do: {:ok, %{body: filename}}
 end

--- a/apps/re_integrations/test/support/test_http.ex
+++ b/apps/re_integrations/test/support/test_http.ex
@@ -1,9 +1,6 @@
 defmodule ReIntegrations.TestHTTP do
   @moduledoc false
 
-  def get("https://res.cloudinary.com/emcasa/image/upload/f_auto/v1513818385/" <> filename),
-    do: {:ok, %{body: filename}}
-
   def get(%URI{path: "/buildings/1/typologies/1/units"}, _) do
     {:ok, %{body: "{\"units\": []}"}}
   end

--- a/config/dev.secret-example.exs
+++ b/config/dev.secret-example.exs
@@ -34,8 +34,6 @@ config :re_integrations,
   grupozap_webhook_secret: "grupozap_secret",
   zapier_webhook_user: "testuser",
   zapier_webhook_pass: "testpass",
-  priceteller_url: "priceteller_url",
-  priceteller_token: "mahtoken",
   orulo_url: "orulo_url",
   orulo_api_token: "orulo_api_token",
   orulo_client_token: "orulo_client_token"
@@ -54,7 +52,9 @@ config :re,
   imovelweb_identity: "1",
   facebook_access_token: "FACEBOOK_ACCESS_TOKEN",
   garagem_url: "localhost",
-  zapier_create_salesforce_lead_url: "SALESFORCE_ZAPIER_URL"
+  zapier_create_salesforce_lead_url: "SALESFORCE_ZAPIER_URL",
+  priceteller_url: "priceteller_url",
+  priceteller_token: "mahtoken"
 
 config :account_kit,
   app_id: "your_dev_app_id",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -64,7 +64,9 @@ config :re,
   imovelweb_identity: System.get_env("IMOVELWEB_IDENTITY"),
   facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN"),
   garagem_url: System.get_env("GARAGEM_URL"),
-  zapier_create_salesforce_lead_url: System.get_env("SALESFORCE_ZAPIER_URL")
+  zapier_create_salesforce_lead_url: System.get_env("SALESFORCE_ZAPIER_URL"),
+  priceteller_url: System.get_env("PRICETELLER_URL"),
+  priceteller_token: System.get_env("PRICETELLER_TOKEN")
 
 config :re_integrations,
   to: System.get_env("INTEREST_NOTIFICATION_EMAILS"),
@@ -81,8 +83,6 @@ config :re_integrations,
   grupozap_webhook_secret: System.get_env("GRUPOZAP_WEBHOOK_SECRET"),
   zapier_webhook_user: System.get_env("ZAPIER_WEBHOOK_USER"),
   zapier_webhook_pass: System.get_env("ZAPIER_WEBHOOK_PASS"),
-  priceteller_url: System.get_env("PRICETELLER_URL"),
-  priceteller_token: System.get_env("PRICETELLER_TOKEN"),
   orulo_url: System.get_env("ORULO_URL"),
   orulo_api_token: System.get_env("ORULO_API_TOKEN"),
   orulo_client_token: System.get_env("ORULO_CLIENT_TOKEN")

--- a/config/test.exs
+++ b/config/test.exs
@@ -65,7 +65,10 @@ config :re,
   imovelweb_identity: "1",
   facebook_access_token: "testsecret",
   garagem_url: "http://localhost:3000",
-  zapier_create_salesforce_lead_url: "http://www.emcasa.com/salesforce_zapier"
+  zapier_create_salesforce_lead_url: "http://www.emcasa.com/salesforce_zapier",
+  priceteller_url: "http://www.emcasa.com/priceteller",
+  priceteller_token: "mahtoken",
+  retry_expiry: 100
 
 config :re_integrations,
   http: ReIntegrations.TestHTTP,
@@ -76,10 +79,7 @@ config :re_integrations,
   grupozap_webhook_secret: "testsecret",
   zapier_webhook_user: "testuser",
   zapier_webhook_pass: "testpass",
-  priceteller_url: "http://www.emcasa.com/priceteller",
-  priceteller_token: "mahtoken",
   cloudinary_client: ReIntegrations.TestCloudex,
-  retry_expiry: 100,
   orulo_url: "http://www.emcasa.com/orulo"
 
 config :junit_formatter,


### PR DESCRIPTION
Added a `CACHE_VERSION` environment variable in CircleCI to be able to update the cache version without changing the config file.
This enables cache resetting through a env var update.

*UPDATE*
Since resetting the cache, `--warning-as-error` decided to work with umbrella soft circular dependency, so I moved some stuff to fix.

We should review our umbrella structure as it's a recurring problem when we want to reference "integrations" from the domain app.