### PR TITLE
refactor(units): Add unit mirror on insert in a dedicated module

### DIFF
--- a/apps/re/lib/developments/job_queue.ex
+++ b/apps/re/lib/developments/job_queue.ex
@@ -4,28 +4,19 @@ defmodule Re.Developments.JobQueue do
   """
   use EctoJob.JobQueue, table_name: "units_jobs"
 
-  require Ecto.Query
-  require Logger
-
   alias Re.{
-    Developments.Listings,
     Developments.Mirror,
-    Repo,
-    Unit
+    Repo
   }
 
   alias Ecto.Multi
 
   def perform(%Multi{} = multi, %{"type" => "mirror_new_unit_to_listing", "uuid" => uuid}) do
-    %{development: %{address: address} = development} =
-      unit =
-      Unit
-      |> Ecto.Query.preload(development: [:address])
-      |> Repo.get(uuid)
-
-    params = Listings.listing_params_from_unit(unit, development)
-
-    Listings.multi_insert(multi, params, development: development, address: address, unit: unit)
+    multi
+    |> Multi.run(:mirror_unit, fn _repo, _changes ->
+      Mirror.mirror_unit_insert_to_listing(uuid)
+    end)
+    |> Repo.transaction()
   end
 
   def perform(%Multi{} = multi, %{"type" => "mirror_update_unit_to_listing", "uuid" => uuid}) do

--- a/apps/re/lib/developments/listings.ex
+++ b/apps/re/lib/developments/listings.ex
@@ -8,28 +8,13 @@ defmodule Re.Developments.Listings do
     Repo
   }
 
-  alias Ecto.{
-    Changeset,
-    Multi
-  }
+  alias Ecto.Changeset
 
   def insert(params, opts) do
     %Listing{}
     |> changeset_for_opts(opts)
     |> Listing.development_changeset(params)
     |> Repo.insert()
-  end
-
-  def multi_insert(multi, params, opts) do
-    %Listing{}
-    |> changeset_for_opts(opts)
-    |> Listing.development_changeset(params)
-    |> insert_listing_on_multi(multi)
-    |> Repo.transaction()
-  end
-
-  defp insert_listing_on_multi(changeset, multi) do
-    Multi.insert(multi, :listing, changeset)
   end
 
   def update(listing, params, opts) do

--- a/apps/re/lib/developments/mirror.ex
+++ b/apps/re/lib/developments/mirror.ex
@@ -2,17 +2,30 @@ defmodule Re.Developments.Mirror do
   @moduledoc """
   Mirror developments and unit info on listings.
   """
+  require Ecto.Query
+  require Logger
 
   alias Re.{
     Developments.Listings,
     Units
   }
 
-  @unit_preload [development: [:address], listing: []]
+  @unit_preload_for_insert [development: [:address]]
+
+  def mirror_unit_insert_to_listing(uuid) do
+    {:ok, %{development: %{address: address} = development} = unit} =
+      Units.get_preloaded(uuid, @unit_preload_for_insert)
+
+    unit
+    |> Listings.listing_params_from_unit(development)
+    |> Listings.insert(development: development, address: address, unit: unit)
+  end
+
+  @unit_preload_for_update [development: [:address], listing: []]
 
   def mirror_unit_update_to_listing(uuid) do
     {:ok, %{listing: listing, development: %{address: address} = development} = unit} =
-      Units.get_preloaded(uuid, @unit_preload)
+      Units.get_preloaded(uuid, @unit_preload_for_update)
 
     params =
       unit

--- a/apps/re/test/developments/job_queue_test.exs
+++ b/apps/re/test/developments/job_queue_test.exs
@@ -17,7 +17,7 @@ defmodule Re.Developments.JobQueueTest do
       development = insert(:development, address: address)
       %{uuid: uuid} = insert(:unit, development: development)
 
-      assert {:ok, %{listing: %{id: listing_id}}} =
+      assert {:ok, %{mirror_unit: %{id: listing_id}}} =
                JobQueue.perform(Multi.new(), %{
                  "type" => "mirror_new_unit_to_listing",
                  "uuid" => uuid

--- a/apps/re/test/developments/listings_test.exs
+++ b/apps/re/test/developments/listings_test.exs
@@ -36,37 +36,6 @@ defmodule Re.Developments.ListingsTest do
     end
   end
 
-  describe "multi_inserts/2" do
-    @insert_listing_params %{
-      "type" => "Apartamento",
-      "description" => "Awesome new brand building",
-      "is_exportable" => true,
-      "price" => 1_000_000,
-      "area" => 100
-    }
-
-    test "should insert development listing" do
-      address = insert(:address)
-      development = insert(:development, address_id: address.id)
-
-      assert {:ok, %{listing: inserted_listing}} =
-               Listings.multi_insert(
-                 Ecto.Multi.new(),
-                 @insert_listing_params,
-                 address: address,
-                 development: development
-               )
-
-      assert retrieved_listing = Repo.get(Re.Listing, inserted_listing.id)
-      assert retrieved_listing.uuid
-      assert retrieved_listing.development_uuid == development.uuid
-      assert retrieved_listing.address_id == address.id
-      assert retrieved_listing.is_exportable == true
-      assert retrieved_listing.price == 1_000_000
-      assert retrieved_listing.area == 100
-    end
-  end
-
   describe "listing_params_from_unit/2" do
     test "should parse unit and development into listing" do
       development = build(:development)

--- a/apps/re/test/developments/mirror_test.exs
+++ b/apps/re/test/developments/mirror_test.exs
@@ -9,6 +9,32 @@ defmodule Re.Developments.MirrorTest do
     Developments.Mirror
   }
 
+  describe "mirror_unit_insert_to_listing/1" do
+    test "insert new listing with unit informations" do
+      address = insert(:address)
+      development = insert(:development, address: address)
+      %{uuid: uuid} = unit = insert(:unit, development: development)
+
+      assert {:ok, %Re.Listing{} = listing} = Mirror.mirror_unit_insert_to_listing(uuid)
+
+      assert listing.area == unit.area
+      assert listing.price == unit.price
+      assert listing.rooms == unit.rooms
+      assert listing.bathrooms == unit.bathrooms
+      assert listing.garage_spots == unit.garage_spots
+      assert listing.garage_type == unit.garage_type
+      assert listing.suites == unit.suites
+      assert listing.complement == unit.complement
+      assert listing.floor == unit.floor
+      assert listing.matterport_code == unit.matterport_code
+      assert listing.property_tax == unit.property_tax
+      assert listing.maintenance_fee == unit.maintenance_fee
+      assert listing.balconies == unit.balconies
+      assert listing.restrooms == unit.restrooms
+      assert listing.is_exportable == unit.is_exportable
+    end
+  end
+
   describe "mirror_unit_update_to_listing/1" do
     test "update associated listing with unit informations" do
       address = insert(:address)


### PR DESCRIPTION
This PR is refactoring only, the idea is mainly to remove logic from `job_queue` module, use the same structure made on PR #626 to mirror new units into listings. 

`multi_insert` was removed, instead, we can use common `insert` and use the response to infer if we should proceed with the transaction or rollback it and try again in the future. 