### PR TITLE
Developments/mirror update

### DIFF
--- a/apps/re/lib/developments/job_queue.ex
+++ b/apps/re/lib/developments/job_queue.ex
@@ -26,4 +26,15 @@ defmodule Re.Developments.JobQueue do
     end)
     |> Repo.transaction()
   end
+
+  def perform(%Multi{} = multi, %{
+        "type" => "mirror_update_development_to_listings",
+        "uuid" => uuid
+      }) do
+    multi
+    |> Multi.run(:mirror_unit, fn _repo, _changes ->
+      Mirror.mirror_development_update_to_listings(uuid)
+    end)
+    |> Repo.transaction()
+  end
 end

--- a/apps/re/lib/developments/listings.ex
+++ b/apps/re/lib/developments/listings.ex
@@ -4,6 +4,7 @@ defmodule Re.Developments.Listings do
   """
   alias Re.{
     Listing,
+    Listings.Queries,
     PubSub,
     Repo
   }
@@ -26,6 +27,12 @@ defmodule Re.Developments.Listings do
     changeset
     |> Repo.update()
     |> PubSub.publish_update(changeset, "update_listing")
+  end
+
+  def batch_update(listings, params, opts) do
+    Repo.transaction(fn ->
+      Enum.map(listings, fn listing -> update(listing, params, opts) end)
+    end)
   end
 
   defp changeset_for_opts(listing, opts) do
@@ -83,5 +90,12 @@ defmodule Re.Developments.Listings do
     changeset
     |> Repo.update()
     |> PubSub.publish_update(changeset, "update_listing")
+  end
+
+  def per_development(%Re.Development{uuid: uuid}, preload \\ []) do
+    Listing
+    |> Queries.per_development(uuid)
+    |> Queries.preload_relations(preload)
+    |> Repo.all()
   end
 end

--- a/apps/re/lib/listings/queries/queries.ex
+++ b/apps/re/lib/listings/queries/queries.ex
@@ -98,6 +98,9 @@ defmodule Re.Listings.Queries do
 
   def count(query \\ Listing), do: from(l in query, select: count(l.id, :distinct))
 
+  def per_development(query \\ Listing, development_uuid),
+    do: from(l in query, where: l.development_uuid == ^development_uuid)
+
   def per_user(query \\ Listing, user_id), do: from(l in query, where: l.user_id == ^user_id)
 
   def by_city(query, listing) do

--- a/apps/re/test/developments/developments_test.exs
+++ b/apps/re/test/developments/developments_test.exs
@@ -51,7 +51,6 @@ defmodule Re.DevelopmentsTest do
       assert updated_development.phase == Map.get(new_development_params, :phase)
     end
 
-    @tag dev: true
     test "should enqueue new mirror_update_development_to_listings job" do
       address = insert(:address)
       development = insert(:development, address: address)

--- a/apps/re/test/developments/developments_test.exs
+++ b/apps/re/test/developments/developments_test.exs
@@ -5,10 +5,14 @@ defmodule Re.DevelopmentsTest do
 
   alias Re.{
     Development,
-    Developments
+    Developments,
+    Developments.JobQueue
   }
 
-  import Re.Factory
+  import Re.{
+    CustomAssertion,
+    Factory
+  }
 
   describe "insert/2" do
     @insert_development_params %{
@@ -45,6 +49,20 @@ defmodule Re.DevelopmentsTest do
       assert updated_development.builder == Map.get(new_development_params, :builder)
       assert updated_development.description == Map.get(new_development_params, :description)
       assert updated_development.phase == Map.get(new_development_params, :phase)
+    end
+
+    @tag dev: true
+    test "should enqueue new mirror_update_development_to_listings job" do
+      address = insert(:address)
+      development = insert(:development, address: address)
+
+      new_development_params = params_for(:development)
+
+      Developments.update(development, new_development_params, address)
+
+      JobQueue
+      |> Re.Repo.all()
+      |> assert_enqueued_job("mirror_update_development_to_listings")
     end
   end
 end

--- a/apps/re/test/developments/mirror_test.exs
+++ b/apps/re/test/developments/mirror_test.exs
@@ -61,4 +61,32 @@ defmodule Re.Developments.MirrorTest do
       assert listing.is_exportable == unit.is_exportable
     end
   end
+
+  describe "mirror_development_update_to_listings" do
+    test "update associated listing with unit informations" do
+      address = insert(:address)
+      %{uuid: uuid} = development = insert(:development, address: address)
+      unit_1 = insert(:unit, development: development)
+      insert(:listing, units: [unit_1], development: development)
+
+      unit_2 = insert(:unit, development: development)
+      insert(:listing, units: [unit_2], development: development)
+
+      assert {:ok,
+              [
+                {:ok, mirrored_listing_1},
+                {:ok, mirrored_listing_2}
+              ]} = Mirror.mirror_development_update_to_listings(uuid)
+
+      assert development.description == mirrored_listing_1.description
+      assert development.floor_count == mirrored_listing_1.floor_count
+      assert development.elevators == mirrored_listing_1.elevators
+      assert development.units_per_floor == mirrored_listing_1.unit_per_floor
+
+      assert development.description == mirrored_listing_2.description
+      assert development.floor_count == mirrored_listing_2.floor_count
+      assert development.elevators == mirrored_listing_2.elevators
+      assert development.units_per_floor == mirrored_listing_2.unit_per_floor
+    end
+  end
 end


### PR DESCRIPTION
It's a complement for #626. 

Feature: 
When updating a development, mirror changes in all associated developments.  


On `Development.Listings` context I added a new `batch_update` function, it runs all updates inside the same transaction and returns `{:ok, [*transaction_listing*]}`, instead `[ok: listing]`, I guess it keeps the consistency with current `insert` and `update` functions... 