### PR TITLE
Add inactivation reason on listings

### DIFF
--- a/apps/re/lib/listings/history/server.ex
+++ b/apps/re/lib/listings/history/server.ex
@@ -54,7 +54,7 @@ defmodule Re.Listings.History.Server do
             new: listing,
             changeset: %{
               changes: %{status: _},
-              data: %{status: status, inactivation_reason: reason}
+              data: %{status: status, deactivation_reason: reason}
             }
           }
         },

--- a/apps/re/lib/listings/history/server.ex
+++ b/apps/re/lib/listings/history/server.ex
@@ -50,12 +50,18 @@ defmodule Re.Listings.History.Server do
         %{
           topic: topic,
           type: :update,
-          content: %{new: listing, changeset: %{changes: %{status: _}, data: %{status: status}}}
+          content: %{
+            new: listing,
+            changeset: %{
+              changes: %{status: _},
+              data: %{status: status, inactivation_reason: reason}
+            }
+          }
         },
         state
       )
       when topic in @status_changes do
-    case Statuses.insert(listing, status) do
+    case Statuses.insert(listing, reason || status) do
       {:ok, _listing} ->
         {:noreply, state}
 

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -134,8 +134,13 @@ defmodule Re.Listings do
     end)
   end
 
-  def deactivate(listing) do
+  def deactivate(listing, opts \\ []) do
     changeset = Changeset.change(listing, status: "inactive")
+
+    changeset =
+      Enum.reduce(opts, changeset, fn
+        {:reason, reason}, changeset -> Changeset.change(changeset, inactivation_reason: reason)
+      end)
 
     changeset
     |> Repo.update()

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -148,7 +148,7 @@ defmodule Re.Listings do
   end
 
   def activate(listing) do
-    changeset = Changeset.change(listing, status: "active")
+    changeset = Changeset.change(listing, status: "active", inactivation_reason: nil)
 
     Multi.new()
     |> Multi.update(:activate_listing, changeset)

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -139,8 +139,8 @@ defmodule Re.Listings do
 
     changeset =
       Enum.reduce(opts, changeset, fn
-        {:inactivation_reason, reason}, changeset ->
-          Changeset.change(changeset, inactivation_reason: reason)
+        {:deactivation_reason, reason}, changeset ->
+          Changeset.change(changeset, deactivation_reason: reason)
 
         {:sold_price, sold_price}, changeset when is_integer(sold_price) ->
           Changeset.change(changeset, sold_price: sold_price)
@@ -152,7 +152,7 @@ defmodule Re.Listings do
   end
 
   def activate(listing) do
-    changeset = Changeset.change(listing, status: "active", inactivation_reason: nil)
+    changeset = Changeset.change(listing, status: "active", deactivation_reason: nil)
 
     Multi.new()
     |> Multi.update(:activate_listing, changeset)

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -139,7 +139,7 @@ defmodule Re.Listings do
 
     changeset =
       Enum.reduce(opts, changeset, fn
-        {:reason, reason}, changeset ->
+        {:inactivation_reason, reason}, changeset ->
           Changeset.change(changeset, inactivation_reason: reason)
 
         {:sold_price, sold_price}, changeset when is_integer(sold_price) ->

--- a/apps/re/lib/listings/listings.ex
+++ b/apps/re/lib/listings/listings.ex
@@ -139,7 +139,11 @@ defmodule Re.Listings do
 
     changeset =
       Enum.reduce(opts, changeset, fn
-        {:reason, reason}, changeset -> Changeset.change(changeset, inactivation_reason: reason)
+        {:reason, reason}, changeset ->
+          Changeset.change(changeset, inactivation_reason: reason)
+
+        {:sold_price, sold_price}, changeset when is_integer(sold_price) ->
+          Changeset.change(changeset, sold_price: sold_price)
       end)
 
     changeset

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -45,7 +45,7 @@ defmodule Re.Listing do
     field :in_person_visit_count, :integer, virtual: true
     field :suggested_price, :float
 
-    field :inactivation_reason, :string
+    field :deactivation_reason, :string
     field :sold_price, :integer
 
     belongs_to :address, Re.Address
@@ -91,7 +91,7 @@ defmodule Re.Listing do
 
   @sun_period_types ~w(morning evening)
 
-  @inactivation_reasons ~w(duplicated gave_up left_emcasa publication_mistake rented
+  @deactivation_reasons ~w(duplicated gave_up left_emcasa publication_mistake rented
                           sold sold_by_emcasa temporarily_suspended to_be_published
                           went_exclusive)
 
@@ -101,7 +101,7 @@ defmodule Re.Listing do
                      maintenance_fee balconies restrooms is_release is_exportable
                      orientation floor_count unit_per_floor sun_period elevators
                      construction_year owner_contact_uuid suggested_price
-                     inactivation_reason sold_price)a
+                     deactivation_reason sold_price)a
 
   @attributes @required ++ @optional
 
@@ -119,7 +119,7 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types)
     |> validate_inclusion(:orientation, @orientation_types)
     |> validate_inclusion(:sun_period, @sun_period_types)
-    |> validate_inclusion(:inactivation_reason, @inactivation_reasons)
+    |> validate_inclusion(:deactivation_reason, @deactivation_reasons)
     |> generate_uuid()
     |> calculate_price_per_area()
   end

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -46,8 +46,7 @@ defmodule Re.Listing do
     field :suggested_price, :float
 
     field :inactivation_reason, :string
-    # field :sold_date, :utc_datetime
-    # field :sold_price, :integer
+    field :sold_price, :integer
 
     belongs_to :address, Re.Address
 
@@ -102,7 +101,7 @@ defmodule Re.Listing do
                      maintenance_fee balconies restrooms is_release is_exportable
                      orientation floor_count unit_per_floor sun_period elevators
                      construction_year owner_contact_uuid suggested_price
-                     inactivation_reason)a
+                     inactivation_reason sold_price)a
 
   @attributes @required ++ @optional
 

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -91,9 +91,9 @@ defmodule Re.Listing do
 
   @sun_period_types ~w(morning evening)
 
-  @inactivation_reasons ~w(duplicity exclusivity give_up left_emcasa
-                          publication_phase publication_error qualification_phase
-                          rented sold sold_by_emcasa temporarely_suspended)
+  @inactivation_reasons ~w(duplicated gave_up left_emcasa publication_mistake rented
+                          sold sold_by_emcasa temporarily_suspended to_be_published
+                          went_exclusive)
 
   @required ~w(type description price rooms bathrooms area garage_spots garage_type
                      score address_id user_id suites dependencies has_elevator)a

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -1,4 +1,4 @@
-defmodule Re.Listing do
+ndefmodule Re.Listing do
   @moduledoc """
   Model for listings, that is, each apartment or real estate piece on sale.
   """
@@ -45,6 +45,10 @@ defmodule Re.Listing do
     field :in_person_visit_count, :integer, virtual: true
     field :suggested_price, :float
 
+    field :inactivation_reason, :string
+    # field :sold_date, :utc_datetime
+    # field :sold_price, :integer
+
     belongs_to :address, Re.Address
 
     belongs_to :development, Re.Development,
@@ -88,14 +92,20 @@ defmodule Re.Listing do
 
   @sun_period_types ~w(morning evening)
 
+  @inactivation_reasons ~w(duplicity exclusivity give_up left_emcasa
+                          publication_phase publication_error qualification_phase
+                          rented sold sold_by_emcasa temporarely_suspended)
+
   @required ~w(type description price rooms bathrooms area garage_spots garage_type
                      score address_id user_id suites dependencies has_elevator)a
   @optional ~w(complement floor matterport_code is_exclusive status property_tax
                      maintenance_fee balconies restrooms is_release is_exportable
                      orientation floor_count unit_per_floor sun_period elevators
-                     construction_year owner_contact_uuid suggested_price)a
+                     construction_year owner_contact_uuid suggested_price
+                     inactivation_reason)a
 
   @attributes @required ++ @optional
+
   def changeset(struct, params) do
     struct
     |> cast(params, @attributes)
@@ -110,6 +120,7 @@ defmodule Re.Listing do
     |> validate_inclusion(:garage_type, @garage_types)
     |> validate_inclusion(:orientation, @orientation_types)
     |> validate_inclusion(:sun_period, @sun_period_types)
+    |> validate_inclusion(:inactivation_reason, @inactivation_reasons)
     |> generate_uuid()
     |> calculate_price_per_area()
   end

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -1,4 +1,4 @@
-ndefmodule Re.Listing do
+defmodule Re.Listing do
   @moduledoc """
   Model for listings, that is, each apartment or real estate piece on sale.
   """

--- a/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
+++ b/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddInactivationReasonToListings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:listings) do
+      add :inactivation_reason, :string
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
+++ b/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
@@ -4,6 +4,7 @@ defmodule Re.Repo.Migrations.AddInactivationReasonToListings do
   def change do
     alter table(:listings) do
       add :inactivation_reason, :string
+      add :sold_price, :integer
     end
   end
 end

--- a/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
+++ b/apps/re/priv/repo/migrations/20190703205600_add_inactivation_reason_to_listings.exs
@@ -3,7 +3,7 @@ defmodule Re.Repo.Migrations.AddInactivationReasonToListings do
 
   def change do
     alter table(:listings) do
-      add :inactivation_reason, :string
+      add :deactivation_reason, :string
       add :sold_price, :integer
     end
   end

--- a/apps/re/test/listings/listing_test.exs
+++ b/apps/re/test/listings/listing_test.exs
@@ -58,7 +58,7 @@ defmodule Re.ListingTest do
     elevators: 2.1
   }
 
-  describe "admin" do
+  describe "changeset/2" do
     test "changeset with valid attributes" do
       address = insert(:address)
       user = insert(:user)

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -367,13 +367,18 @@ defmodule Re.ListingsTest do
   end
 
   describe "deactivate/2" do
-    test "should set status to inactive with reason" do
+    test "should set status to inactive with reason and sold_price" do
       listing = insert(:listing, status: "active")
 
-      {:ok, listing} = Listings.deactivate(listing, reason: "rented")
+      {:ok, listing} =
+        Listings.deactivate(listing,
+          reason: "sold",
+          sold_price: 1_000_000
+        )
 
       assert listing.status == "inactive"
-      assert listing.inactivation_reason == "rented"
+      assert listing.inactivation_reason == "sold"
+      assert listing.sold_price == 1_000_000
     end
 
     test "should save status change to history when set to inactive" do

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -372,7 +372,7 @@ defmodule Re.ListingsTest do
 
       {:ok, listing} =
         Listings.deactivate(listing,
-          reason: "sold",
+          inactivation_reason: "sold",
           sold_price: 1_000_000
         )
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -372,12 +372,12 @@ defmodule Re.ListingsTest do
 
       {:ok, listing} =
         Listings.deactivate(listing,
-          inactivation_reason: "sold",
+          deactivation_reason: "sold",
           sold_price: 1_000_000
         )
 
       assert listing.status == "inactive"
-      assert listing.inactivation_reason == "sold"
+      assert listing.deactivation_reason == "sold"
       assert listing.sold_price == 1_000_000
     end
 
@@ -396,17 +396,17 @@ defmodule Re.ListingsTest do
 
   describe "activate/1" do
     test "should set status to active and clean inativation_reason" do
-      listing = insert(:listing, status: "inactive", inactivation_reason: "rented")
+      listing = insert(:listing, status: "inactive", deactivation_reason: "rented")
 
       {:ok, listing} = Listings.activate(listing)
 
       assert listing.status == "active"
-      assert listing.inactivation_reason == nil
+      assert listing.deactivation_reason == nil
     end
 
-    test "should save old inactivation_reason as status on history" do
+    test "should save old deactivation_reason as status on history" do
       Server.start_link()
-      listing = insert(:listing, status: "inactive", inactivation_reason: "rented")
+      listing = insert(:listing, status: "inactive", deactivation_reason: "rented")
 
       {:ok, _listing} = Listings.activate(listing)
 

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -366,13 +366,14 @@ defmodule Re.ListingsTest do
     end
   end
 
-  describe "deactivate/1" do
-    test "should set status to inactive" do
+  describe "deactivate/2" do
+    test "should set status to inactive with reason" do
       listing = insert(:listing, status: "active")
 
-      {:ok, listing} = Listings.deactivate(listing)
+      {:ok, listing} = Listings.deactivate(listing, reason: "rented")
 
       assert listing.status == "inactive"
+      assert listing.inactivation_reason == "rented"
     end
 
     test "should save status change to history when set to inactive" do

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -368,6 +368,14 @@ defmodule Re.ListingsTest do
 
   describe "deactivate/1" do
     test "should set status to inactive" do
+      listing = insert(:listing, status: "active")
+
+      {:ok, listing} = Listings.deactivate(listing)
+
+      assert listing.status == "inactive"
+    end
+
+    test "should save status change to history when set to inactive" do
       Server.start_link()
       listing = insert(:listing, status: "active")
 
@@ -375,7 +383,6 @@ defmodule Re.ListingsTest do
 
       GenServer.call(Server, :inspect)
 
-      assert listing.status == "inactive"
       status_history = Repo.one(Re.Listings.StatusHistory)
       assert "active" == status_history.status
     end

--- a/apps/re/test/listings/listings_test.exs
+++ b/apps/re/test/listings/listings_test.exs
@@ -399,7 +399,19 @@ defmodule Re.ListingsTest do
       assert listing.inactivation_reason == nil
     end
 
-    test "should save old status on history" do
+    test "should save old inactivation_reason as status on history" do
+      Server.start_link()
+      listing = insert(:listing, status: "inactive", inactivation_reason: "rented")
+
+      {:ok, _listing} = Listings.activate(listing)
+
+      GenServer.call(Server, :inspect)
+
+      status_history = Repo.one(Re.Listings.StatusHistory)
+      assert "rented" == status_history.status
+    end
+
+    test "should save old status on history when has no reason" do
       Server.start_link()
       listing = insert(:listing, status: "inactive")
 

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -171,7 +171,7 @@ defmodule ReWeb.Resolvers.Listings do
   def deactivate(%{id: id} = params, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Listings, :deactivate_listing, current_user, %{}),
          {:ok, listing} <- Listings.get(id),
-         opts <- Map.get(params, :input, %{}) |> Map.to_list(),
+         opts <- params |> Map.get(:input, %{}) |> Map.to_list(),
          do: Listings.deactivate(listing, opts)
   end
 

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -168,10 +168,11 @@ defmodule ReWeb.Resolvers.Listings do
          do: Listings.activate(listing)
   end
 
-  def deactivate(%{id: id}, %{context: %{current_user: current_user}}) do
+  def deactivate(%{id: id} = params, %{context: %{current_user: current_user}}) do
     with :ok <- Bodyguard.permit(Listings, :deactivate_listing, current_user, %{}),
          {:ok, listing} <- Listings.get(id),
-         do: Listings.deactivate(listing)
+         opts <- Map.get(params, :input, %{}) |> Map.to_list(),
+         do: Listings.deactivate(listing, opts)
   end
 
   def per_user(_, %{context: %{current_user: current_user}}) do

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -11,9 +11,9 @@ defmodule ReWeb.Types.Listing do
     Resolvers
   }
 
-  enum :inactivation_reason, values: ~w(duplicity exclusivity give_up left_emcasa
-                          publication_phase publication_error qualification_phase
-                          rented sold sold_by_emcasa temporarely_suspended)
+  enum :inactivation_reason, values: ~w(duplicated gave_up left_emcasa publication_mistake rented
+                          sold sold_by_emcasa temporarily_suspended to_be_published
+                          went_exclusive)
 
   enum :garage_type, values: ~w(contract condominium)
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -11,7 +11,7 @@ defmodule ReWeb.Types.Listing do
     Resolvers
   }
 
-  enum :inactivation_reason, values: ~w(duplicated gave_up left_emcasa publication_mistake rented
+  enum :deactivation_reason, values: ~w(duplicated gave_up left_emcasa publication_mistake rented
                           sold sold_by_emcasa temporarily_suspended to_be_published
                           went_exclusive)
 
@@ -55,7 +55,7 @@ defmodule ReWeb.Types.Listing do
     field :price_per_area, :float
     field :inserted_at, :naive_datetime
     field :score, :integer, resolve: &Resolvers.Listings.score/3
-    field :inactivation_reason, :inactivation_reason
+    field :deactivation_reason, :deactivation_reason
     field :sold_price, :integer
 
     field :address, :address,
@@ -142,7 +142,7 @@ defmodule ReWeb.Types.Listing do
     field :tags, list_of(non_null(:uuid))
 
     field :owner_contact, :owner_contact_input
-    field :inactivation_reason, :inactivation_reason
+    field :deactivation_reason, :deactivation_reason
   end
 
   object :address do
@@ -190,7 +190,7 @@ defmodule ReWeb.Types.Listing do
   end
 
   input_object :deactivation_options_input do
-    field :inactivation_reason, non_null(:inactivation_reason)
+    field :deactivation_reason, non_null(:deactivation_reason)
     field :sold_price, :integer
   end
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -11,6 +11,16 @@ defmodule ReWeb.Types.Listing do
     Resolvers
   }
 
+  enum :inactivation_reason, values: ~w(duplicity exclusivity give_up left_emcasa
+                          publication_phase publication_error qualification_phase
+                          rented sold sold_by_emcasa temporarely_suspended)
+
+  enum :garage_type, values: ~w(contract condominium)
+
+  enum :orientation_type, values: ~w(frontside backside lateral inside)
+
+  enum :sun_period_type, values: ~w(morning evening)
+
   object :listing do
     field :id, :id
     field :uuid, :uuid, resolve: &Resolvers.Listings.get_uuid/3
@@ -45,6 +55,7 @@ defmodule ReWeb.Types.Listing do
     field :price_per_area, :float
     field :inserted_at, :naive_datetime
     field :score, :integer, resolve: &Resolvers.Listings.score/3
+    field :inactivation_reason, :inactivation_reason
 
     field :address, :address,
       resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_listing/3)
@@ -130,13 +141,8 @@ defmodule ReWeb.Types.Listing do
     field :tags, list_of(non_null(:uuid))
 
     field :owner_contact, :owner_contact_input
+    field :inactivation_reason, :inactivation_reason
   end
-
-  enum :garage_type, values: ~w(contract condominium)
-
-  enum :orientation_type, values: ~w(frontside backside lateral inside)
-
-  enum :sun_period_type, values: ~w(morning evening)
 
   object :address do
     field :id, :id

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -189,6 +189,11 @@ defmodule ReWeb.Types.Listing do
     field :lng, non_null(:float)
   end
 
+  input_object :deactivation_options_input do
+    field :inactivation_reason, non_null(:inactivation_reason)
+    field :sold_price, :integer
+  end
+
   object :listing_user do
     field :listing, :listing
     field :user, :user
@@ -398,8 +403,7 @@ defmodule ReWeb.Types.Listing do
     @desc "Deactivate listing"
     field :deactivate_listing, type: :listing do
       arg :id, non_null(:id)
-      arg :inactivation_reason, :inactivation_reason
-      arg :sold_price, :integer
+      arg :input, :deactivation_options_input
 
       resolve &Resolvers.Listings.deactivate/2
     end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -56,6 +56,7 @@ defmodule ReWeb.Types.Listing do
     field :inserted_at, :naive_datetime
     field :score, :integer, resolve: &Resolvers.Listings.score/3
     field :inactivation_reason, :inactivation_reason
+    field :sold_price, :integer
 
     field :address, :address,
       resolve: dataloader(Re.Addresses, &Resolvers.Addresses.per_listing/3)
@@ -397,6 +398,8 @@ defmodule ReWeb.Types.Listing do
     @desc "Deactivate listing"
     field :deactivate_listing, type: :listing do
       arg :id, non_null(:id)
+      arg :inactivation_reason, :inactivation_reason
+      arg :sold_price, :integer
 
       resolve &Resolvers.Listings.deactivate/2
     end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -861,7 +861,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       mutation DeactivateListing ($id: ID!, $input: DeactivationOptionsInput!) {
         deactivateListing(id: $id, input: $input) {
           id
-          inactivation_reason
+          deactivation_reason
           sold_price
         }
       }
@@ -870,7 +870,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
       variables = %{
         "id" => listing_id,
         "input" => %{
-          "inactivation_reason" => "SOLD",
+          "deactivation_reason" => "SOLD",
           "sold_price" => 1_000_000
         }
       }
@@ -879,7 +879,7 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
 
       assert %{
                "id" => to_string(listing.id),
-               "inactivation_reason" => "SOLD",
+               "deactivation_reason" => "SOLD",
                "sold_price" => 1_000_000
              } == json_response(conn, 200)["data"]["deactivateListing"]
     end

--- a/apps/re_web/test/graphql/listings/mutation_test.exs
+++ b/apps/re_web/test/graphql/listings/mutation_test.exs
@@ -834,6 +834,57 @@ defmodule ReWeb.GraphQL.Listings.MutationTest do
     end
   end
 
+  describe "deactivateListing" do
+    test "admin should deactivate a listing without options", %{admin_conn: conn} do
+      %{id: listing_id} = listing = insert(:listing)
+
+      mutation = """
+      mutation DeactivateListing ($id: ID!) {
+        deactivateListing(id: $id) {
+          id
+        }
+      }
+      """
+
+      variables = %{"id" => listing_id}
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert %{"id" => to_string(listing.id)} ==
+               json_response(conn, 200)["data"]["deactivateListing"]
+    end
+
+    test "admin should deactivate a listing with options", %{admin_conn: conn} do
+      %{id: listing_id} = listing = insert(:listing)
+
+      mutation = """
+      mutation DeactivateListing ($id: ID!, $input: DeactivationOptionsInput!) {
+        deactivateListing(id: $id, input: $input) {
+          id
+          inactivation_reason
+          sold_price
+        }
+      }
+      """
+
+      variables = %{
+        "id" => listing_id,
+        "input" => %{
+          "inactivation_reason" => "SOLD",
+          "sold_price" => 1_000_000
+        }
+      }
+
+      conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, variables))
+
+      assert %{
+               "id" => to_string(listing.id),
+               "inactivation_reason" => "SOLD",
+               "sold_price" => 1_000_000
+             } == json_response(conn, 200)["data"]["deactivateListing"]
+    end
+  end
+
   def insert_development_listing_variables(listing, address_id, development_uuid) do
     %{
       "input" => development_listing_input(listing, address_id, development_uuid)

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -1345,7 +1345,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
     end
 
     test "admin should see inactive listing", %{admin_conn: conn} do
-      %{id: listing_id} = insert(:listing, status: "inactive")
+      %{id: listing_id} = insert(:listing, status: "inactive", inactivation_reason: "rented")
 
       variables = %{"id" => listing_id}
 
@@ -1353,13 +1353,17 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         query Listing ($id: ID!) {
           listing (id: $id) {
             id
+            inactivation_reason
           }
         }
       """
 
       conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
 
-      assert %{"id" => to_string(listing_id)} == json_response(conn, 200)["data"]["listing"]
+      assert %{
+               "id" => to_string(listing_id),
+               "inactivation_reason" => "RENTED"
+             } == json_response(conn, 200)["data"]["listing"]
     end
 
     test "owner should see inactive listing", %{user_conn: conn, user_user: user} do

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -1348,7 +1348,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
       %{id: listing_id} =
         insert(:listing,
           status: "inactive",
-          inactivation_reason: "sold",
+          deactivation_reason: "sold",
           sold_price: 1_000_000
         )
 
@@ -1358,7 +1358,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
         query Listing ($id: ID!) {
           listing (id: $id) {
             id
-            inactivation_reason
+            deactivation_reason
             sold_price
           }
         }
@@ -1368,7 +1368,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
 
       assert %{
                "id" => to_string(listing_id),
-               "inactivation_reason" => "SOLD",
+               "deactivation_reason" => "SOLD",
                "sold_price" => 1_000_000
              } == json_response(conn, 200)["data"]["listing"]
     end

--- a/apps/re_web/test/graphql/listings/query_test.exs
+++ b/apps/re_web/test/graphql/listings/query_test.exs
@@ -1345,7 +1345,12 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
     end
 
     test "admin should see inactive listing", %{admin_conn: conn} do
-      %{id: listing_id} = insert(:listing, status: "inactive", inactivation_reason: "rented")
+      %{id: listing_id} =
+        insert(:listing,
+          status: "inactive",
+          inactivation_reason: "sold",
+          sold_price: 1_000_000
+        )
 
       variables = %{"id" => listing_id}
 
@@ -1354,6 +1359,7 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
           listing (id: $id) {
             id
             inactivation_reason
+            sold_price
           }
         }
       """
@@ -1362,7 +1368,8 @@ defmodule ReWeb.GraphQL.Listings.QueryTest do
 
       assert %{
                "id" => to_string(listing_id),
-               "inactivation_reason" => "RENTED"
+               "inactivation_reason" => "SOLD",
+               "sold_price" => 1_000_000
              } == json_response(conn, 200)["data"]["listing"]
     end
 


### PR DESCRIPTION
Allow user to set a reason when deactivating listings. Also, add sold_price to keep price when a listing is deactivated cause was sold (both for us or another real estate companies). 

A workaround made to keep the history complete when it's inactivated is to keep the reason as the status (only on status story), so if a listing is deactivated but changes the reason from  `temporarely_suspended` to `sold_by_emcasa` we keep recording these changes (if the inactivation has no reason I keep `inactive` as status).  

Last but not least, by now both price and reason are not required, and validations are really soft (like allow a `sold_price` for other reasons). Things tend to be more when the demand grows up.      