### PR TITLE
Refactor buyer leads

### DIFF
--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -6,6 +6,7 @@ defmodule Re.SellerLeads do
   alias Re.{
     PubSub,
     Repo,
+    SellerLeads.Facebook,
     SellerLeads.Site
   }
 
@@ -16,5 +17,11 @@ defmodule Re.SellerLeads do
     |> Site.changeset(params)
     |> Repo.insert()
     |> PubSub.publish_new("new_site_seller_lead")
+  end
+
+  def create(%{"source" => "facebook_seller"} = payload) do
+    %Facebook{}
+    |> Facebook.changeset(payload)
+    |> Repo.insert()
   end
 end

--- a/apps/re/test/buyer_leads/buyer_leads_test.exs
+++ b/apps/re/test/buyer_leads/buyer_leads_test.exs
@@ -2,6 +2,7 @@ defmodule Re.BuyerLeadsTest do
   use Re.ModelCase
 
   import Re.Factory
+  import Re.CustomAssertion
 
   alias Re.{
     BuyerLeads,
@@ -19,7 +20,7 @@ defmodule Re.BuyerLeadsTest do
       assert {:ok, _buyer_lead} = BuyerLeads.create_budget(params, user)
 
       assert Repo.one(Budget)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "process_budget_buyer_lead")
     end
   end
 
@@ -31,7 +32,7 @@ defmodule Re.BuyerLeadsTest do
       assert {:ok, _buyer_lead} = BuyerLeads.create_empty_search(params, user)
 
       assert Repo.one(EmptySearch)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "process_empty_search_buyer_lead")
     end
   end
 end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -3,6 +3,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
   use Mockery
 
   import Re.Factory
+  import Re.CustomAssertion
 
   alias Re.{
     BuyerLead,
@@ -26,7 +27,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -44,7 +45,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -61,7 +62,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -78,7 +79,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.phone_number == "not informed"
@@ -96,7 +97,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -115,7 +116,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "grupozap_buyer_lead", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -141,7 +142,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -164,6 +165,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       end
 
       refute Repo.one(BuyerLead)
+      refute Repo.one(JobQueue)
     end
 
     test "process lead with no user" do
@@ -179,7 +181,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -201,7 +203,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert listing_uuid == buyer.listing_uuid
@@ -225,7 +227,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -250,7 +252,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -275,7 +277,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "facebook_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -298,7 +300,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -327,7 +329,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -345,7 +347,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                JobQueue.perform(Multi.new(), %{"type" => "imovelweb_buyer", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       refute buyer.listing_uuid
@@ -367,7 +369,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert {:ok, _} = JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.listing_uuid == listing_uuid
@@ -397,7 +399,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert {:ok, _} = JobQueue.perform(Multi.new(), %{"type" => "interest", "uuid" => uuid})
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       refute buyer.user_uuid
       assert buyer.phone_number == "011999999999"
@@ -427,7 +429,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"
@@ -456,7 +458,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"
@@ -484,7 +486,7 @@ defmodule Re.BuyerLeads.JobQueueTest do
                })
 
       assert buyer = Repo.one(BuyerLead)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert buyer.uuid
       assert buyer.user_uuid == user_uuid
       assert buyer.location == "new-york|ny"

--- a/apps/re/test/interests/interests_test.exs
+++ b/apps/re/test/interests/interests_test.exs
@@ -10,8 +10,8 @@ defmodule Re.InterestsTest do
   }
 
   import Re.Factory
-
   import Mockery
+  import Re.CustomAssertion
 
   describe "request_price_suggestion/2" do
     test "should store price suggestion request" do
@@ -196,7 +196,7 @@ defmodule Re.InterestsTest do
       assert interest = Repo.get(Interest, interest.id)
       assert interest.uuid
       assert_receive %{new: _, topic: "new_interest", type: :new}
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "interest")
     end
 
     test "should not create interest in invalid listing" do

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -393,7 +393,7 @@ defmodule Re.ListingsTest do
       assert listing.status == "active"
       status_history = Repo.one(Re.Listings.StatusHistory)
       assert "inactive" == status_history.status
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "save_price_suggestion")
     end
   end
 
@@ -521,7 +521,7 @@ defmodule Re.ListingsTest do
       Listings.update(listing, %{rooms: 4}, address: address, user: user)
 
       refute Repo.one(Re.Listings.PriceHistory)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "save_price_suggestion")
     end
 
     test "should update owner contact" do
@@ -540,7 +540,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.owner_contact_uuid == updated_owner_contact.uuid
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "save_price_suggestion")
     end
 
     test "should update if owner contact is nil" do
@@ -557,7 +557,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.owner_contact_uuid == original_owner_contact.uuid
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "save_price_suggestion")
     end
 
     test "should not change user who created listing" do
@@ -572,7 +572,7 @@ defmodule Re.ListingsTest do
 
       updated_listing = Repo.get(Listing, listing.id)
       assert updated_listing.user_id == original_user.id
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "save_price_suggestion")
     end
   end
 

--- a/apps/re/test/units/units_test.exs
+++ b/apps/re/test/units/units_test.exs
@@ -48,7 +48,7 @@ defmodule Re.UnitsTest do
 
       assert {:ok, _} = Units.insert(@unit_attrs, development: development)
 
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Re.Repo.all(JobQueue), "mirror_new_unit_to_listing")
     end
   end
 
@@ -59,9 +59,7 @@ defmodule Re.UnitsTest do
 
       Units.update(unit, @unit_attrs, development: development)
 
-      JobQueue
-      |> Re.Repo.all()
-      |> assert_enqueued_job("mirror_update_unit_to_listing")
+      assert_enqueued_job(Re.Repo.all(JobQueue), "mirror_update_unit_to_listing")
     end
   end
 end

--- a/apps/re_integrations/lib/zapier/zapier.ex
+++ b/apps/re_integrations/lib/zapier/zapier.ex
@@ -17,31 +17,31 @@ defmodule ReIntegrations.Zapier do
     Multi
   }
 
-  def new_lead(%{"source" => "facebook_buyer"} = payload) do
+  def handle_payload(%{"source" => "facebook_buyer"} = payload) do
     %BuyerLeads.Facebook{}
     |> BuyerLeads.Facebook.changeset(payload)
     |> do_new_buyer_lead("facebook_buyer")
   end
 
-  def new_lead(%{"source" => "imovelweb_buyer"} = payload) do
+  def handle_payload(%{"source" => "imovelweb_buyer"} = payload) do
     %ImovelWeb{}
     |> ImovelWeb.changeset(payload)
     |> do_new_buyer_lead("imovelweb_buyer")
   end
 
-  def new_lead(%{"source" => "facebook_seller"} = payload) do
+  def handle_payload(%{"source" => "facebook_seller"} = payload) do
     %SellerLeads.Facebook{}
     |> SellerLeads.Facebook.changeset(payload)
     |> Repo.insert()
   end
 
-  def new_lead(%{"source" => _source} = payload) do
+  def handle_payload(%{"source" => _source} = payload) do
     Logger.warn("Invalid payload source. Payload: #{Kernel.inspect(payload)}")
 
     {:error, :unexpected_payload, payload}
   end
 
-  def new_lead(payload) do
+  def handle_payload(payload) do
     Logger.warn("No payload source. Payload: #{Kernel.inspect(payload)}")
 
     {:error, :unexpected_payload, payload}

--- a/apps/re_integrations/lib/zapier/zapier.ex
+++ b/apps/re_integrations/lib/zapier/zapier.ex
@@ -6,61 +6,23 @@ defmodule ReIntegrations.Zapier do
 
   alias Re.{
     BuyerLeads,
-    BuyerLeads.JobQueue,
-    BuyerLeads.ImovelWeb,
-    SellerLeads,
-    Repo
+    SellerLeads
   }
 
-  alias Ecto.{
-    Changeset,
-    Multi
-  }
+  @buyer_lead_sources ~w(facebook_buyer imovelweb_buyer)
+  @seller_lead_sources ~w(facebook_seller)
 
-  def handle_payload(%{"source" => "facebook_buyer"} = payload) do
-    %BuyerLeads.Facebook{}
-    |> BuyerLeads.Facebook.changeset(payload)
-    |> do_new_buyer_lead("facebook_buyer")
+  def handle_payload(%{"source" => source} = payload) when source in @buyer_lead_sources do
+    BuyerLeads.create(payload)
   end
 
-  def handle_payload(%{"source" => "imovelweb_buyer"} = payload) do
-    %ImovelWeb{}
-    |> ImovelWeb.changeset(payload)
-    |> do_new_buyer_lead("imovelweb_buyer")
-  end
-
-  def handle_payload(%{"source" => "facebook_seller"} = payload) do
-    %SellerLeads.Facebook{}
-    |> SellerLeads.Facebook.changeset(payload)
-    |> Repo.insert()
-  end
-
-  def handle_payload(%{"source" => _source} = payload) do
-    Logger.warn("Invalid payload source. Payload: #{Kernel.inspect(payload)}")
-
-    {:error, :unexpected_payload, payload}
+  def handle_payload(%{"source" => source} = payload) when source in @seller_lead_sources do
+    SellerLeads.create(payload)
   end
 
   def handle_payload(payload) do
-    Logger.warn("No payload source. Payload: #{Kernel.inspect(payload)}")
+    Logger.warn("Invalid payload source. Payload: #{Kernel.inspect(payload)}")
 
     {:error, :unexpected_payload, payload}
-  end
-
-  defp do_new_buyer_lead(changeset, type) do
-    case changeset do
-      %{valid?: true} = changeset ->
-        uuid = Changeset.get_field(changeset, :uuid)
-
-        Multi.new()
-        |> JobQueue.enqueue(:buyer_lead_job, %{"type" => type, "uuid" => uuid})
-        |> Multi.insert(:add_buyer_lead, changeset)
-        |> Repo.transaction()
-
-      %{errors: errors} ->
-        Logger.warn("Invalid payload from #{type}. Errors: #{Kernel.inspect(errors)}")
-
-        {:error, :unexpected_payload, errors}
-    end
   end
 end

--- a/apps/re_integrations/test/orulo/orulo_test.exs
+++ b/apps/re_integrations/test/orulo/orulo_test.exs
@@ -17,7 +17,7 @@ defmodule ReIntegrations.OruloTest do
   describe "get_building_payload/2" do
     test "create o new job with to sync development" do
       assert {:ok, _} = Orulo.get_building_payload(100)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "import_development_from_orulo")
     end
 
     test "doesn't create a job if building payload already exists for orulo id" do
@@ -42,7 +42,7 @@ defmodule ReIntegrations.OruloTest do
     test "enqueue a new parse job" do
       params = %{external_id: 666, payload: %{test: "building_payload"}}
       assert {:ok, _} = Orulo.multi_building_payload_insert(Multi.new(), params)
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "parse_building_into_development")
     end
   end
 
@@ -62,7 +62,7 @@ defmodule ReIntegrations.OruloTest do
       params = %{external_id: 666, payload: %{test: "images_payload"}}
       assert {:ok, _} = Orulo.multi_images_payload_insert(Multi.new(), params)
 
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "parse_images_payloads_into_images")
     end
   end
 

--- a/apps/re_web/lib/webhooks/zapier_plug.ex
+++ b/apps/re_web/lib/webhooks/zapier_plug.ex
@@ -15,7 +15,7 @@ defmodule ReWeb.Webhooks.ZapierPlug do
 
   def call(%{method: "POST", params: params} = conn, _args) do
     with :ok <- validate_credentials(conn),
-         {:ok, _} <- Zapier.new_lead(params) do
+         {:ok, _} <- Zapier.handle_payload(params) do
       conn
       |> put_resp_content_type("text/plain")
       |> send_resp(200, "ok")

--- a/apps/re_web/test/controllers/interests/interest_controller_test.exs
+++ b/apps/re_web/test/controllers/interests/interest_controller_test.exs
@@ -2,6 +2,7 @@ defmodule ReWeb.InterestControllerTest do
   use ReWeb.ConnCase
 
   import Re.Factory
+  import Re.CustomAssertion
 
   alias Re.{
     BuyerLeads.JobQueue,
@@ -31,7 +32,7 @@ defmodule ReWeb.InterestControllerTest do
       interest_id = response["data"]["id"]
       assert interest = Repo.get(Interest, interest_id)
       assert interest.uuid
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "interest")
     end
 
     test "show interest in invalid listing", %{conn: conn} do

--- a/apps/re_web/test/graphql/interests/mutation_test.exs
+++ b/apps/re_web/test/graphql/interests/mutation_test.exs
@@ -4,6 +4,7 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
   alias ReWeb.AbsintheHelpers
 
   import Re.Factory
+  import Re.CustomAssertion
 
   alias Re.{
     BuyerLeads.JobQueue,
@@ -69,7 +70,7 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
 
     assert interest = Repo.get_by(Interest, name: "Mah Name")
     assert interest.uuid
-    assert Repo.one(JobQueue)
+    assert_enqueued_job(Repo.all(JobQueue), "interest")
   end
 
   test "user should request contact", %{user_conn: conn} do

--- a/apps/re_web/test/webhooks/grupozap_plug_test.exs
+++ b/apps/re_web/test/webhooks/grupozap_plug_test.exs
@@ -1,6 +1,8 @@
 defmodule ReWeb.Webhooks.GrupozapPlugTest do
   use ReWeb.ConnCase
 
+  import Re.CustomAssertion
+
   alias Re.{
     BuyerLeads.JobQueue,
     BuyerLeads.Grupozap,
@@ -55,7 +57,7 @@ defmodule ReWeb.Webhooks.GrupozapPlugTest do
       assert gb.origin_lead_id
       assert gb.origin_listing_id
       assert gb.client_listing_id
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "grupozap_buyer_lead")
     end
 
     @long_message_payload %{
@@ -78,7 +80,7 @@ defmodule ReWeb.Webhooks.GrupozapPlugTest do
 
       assert gb = Repo.one(Grupozap)
       assert gb.message
-      assert Repo.one(JobQueue)
+      assert_enqueued_job(Repo.all(JobQueue), "grupozap_buyer_lead")
     end
 
     @tag capture_log: true


### PR DESCRIPTION
- Move code from `Zapier` module to `BuyerLeads`
- Use `assert_enqueued_job` to check created jobs with proper types
- Remove some duplicated job queueing code

This is a refactor to do a bit of cleanup since we're gonna use zapier webhooks a little bit more soon and was getting cluttered.