### PR TITLE
Add missing params to UnitInput

### DIFF
--- a/apps/re/lib/developments/units/unit.ex
+++ b/apps/re/lib/developments/units/unit.ex
@@ -43,7 +43,7 @@ defmodule Re.Unit do
 
   @required ~w(price rooms bathrooms area garage_spots suites development_uuid status)a
   @optional ~w(complement floor property_tax maintenance_fee balconies restrooms garage_type
-              dependencies listing_id)a
+              dependencies listing_id matterport_code is_exportable)a
 
   @attributes @required ++ @optional
 

--- a/apps/re_web/lib/graphql/types/unit.ex
+++ b/apps/re_web/lib/graphql/types/unit.ex
@@ -44,6 +44,8 @@ defmodule ReWeb.Types.Unit do
     field :balconies, :integer
     field :status, :string
     field :development_uuid, non_null(:uuid)
+    field :matterport_code, :string
+    field :is_exportable, :boolean
   end
 
   object :unit_mutations do


### PR DESCRIPTION
Add `matterport_code` and `is_exportable` to graphql unit input.