### PR TITLE
Units/mirror update

### DIFF
--- a/apps/re/lib/developments/job_queue.ex
+++ b/apps/re/lib/developments/job_queue.ex
@@ -9,6 +9,7 @@ defmodule Re.Developments.JobQueue do
 
   alias Re.{
     Developments.Listings,
+    Developments.Mirror,
     Repo,
     Unit
   }
@@ -25,5 +26,13 @@ defmodule Re.Developments.JobQueue do
     params = Listings.listing_params_from_unit(unit, development)
 
     Listings.multi_insert(multi, params, development: development, address: address, unit: unit)
+  end
+
+  def perform(%Multi{} = multi, %{"type" => "mirror_update_unit_to_listing", "uuid" => uuid}) do
+    multi
+    |> Multi.run(:mirror_unit, fn _repo, _changes ->
+      Mirror.mirror_unit_update_to_listing(uuid)
+    end)
+    |> Repo.transaction()
   end
 end

--- a/apps/re/lib/developments/mirror.ex
+++ b/apps/re/lib/developments/mirror.ex
@@ -5,14 +5,14 @@ defmodule Re.Developments.Mirror do
 
   alias Re.{
     Developments.Listings,
-    Repo
+    Units
   }
 
-  def mirror_unit_update(uuid) do
-    %{listing: listing, development: %{address: address} = development} =
-      unit =
-      Repo.get(Re.Unit, uuid)
-      |> Repo.preload(development: [:address], listing: [])
+  @unit_preload [development: [:address], listing: []]
+
+  def mirror_unit_update_to_listing(uuid) do
+    {:ok, %{listing: listing, development: %{address: address} = development} = unit} =
+      Units.get_preloaded(uuid, @unit_preload)
 
     params =
       unit
@@ -22,7 +22,7 @@ defmodule Re.Developments.Mirror do
   end
 
   @unit_cloned_attributes ~w(area price rooms bathrooms garage_spots garage_type suites complement
-                            floor status property_tax maintenance_fee balconies restrooms
+                            floor property_tax maintenance_fee balconies restrooms
                             matterport_code is_exportable)a
 
   defp to_params(unit) do

--- a/apps/re/lib/developments/mirror.ex
+++ b/apps/re/lib/developments/mirror.ex
@@ -1,0 +1,31 @@
+defmodule Re.Developments.Mirror do
+  @moduledoc """
+  Mirror developments and unit info on listings.
+  """
+
+  alias Re.{
+    Developments.Listings,
+    Repo
+  }
+
+  def mirror_unit_update(uuid) do
+    %{listing: listing, development: %{address: address} = development} =
+      unit =
+      Repo.get(Re.Unit, uuid)
+      |> Repo.preload(development: [:address], listing: [])
+
+    params =
+      unit
+      |> to_params()
+
+    Listings.update(listing, params, development: development, address: address)
+  end
+
+  @unit_cloned_attributes ~w(area price rooms bathrooms garage_spots garage_type suites complement
+                            floor status property_tax maintenance_fee balconies restrooms
+                            matterport_code is_exportable)a
+
+  defp to_params(unit) do
+    Map.take(unit, @unit_cloned_attributes)
+  end
+end

--- a/apps/re/lib/developments/units/queries.ex
+++ b/apps/re/lib/developments/units/queries.ex
@@ -12,4 +12,8 @@ defmodule Re.Units.Queries do
   def by_listing(query, id), do: where(query, [u], u.listing_id == ^id)
 
   def active(query \\ Unit), do: where(query, [u], u.status == "active")
+
+  def preload_relations(query \\ Unit, relations \\ [])
+
+  def preload_relations(query, relations), do: preload(query, ^relations)
 end

--- a/apps/re/lib/developments/units/unit.ex
+++ b/apps/re/lib/developments/units/unit.ex
@@ -25,6 +25,8 @@ defmodule Re.Unit do
     field :dependencies, :integer
     field :balconies, :integer
     field :status, :string
+    field :matterport_code, :string
+    field :is_exportable, :boolean, default: false
 
     belongs_to :development, Re.Development,
       references: :uuid,

--- a/apps/re/lib/developments/units/units.ex
+++ b/apps/re/lib/developments/units/units.ex
@@ -34,6 +34,9 @@ defmodule Re.Units do
 
   def get(uuid), do: do_get(Unit, uuid)
 
+  def get_preloaded(uuid, preload),
+    do: do_get(Queries.preload_relations(Unit, preload), uuid)
+
   defp do_get(query, uuid) do
     case Repo.get(query, uuid) do
       nil -> {:error, :not_found}

--- a/apps/re/priv/repo/migrations/20190628140231_add_attributes_to_units.exs
+++ b/apps/re/priv/repo/migrations/20190628140231_add_attributes_to_units.exs
@@ -1,0 +1,10 @@
+defmodule Re.Repo.Migrations.AddAttributesToUnits do
+  use Ecto.Migration
+
+  def change do
+    alter table(:units) do
+      add :matterport_code, :string
+      add :is_exportable, :boolean
+    end
+  end
+end

--- a/apps/re/test/developments/mirror_test.exs
+++ b/apps/re/test/developments/mirror_test.exs
@@ -9,14 +9,14 @@ defmodule Re.Developments.MirrorTest do
     Developments.Mirror
   }
 
-  describe "mirror_update_unit/1" do
+  describe "mirror_unit_update_to_listing/1" do
     test "update associated listing with unit informations" do
       address = insert(:address)
       development = insert(:development, address: address)
       %{uuid: uuid} = unit = insert(:unit, development: development)
       insert(:listing, units: [unit], development: development)
 
-      assert {:ok, %Re.Listing{} = listing} = Mirror.mirror_unit_update(uuid)
+      assert {:ok, %Re.Listing{} = listing} = Mirror.mirror_unit_update_to_listing(uuid)
 
       assert listing.area == unit.area
       assert listing.price == unit.price
@@ -28,7 +28,6 @@ defmodule Re.Developments.MirrorTest do
       assert listing.complement == unit.complement
       assert listing.floor == unit.floor
       assert listing.matterport_code == unit.matterport_code
-      assert listing.status == unit.status
       assert listing.property_tax == unit.property_tax
       assert listing.maintenance_fee == unit.maintenance_fee
       assert listing.balconies == unit.balconies

--- a/apps/re/test/developments/mirror_test.exs
+++ b/apps/re/test/developments/mirror_test.exs
@@ -1,0 +1,39 @@
+defmodule Re.Developments.MirrorTest do
+  use Re.ModelCase
+
+  import Re.{
+    Factory
+  }
+
+  alias Re.{
+    Developments.Mirror
+  }
+
+  describe "mirror_update_unit/1" do
+    test "update associated listing with unit informations" do
+      address = insert(:address)
+      development = insert(:development, address: address)
+      %{uuid: uuid} = unit = insert(:unit, development: development)
+      insert(:listing, units: [unit], development: development)
+
+      assert {:ok, %Re.Listing{} = listing} = Mirror.mirror_unit_update(uuid)
+
+      assert listing.area == unit.area
+      assert listing.price == unit.price
+      assert listing.rooms == unit.rooms
+      assert listing.bathrooms == unit.bathrooms
+      assert listing.garage_spots == unit.garage_spots
+      assert listing.garage_type == unit.garage_type
+      assert listing.suites == unit.suites
+      assert listing.complement == unit.complement
+      assert listing.floor == unit.floor
+      assert listing.matterport_code == unit.matterport_code
+      assert listing.status == unit.status
+      assert listing.property_tax == unit.property_tax
+      assert listing.maintenance_fee == unit.maintenance_fee
+      assert listing.balconies == unit.balconies
+      assert listing.restrooms == unit.restrooms
+      assert listing.is_exportable == unit.is_exportable
+    end
+  end
+end

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -1,11 +1,15 @@
 defmodule Re.UnitsTest do
+  @moduledoc false
+
   use Re.ModelCase
 
   alias Re.{
+    Developments.JobQueue,
     Unit,
     Units
   }
 
+  import Re.CustomAssertion
   import Re.Factory
 
   @unit_attrs %{
@@ -44,7 +48,20 @@ defmodule Re.UnitsTest do
 
       assert {:ok, _} = Units.insert(@unit_attrs, development: development)
 
-      assert Repo.one(Re.Developments.JobQueue)
+      assert Repo.one(JobQueue)
+    end
+  end
+
+  describe "update/2" do
+    test "create new mirror_update_unit_to_listing" do
+      development = insert(:development)
+      unit = insert(:unit)
+
+      Units.update(unit, @unit_attrs, development: development)
+
+      JobQueue
+      |> Re.Repo.all()
+      |> assert_enqueued_job("mirror_update_unit_to_listing")
     end
   end
 end

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -23,6 +23,8 @@ defmodule ReWeb.Types.Unit do
     field :dependencies, :integer
     field :balconies, :integer
     field :status, :string
+    field :matterport_code, :string
+    field :is_exportable, :boolean
   end
 
   input_object :unit_input do


### PR DESCRIPTION
Allow mirroring changes from unit to associated listing every time a unit is updated.   
The reason for this is whenever we edit a listing on the primary market we're actually editing and unit. 

--
 
Edit: also add two missing fields in the unit. 