### PR TITLE
Ignore priceteller invalid params

### DIFF
--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -10,7 +10,10 @@ defmodule Re.Listings.JobQueue do
     Repo
   }
 
-  alias Ecto.Multi
+  alias Ecto.{
+    Changeset,
+    Multi
+  }
 
   def perform(%Multi{} = multi, %{"type" => "save_price_suggestion", "uuid" => uuid}) do
     listing = Repo.get_by(Listing, uuid: uuid)
@@ -24,6 +27,9 @@ defmodule Re.Listings.JobQueue do
         multi
         |> Multi.update(:update_suggested_price, changeset)
         |> Repo.transaction()
+
+      {:error, %Changeset{}} ->
+        Repo.transaction(multi)
 
       error ->
         error

--- a/apps/re/test/addresses/district_test.exs
+++ b/apps/re/test/addresses/district_test.exs
@@ -1,12 +1,7 @@
 defmodule Re.Addresses.DistrictTest do
   use Re.ModelCase
 
-  alias Re.{
-    Addresses.District,
-    Repo
-  }
-
-  import Re.Factory
+  alias Re.Addresses.District
 
   @valid_attrs %{
     state: "RJ",
@@ -32,6 +27,7 @@ defmodule Re.Addresses.DistrictTest do
     refute changeset.valid?
 
     assert Keyword.get(changeset.errors, :status) ==
-             {"is invalid", [validation: :inclusion, enum: ~w(covered partially_covered uncovered)]}
+             {"is invalid",
+              [validation: :inclusion, enum: ~w(covered partially_covered uncovered)]}
   end
 end

--- a/apps/re/test/listings/job_queue_test.exs
+++ b/apps/re/test/listings/job_queue_test.exs
@@ -51,5 +51,20 @@ defmodule Re.Listings.JobQueueTest do
         })
       end
     end
+
+    @tag capture_log: true
+    test "do not raise when parameters are invalid" do
+      mock(HTTPoison, :post, {:error, %{error: "some error"}})
+
+      %{uuid: listing_uuid} = insert(:listing, address: build(:address), area: 0)
+
+      {:ok, _} =
+        JobQueue.perform(Multi.new(), %{
+          "type" => "save_price_suggestion",
+          "uuid" => listing_uuid
+        })
+
+      refute Repo.one(JobQueue)
+    end
   end
 end


### PR DESCRIPTION
When there's an invalid set of params passed to price suggestion through `Re.Listings.JobQueue`, finish the job to not trigger retries.