### PR TITLE
Return additional priceteller fields in requestPriceSuggestion

### DIFF
--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -22,7 +22,7 @@ defmodule Re.Listings.JobQueue do
     |> PriceSuggestions.suggest_price()
     |> case do
       {:ok, suggested_price} ->
-        changeset = Listing.changeset(listing, %{suggested_price: suggested_price})
+        changeset = Listing.changeset(listing, %{suggested_price: suggested_price.listing_price_rounded})
 
         multi
         |> Multi.update(:update_suggested_price, changeset)

--- a/apps/re/lib/listings/job_queue.ex
+++ b/apps/re/lib/listings/job_queue.ex
@@ -22,7 +22,8 @@ defmodule Re.Listings.JobQueue do
     |> PriceSuggestions.suggest_price()
     |> case do
       {:ok, suggested_price} ->
-        changeset = Listing.changeset(listing, %{suggested_price: suggested_price.listing_price_rounded})
+        changeset =
+          Listing.changeset(listing, %{suggested_price: suggested_price.listing_price_rounded})
 
         multi
         |> Multi.update(:update_suggested_price, changeset)

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -20,15 +20,9 @@ defmodule Re.PriceSuggestions do
     |> do_suggest_price()
     |> case do
       {:ok, suggested_price} ->
+        params = Map.merge(%{suggested_price: suggested_price.listing_price_rounded}, suggested_price)
         request
-        |> Request.changeset(%{
-          suggested_price: suggested_price.listing_price_rounded,
-          listing_price_rounded: suggested_price.listing_price_rounded,
-          listing_price_error_q90_min: suggested_price.listing_price_error_q90_min,
-          listing_price_error_q90_max: suggested_price.listing_price_error_q90_max,
-          listing_price_per_sqr_meter: suggested_price.listing_price_per_sqr_meter,
-          listing_average_price_per_sqr_meter: suggested_price.listing_average_price_per_sqr_meter
-        })
+        |> Request.changeset(params)
         |> Repo.update()
 
       error ->

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -47,7 +47,7 @@ defmodule Re.PriceSuggestions do
 
   defp persist_suggested_price({:ok, suggested_price}, listing) do
     listing
-    |> Listing.changeset(%{suggested_price: suggested_price})
+    |> Listing.changeset(%{suggested_price: suggested_price.listing_price_rounded})
     |> Repo.update()
 
     {:ok, suggested_price}

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -20,7 +20,9 @@ defmodule Re.PriceSuggestions do
     |> do_suggest_price()
     |> case do
       {:ok, suggested_price} ->
-        params = Map.merge(%{suggested_price: suggested_price.listing_price_rounded}, suggested_price)
+        params =
+          Map.merge(%{suggested_price: suggested_price.listing_price_rounded}, suggested_price)
+
         request
         |> Request.changeset(params)
         |> Repo.update()

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -21,7 +21,14 @@ defmodule Re.PriceSuggestions do
     |> case do
       {:ok, suggested_price} ->
         request
-        |> Request.changeset(%{suggested_price: suggested_price})
+        |> Request.changeset(%{
+          suggested_price: suggested_price.listing_price_rounded,
+          listing_price_rounded: suggested_price.listing_price_rounded,
+          listing_price_error_q90_min: suggested_price.listing_price_error_q90_min,
+          listing_price_error_q90_max: suggested_price.listing_price_error_q90_max,
+          listing_price_per_sqr_meter: suggested_price.listing_price_per_sqr_meter,
+          listing_average_price_per_sqr_meter: suggested_price.listing_average_price_per_sqr_meter
+        })
         |> Repo.update()
 
       error ->
@@ -79,8 +86,7 @@ defmodule Re.PriceSuggestions do
   defp round_if_not_nil(nil), do: 0
   defp round_if_not_nil(maintenance_fee), do: round(maintenance_fee)
 
-  defp format_output({:ok, %{listing_price_rounded: listing_price_rounded}}),
-    do: {:ok, listing_price_rounded}
+  defp format_output({:ok, suggested_price}), do: {:ok, suggested_price}
 
   defp format_output(response) do
     Sentry.capture_message("Error on priceteller response",

--- a/apps/re/lib/price_suggestions/priceteller/output.ex
+++ b/apps/re/lib/price_suggestions/priceteller/output.ex
@@ -11,9 +11,15 @@ defmodule Re.PriceTeller.Output do
     field :listing_price_rounded, :float
     field :sale_price, :float
     field :sale_price_rounded, :float
+    field :listing_price_error_q90_min, :float
+    field :listing_price_error_q90_max, :float
+    field :listing_price_per_sqr_meter, :float
+    field :listing_average_price_per_sqr_meter, :float
   end
 
-  @params ~w(listing_price listing_price_rounded sale_price sale_price_rounded)a
+  @params ~w(listing_price listing_price_rounded sale_price sale_price_rounded
+             listing_price_error_q90_min listing_price_error_q90_max listing_price_per_sqr_meter
+             listing_average_price_per_sqr_meter)a
 
   def validate(payload) do
     %__MODULE__{}

--- a/apps/re/lib/price_suggestions/request.ex
+++ b/apps/re/lib/price_suggestions/request.ex
@@ -19,6 +19,11 @@ defmodule Re.PriceSuggestions.Request do
     field :type, :string
     field :is_covered, :boolean
     field :suggested_price, :float
+    field :listing_price_rounded, :float
+    field :listing_price_error_q90_min, :float
+    field :listing_price_error_q90_max, :float
+    field :listing_price_per_sqr_meter, :float
+    field :listing_average_price_per_sqr_meter, :float
 
     belongs_to :address, Re.Address
     belongs_to :user, Re.User
@@ -27,7 +32,9 @@ defmodule Re.PriceSuggestions.Request do
   end
 
   @required ~w(address_id area rooms bathrooms garage_spots is_covered)a
-  @optional ~w(name email user_id suggested_price suites type maintenance_fee)a
+  @optional ~w(name email user_id suggested_price listing_price_rounded
+              listing_price_error_q90_min listing_price_error_q90_max listing_price_per_sqr_meter
+              listing_average_price_per_sqr_meter suites type maintenance_fee)a
 
   def changeset(struct, params \\ %{}) do
     struct

--- a/apps/re/priv/repo/migrations/20190703153502_add_priceteller_fields_to_price_requests.exs
+++ b/apps/re/priv/repo/migrations/20190703153502_add_priceteller_fields_to_price_requests.exs
@@ -1,0 +1,13 @@
+defmodule Re.Repo.Migrations.AddPricetellerFieldsToPriceRequests do
+  use Ecto.Migration
+
+  def change do
+    alter table(:price_suggestion_requests) do
+      add :listing_price_rounded, :float
+      add :listing_price_error_q90_min, :float
+      add :listing_price_error_q90_max, :float
+      add :listing_price_per_sqr_meter, :float
+      add :listing_average_price_per_sqr_meter, :float
+    end
+  end
+end

--- a/apps/re/test/interests/interests_test.exs
+++ b/apps/re/test/interests/interests_test.exs
@@ -21,7 +21,7 @@ defmodule Re.InterestsTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":1342.0,\"sale_price\":1342.213,\"listing_price_rounded\":1565.0,\"listing_price\":1565.654}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
@@ -50,11 +50,11 @@ defmodule Re.InterestsTest do
         is_covered: true
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 1565.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
                Interests.request_price_suggestion(params, nil)
 
       assert request = Repo.get(Request, request_id)
-      assert request.suggested_price == 1565.0
+      assert request.suggested_price == 26279.0
     end
 
     test "should store price suggestion request with user attached" do
@@ -64,7 +64,7 @@ defmodule Re.InterestsTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":1342.0,\"sale_price\":1342.213,\"listing_price_rounded\":1565.0,\"listing_price\":1565.654}"
+            "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
@@ -95,12 +95,12 @@ defmodule Re.InterestsTest do
         is_covered: true
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 1565.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
                Interests.request_price_suggestion(params, user)
 
       assert request = Repo.get(Request, request_id)
       assert request.user_id == user.id
-      assert request.suggested_price == 1565.0
+      assert request.suggested_price == 26279.0
     end
 
     test "should store price suggestion request when street is not covered" do
@@ -110,7 +110,7 @@ defmodule Re.InterestsTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":1342.0,\"sale_price\":1342.213,\"listing_price_rounded\":1565.0,\"listing_price\":1565.654}"
+            "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
@@ -139,11 +139,11 @@ defmodule Re.InterestsTest do
         is_covered: false
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 1565.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
                Interests.request_price_suggestion(params, nil)
 
       assert request = Repo.get(Request, request_id)
-      assert request.suggested_price == 1565.0
+      assert request.suggested_price == 26279.0
     end
   end
 

--- a/apps/re/test/interests/interests_test.exs
+++ b/apps/re/test/interests/interests_test.exs
@@ -50,11 +50,11 @@ defmodule Re.InterestsTest do
         is_covered: true
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26_279.0}} =
                Interests.request_price_suggestion(params, nil)
 
       assert request = Repo.get(Request, request_id)
-      assert request.suggested_price == 26279.0
+      assert request.suggested_price == 26_279.0
     end
 
     test "should store price suggestion request with user attached" do
@@ -95,12 +95,12 @@ defmodule Re.InterestsTest do
         is_covered: true
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26_279.0}} =
                Interests.request_price_suggestion(params, user)
 
       assert request = Repo.get(Request, request_id)
       assert request.user_id == user.id
-      assert request.suggested_price == 26279.0
+      assert request.suggested_price == 26_279.0
     end
 
     test "should store price suggestion request when street is not covered" do
@@ -139,11 +139,11 @@ defmodule Re.InterestsTest do
         is_covered: false
       }
 
-      assert {:ok, %{id: request_id, suggested_price: 26279.0}} =
+      assert {:ok, %{id: request_id, suggested_price: 26_279.0}} =
                Interests.request_price_suggestion(params, nil)
 
       assert request = Repo.get(Request, request_id)
-      assert request.suggested_price == 26279.0
+      assert request.suggested_price == 26_279.0
     end
   end
 

--- a/apps/re/test/listings/job_queue_test.exs
+++ b/apps/re/test/listings/job_queue_test.exs
@@ -35,7 +35,7 @@ defmodule Re.Listings.JobQueueTest do
                })
 
       assert listing = Repo.get_by(Listing, uuid: listing_uuid)
-      assert listing.suggested_price == 26279
+      assert listing.suggested_price == 26_279
     end
 
     @tag capture_log: true

--- a/apps/re/test/listings/job_queue_test.exs
+++ b/apps/re/test/listings/job_queue_test.exs
@@ -22,7 +22,7 @@ defmodule Re.Listings.JobQueueTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":575000.0,\"sale_price\":575910.45,\"listing_price_rounded\":635000.0,\"listing_price\":632868.63}"
+            "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
@@ -35,7 +35,7 @@ defmodule Re.Listings.JobQueueTest do
                })
 
       assert listing = Repo.get_by(Listing, uuid: listing_uuid)
-      assert listing.suggested_price == 635_000
+      assert listing.suggested_price == 26279
     end
 
     @tag capture_log: true

--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -32,11 +32,21 @@ defmodule Re.PriceSuggestionsTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
-      assert {:ok, 26_279.0} == PriceSuggestions.suggest_price(listing)
+      assert {:ok,
+              %{
+                listing_price: 26279.915,
+                listing_price_rounded: 26279.0,
+                sale_price: 24195.791,
+                sale_price_rounded: 24195.0,
+                listing_price_error_q90_min: 25200.0,
+                listing_price_error_q90_max: 28544.0,
+                listing_price_per_sqr_meter: 560.0,
+                listing_average_price_per_sqr_meter: 610.0
+      }} == PriceSuggestions.suggest_price(listing)
       listing = Repo.get_by(Listing, uuid: uuid)
       assert listing.suggested_price == 26_279.0
     end
@@ -60,11 +70,21 @@ defmodule Re.PriceSuggestionsTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
-      assert {:ok, 26_279.0} == PriceSuggestions.suggest_price(listing)
+      assert {:ok,
+              %{
+                listing_price: 26279.915,
+                listing_price_rounded: 26279.0,
+                sale_price: 24195.791,
+                sale_price_rounded: 24195.0,
+                listing_price_error_q90_min: 25200.0,
+                listing_price_error_q90_max: 28544.0,
+                listing_price_per_sqr_meter: 560.0,
+                listing_average_price_per_sqr_meter: 610.0
+      }} == PriceSuggestions.suggest_price(listing)
       listing = Repo.get_by(Listing, uuid: uuid)
       assert listing.suggested_price == 26_279.0
     end

--- a/apps/re/test/price_suggestions/price_suggestions_test.exs
+++ b/apps/re/test/price_suggestions/price_suggestions_test.exs
@@ -38,12 +38,12 @@ defmodule Re.PriceSuggestionsTest do
 
       assert {:ok,
               %{
-                listing_price: 26279.915,
-                listing_price_rounded: 26279.0,
-                sale_price: 24195.791,
-                sale_price_rounded: 24195.0,
-                listing_price_error_q90_min: 25200.0,
-                listing_price_error_q90_max: 28544.0,
+                listing_price: 26_279.915,
+                listing_price_rounded: 26_279.0,
+                sale_price: 24_195.791,
+                sale_price_rounded: 24_195.0,
+                listing_price_error_q90_min: 25_200.0,
+                listing_price_error_q90_max: 28_544.0,
                 listing_price_per_sqr_meter: 560.0,
                 listing_average_price_per_sqr_meter: 610.0
       }} == PriceSuggestions.suggest_price(listing)
@@ -76,12 +76,12 @@ defmodule Re.PriceSuggestionsTest do
 
       assert {:ok,
               %{
-                listing_price: 26279.915,
-                listing_price_rounded: 26279.0,
-                sale_price: 24195.791,
-                sale_price_rounded: 24195.0,
-                listing_price_error_q90_min: 25200.0,
-                listing_price_error_q90_max: 28544.0,
+                listing_price: 26_279.915,
+                listing_price_rounded: 26_279.0,
+                sale_price: 24_195.791,
+                sale_price_rounded: 24_195.0,
+                listing_price_error_q90_min: 25_200.0,
+                listing_price_error_q90_max: 28_544.0,
                 listing_price_per_sqr_meter: 560.0,
                 listing_average_price_per_sqr_meter: 610.0
       }} == PriceSuggestions.suggest_price(listing)

--- a/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
+++ b/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
@@ -47,12 +47,12 @@ defmodule Re.PriceTellerTest do
 
       assert {:ok,
               %{
-                listing_price: 26279.915,
-                listing_price_rounded: 26279.0,
-                sale_price: 24195.791,
-                sale_price_rounded: 24195.0,
-                listing_price_error_q90_min: 25200.0,
-                listing_price_error_q90_max: 28544.0,
+                listing_price: 26_279.915,
+                listing_price_rounded: 26_279.0,
+                sale_price: 24_195.791,
+                sale_price_rounded: 24_195.0,
+                listing_price_error_q90_min: 25_200.0,
+                listing_price_error_q90_max: 28_544.0,
                 listing_price_per_sqr_meter: 560.0,
                 listing_average_price_per_sqr_meter: 610.0
               }} == PriceTeller.ask(@valid_payload)

--- a/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
+++ b/apps/re/test/price_suggestions/priceteller/price_teller_test.exs
@@ -41,16 +41,20 @@ defmodule Re.PriceTellerTest do
         {:ok,
          %{
            body:
-             "{\"sale_price_rounded\":575000.0,\"sale_price\":575910.45,\"listing_price_rounded\":635000.0,\"listing_price\":632868.63}"
+            "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
          }}
       )
 
       assert {:ok,
               %{
-                listing_price: 632_868.63,
-                listing_price_rounded: 635_000.0,
-                sale_price: 575_910.45,
-                sale_price_rounded: 575_000.0
+                listing_price: 26279.915,
+                listing_price_rounded: 26279.0,
+                sale_price: 24195.791,
+                sale_price_rounded: 24195.0,
+                listing_price_error_q90_min: 25200.0,
+                listing_price_error_q90_max: 28544.0,
+                listing_price_per_sqr_meter: 560.0,
+                listing_average_price_per_sqr_meter: 610.0
               }} == PriceTeller.ask(@valid_payload)
     end
 

--- a/apps/re_web/lib/graphql/types/interest.ex
+++ b/apps/re_web/lib/graphql/types/interest.ex
@@ -55,6 +55,11 @@ defmodule ReWeb.Types.Interest do
     field :garage_spots, :integer
     field :is_covered, :boolean
     field :suggested_price, :float
+    field :listing_price_rounded, :float
+    field :listing_price_error_q90_min, :float
+    field :listing_price_error_q90_max, :float
+    field :listing_price_per_sqr_meter, :float
+    field :listing_average_price_per_sqr_meter, :float
 
     field :address, :address, resolve: dataloader(Re.Addresses)
     field :user, :user, resolve: dataloader(Re.Accounts)

--- a/apps/re_web/test/graphql/interests/price_suggestions/query_test.exs
+++ b/apps/re_web/test/graphql/interests/price_suggestions/query_test.exs
@@ -104,7 +104,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
       {:ok,
        %{
          body:
-           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+          "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
        }}
     )
 
@@ -155,7 +155,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
       {:ok,
        %{
          body:
-           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+          "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
        }}
     )
 
@@ -209,7 +209,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
       {:ok,
        %{
          body:
-           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
        }}
     )
 


### PR DESCRIPTION
Includes additional fields in `requestPriceSuggestion` mutation:

- listing_price_rounded
- listing_price_error_q90_min
- listing_price_error_q90_max
- listing_price_per_sqr_meter
- listing_average_price_per_sqr_meter

Create a migration `add_priceteller_fields_to_price_requests` to add these fields to `price_suggestion_requests`.