### PR TITLE
feature(listings): allow exclude listings from primary market who are…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ erl_crash.dump
 /cover
 /test/temp
 .tool-versions-e
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ erl_crash.dump
 /cover
 /test/temp
 .tool-versions-e
-/.vscode

--- a/apps/re/lib/listings/filters/filters.ex
+++ b/apps/re/lib/listings/filters/filters.ex
@@ -52,6 +52,7 @@ defmodule Re.Listings.Filters do
     field :min_maintenance_fee, :float
     field :max_maintenance_fee, :float
     field :is_release, :boolean
+    field :exclude_similar_for_primary_market, :boolean
   end
 
   @filters ~w(max_price min_price max_rooms min_rooms max_suites min_suites min_area max_area
@@ -60,7 +61,7 @@ defmodule Re.Listings.Filters do
               exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
               min_unit_per_floor max_unit_per_floor orientations sun_periods min_age max_age
               min_price_per_area max_price_per_area min_maintenance_fee max_maintenance_fee
-              max_bathrooms min_bathrooms is_release)a
+              max_bathrooms min_bathrooms is_release exclude_similar_for_primary_market)a
 
   def changeset(struct, params \\ %{}), do: cast(struct, params, @filters)
 
@@ -355,6 +356,13 @@ defmodule Re.Listings.Filters do
     from(
       l in query,
       where: l.is_release == ^is_release
+    )
+  end
+
+  defp attr_filter({:exclude_similar_for_primary_market, true}, query) do
+    from(
+      l in query,
+      where: not (l.is_release == true and l.is_exportable == false)
     )
   end
 

--- a/apps/re/test/listings/filters/filters_test.exs
+++ b/apps/re/test/listings/filters/filters_test.exs
@@ -698,6 +698,29 @@ defmodule Re.Listings.FiltersTest do
       assert_mapper_match([%{id: id}], result, &map_id/1)
     end
 
+    test "filter by exclude_similar_for_primary_market when is true return listings from secondary market or from primary market exportable" do
+      listing_1 =
+        build(:listing)
+        |> for_secondary_market()
+        |> insert()
+
+      listing_2 =
+        build(:listing, is_exportable: true)
+        |> for_primary_market()
+        |> insert()
+
+      build(:listing, is_exportable: false)
+      |> for_primary_market()
+      |> insert()
+
+      result =
+        Listing
+        |> Filters.apply(%{exclude_similar_for_primary_market: true})
+        |> Repo.all()
+
+      assert_mapper_match([listing_1, listing_2], result, &map_id/1)
+    end
+
     test "apply all filters at once" do
       tag_1 = insert(:tag, name: "Tag 1", name_slug: "tag-1")
       tag_2 = insert(:tag, name: "Tag 2", name_slug: "tag-2")

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -66,6 +66,14 @@ defmodule Re.Factory do
     }
   end
 
+  def for_primary_market(listing) do
+    %{listing | is_release: true}
+  end
+
+  def for_secondary_market(listing) do
+    %{listing | is_release: false}
+  end
+
   def address_factory do
     street_name = Address.street_name()
     street_slug = Re.Slugs.sluggify(street_name)

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -248,6 +248,7 @@ defmodule ReWeb.Types.Listing do
     field :min_maintenance_fee, :float
     field :max_maintenance_fee, :float
     field :is_release, :boolean
+    field :exclude_similar_for_primary_market, :boolean
   end
 
   object :listing_filter do
@@ -287,6 +288,7 @@ defmodule ReWeb.Types.Listing do
     field :min_price_per_area, :float
     field :max_price_per_area, :float
     field :is_release, :boolean
+    field :exclude_similar_for_primary_market, :boolean
   end
 
   object :price_history do


### PR DESCRIPTION
Allow removing listings from search when has multiple similar results. 

Now listings with the different area and features, are marked manually to appear on integrations. Someday we can change this heuristic, but the principle will be the same, don't show similar links and make search bad/ugly with multiple results.  