### PR TITLE
Units/refactor optional params

### DIFF
--- a/apps/re/lib/developments/units/units.ex
+++ b/apps/re/lib/developments/units/units.ex
@@ -65,26 +65,20 @@ defmodule Re.Units do
     end
   end
 
-  def update(unit, params, development, listing \\ nil)
-
-  def update(unit, params, development, nil) do
+  def update(unit, params, opts) do
     changeset =
       unit
-      |> Changeset.change(development_uuid: development.uuid)
+      |> changeset_for_opts(opts)
       |> Unit.changeset(params)
 
     changeset
     |> Repo.update()
   end
 
-  def update(unit, params, development, listing) do
-    changeset =
-      unit
-      |> Changeset.change(development_uuid: development.uuid)
-      |> Changeset.change(listing_id: listing.id)
-      |> Unit.changeset(params)
-
-    changeset
-    |> Repo.update()
+  defp changeset_for_opts(unit, opts) do
+    Enum.reduce(opts, Changeset.change(unit), fn
+      {:development, development}, changeset ->
+        Changeset.change(changeset, %{development_uuid: development.uuid})
+    end)
   end
 end

--- a/apps/re/lib/developments/units/units.ex
+++ b/apps/re/lib/developments/units/units.ex
@@ -41,9 +41,9 @@ defmodule Re.Units do
     end
   end
 
-  def insert(params, development) do
+  def insert(params, opts) do
     %Unit{}
-    |> Changeset.change(development_uuid: development.uuid)
+    |> changeset_for_opts(opts)
     |> Unit.changeset(params)
     |> do_new_unit()
   end
@@ -65,7 +65,7 @@ defmodule Re.Units do
     end
   end
 
-  def update(unit, params, opts) do
+  def update(unit, params, opts \\ []) do
     changeset =
       unit
       |> changeset_for_opts(opts)

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -31,7 +31,7 @@ defmodule Re.UnitsTest do
       development = insert(:development)
 
       assert {:ok, %{add_unit: inserted_unit, units_job: _}} =
-               Units.insert(@unit_attrs, development)
+               Units.insert(@unit_attrs, development: development)
 
       retrieved_unit = Repo.get(Unit, inserted_unit.uuid)
 
@@ -42,7 +42,7 @@ defmodule Re.UnitsTest do
     test "create new development job" do
       development = insert(:development)
 
-      assert {:ok, _} = Units.insert(@unit_attrs, development)
+      assert {:ok, _} = Units.insert(@unit_attrs, development: development)
 
       assert Repo.one(Re.Developments.JobQueue)
     end

--- a/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/typologies.ex
@@ -57,7 +57,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Typologies do
     typology
     |> TypologyMapper.typology_payload_into_unit_params(unit)
     |> Map.merge(@static_params)
-    |> Units.insert(development)
+    |> Units.insert(development: development)
   end
 
   defp extract_typology_info_from_payload(id, %{"typologies" => typologies}) do

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -12,7 +12,7 @@ defmodule ReWeb.Resolvers.Units do
   def insert(%{input: params}, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Units, :create_unit, current_user, params),
          {:ok, development} <- get_development(params),
-         {:ok, %{add_unit: new_unit}} <- Units.insert(params, development) do
+         {:ok, %{add_unit: new_unit}} <- Units.insert(params, development: development) do
       {:ok, new_unit}
     else
       {:error, _, error, _} -> {:error, error}

--- a/apps/re_web/lib/graphql/resolvers/units.ex
+++ b/apps/re_web/lib/graphql/resolvers/units.ex
@@ -26,7 +26,7 @@ defmodule ReWeb.Resolvers.Units do
     with :ok <- Bodyguard.permit(Units, :update_unit, current_user, params),
          {:ok, unit} <- Units.get(uuid),
          {:ok, development} <- get_development(params),
-         {:ok, new_unit} <- Units.update(unit, params, development) do
+         {:ok, new_unit} <- Units.update(unit, params, development: development) do
       {:ok, new_unit}
     end
   end


### PR DESCRIPTION
While adding another feature passed by this old refactor opportunity, also remove a section from the code which wasn't being used (`def update(unit, params, development, listing) do ...`) anymore. 