### PR TITLE
feature(garage-type): remove unknown from allowed garage types

### DIFF
--- a/apps/re/lib/developments/units/unit.ex
+++ b/apps/re/lib/developments/units/unit.ex
@@ -36,7 +36,7 @@ defmodule Re.Unit do
     timestamps()
   end
 
-  @garage_types ~w(contract condominium unknown)
+  @garage_types ~w(contract condominium)
   @statuses ~w(active inactive)
 
   @required ~w(price rooms bathrooms area garage_spots suites development_uuid status)a

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -82,7 +82,7 @@ defmodule Re.Listing do
 
   @types ~w(Apartamento Casa Cobertura)
 
-  @garage_types ~w(contract condominium unknown)
+  @garage_types ~w(contract condominium)
 
   @orientation_types ~w(frontside backside lateral inside)
 

--- a/apps/re/priv/repo/migrations/20190625210930_remove_unknown_from_garage_type.exs
+++ b/apps/re/priv/repo/migrations/20190625210930_remove_unknown_from_garage_type.exs
@@ -1,0 +1,18 @@
+defmodule Re.Repo.Migrations.RemoveUnknownFromGarageType do
+  use Ecto.Migration
+
+  require Ecto.Query
+
+  def up do
+    "listings"
+    |> Ecto.Query.where([l], l.garage_type == "unknown")
+    |> Re.Repo.update_all(set: [garage_type: nil])
+
+    "units"
+    |> Ecto.Query.where([l], l.garage_type == "unknown")
+    |> Re.Repo.update_all(set: [garage_type: nil])
+  end
+
+  def down do
+  end
+end

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -144,7 +144,7 @@ defmodule Re.ListingTest do
                {"is invalid", [type: :integer, validation: :cast]}
 
       assert Keyword.get(changeset.errors, :garage_type) ==
-               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium unknown)]}
+               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium)]}
 
       changeset = Listing.changeset(%Listing{}, %{score: 0, price: 110_000_000})
       refute changeset.valid?

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -111,7 +111,7 @@ defmodule Re.UnitTest do
                 [validation: :number, kind: :greater_than_or_equal_to, number: 0]}
 
       assert Keyword.get(changeset.errors, :garage_type) ==
-               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium unknown)]}
+               {"is invalid", [validation: :inclusion, enum: ~w(contract condominium)]}
 
       assert Keyword.get(changeset.errors, :status) ==
                {"is invalid", [validation: :inclusion, enum: ~w(active inactive)]}

--- a/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
@@ -50,8 +50,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
   end
 
   @static_params %{
-    status: "active",
-    garage_type: "unknown"
+    status: "active"
   }
 
   defp insert_unit(unit, typology, development) do

--- a/apps/re_integrations/test/orulo/payload_processor_test.exs
+++ b/apps/re_integrations/test/orulo/payload_processor_test.exs
@@ -125,7 +125,6 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert inserted_unit_1.bathrooms == 2
       assert inserted_unit_1.suites == 1
       assert inserted_unit_1.garage_spots == 2
-      assert inserted_unit_1.garage_type == "unknown"
       assert inserted_unit_1.complement == "50"
       assert inserted_unit_1.status == "active"
 
@@ -136,7 +135,6 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert inserted_unit_2.bathrooms == 2
       assert inserted_unit_2.suites == 1
       assert inserted_unit_2.garage_spots == 2
-      assert inserted_unit_2.garage_type == "unknown"
       assert inserted_unit_2.complement == "100"
       assert inserted_unit_1.status == "active"
     end
@@ -248,7 +246,6 @@ defmodule ReIntegrations.Orulo.PayloadProcessorTest do
       assert inserted_unit_1.bathrooms == 2
       assert inserted_unit_1.suites == 1
       assert inserted_unit_1.garage_spots == 2
-      assert inserted_unit_1.garage_type == "unknown"
       assert inserted_unit_1.complement == "51"
       assert inserted_unit_1.status == "active"
     end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -132,7 +132,7 @@ defmodule ReWeb.Types.Listing do
     field :owner_contact, :owner_contact_input
   end
 
-  enum :garage_type, values: ~w(contract condominium unknown)
+  enum :garage_type, values: ~w(contract condominium)
 
   enum :orientation_type, values: ~w(frontside backside lateral inside)
 


### PR DESCRIPTION
I didn't ask around while adding this new option. The `unknown` looks confuse to read on external tools, use nil/null/empty value is preferred in these cases.
 
¯\_(ツ)_/¯