### PR TITLE
refactor(graphql): extract address type from listing type

### DIFF
--- a/apps/re_web/lib/graphql/resolvers/addresses.ex
+++ b/apps/re_web/lib/graphql/resolvers/addresses.ex
@@ -48,6 +48,8 @@ defmodule ReWeb.Resolvers.Addresses do
 
   def is_covered(address, _, _), do: {:ok, Addresses.is_covered(address)}
 
+  def neighborhoods(_, _), do: {:ok, Neighborhoods.all()}
+
   defp has_admin_rights?(user, %Listing{} = listing) do
     Bodyguard.permit?(Listings, :has_admin_rights, user, listing)
   end

--- a/apps/re_web/lib/graphql/resolvers/listings.ex
+++ b/apps/re_web/lib/graphql/resolvers/listings.ex
@@ -6,7 +6,6 @@ defmodule ReWeb.Resolvers.Listings do
 
   alias Re.{
     Addresses,
-    Addresses.Neighborhoods,
     Developments,
     Listings.Filters,
     Listings,
@@ -293,8 +292,6 @@ defmodule ReWeb.Resolvers.Listings do
 
     {:ok, listing_index}
   end
-
-  def neighborhoods(_, _), do: {:ok, Neighborhoods.all()}
 
   def featured(_, _), do: {:ok, Featured.get_graphql()}
 

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -4,6 +4,7 @@ defmodule ReWeb.Schema do
   """
   use Absinthe.Schema
 
+  import_types ReWeb.Types.Address
   import_types ReWeb.Types.Listing
   import_types ReWeb.Types.Image
   import_types ReWeb.Types.User
@@ -35,6 +36,7 @@ defmodule ReWeb.Schema do
   end
 
   query do
+    import_fields(:address_queries)
     import_fields(:listing_queries)
     import_fields(:user_queries)
     import_fields(:dashboard_queries)
@@ -45,6 +47,7 @@ defmodule ReWeb.Schema do
   end
 
   mutation do
+    import_fields(:address_mutations)
     import_fields(:listing_mutations)
     import_fields(:image_mutations)
     import_fields(:user_mutations)

--- a/apps/re_web/lib/graphql/types/address.ex
+++ b/apps/re_web/lib/graphql/types/address.ex
@@ -51,6 +51,9 @@ defmodule ReWeb.Types.Address do
   end
 
   object :address_queries do
+    @desc "Get all neighborhoods"
+    field :neighborhoods, list_of(:string), resolve: &Resolvers.Addresses.neighborhoods/2
+
     @desc "Get all districts"
     field :districts, list_of(:district), resolve: &Resolvers.Addresses.districts/2
 

--- a/apps/re_web/lib/graphql/types/address.ex
+++ b/apps/re_web/lib/graphql/types/address.ex
@@ -1,0 +1,84 @@
+defmodule ReWeb.Types.Address do
+  @moduledoc """
+  GraphQL types for addresses
+  """
+  use Absinthe.Schema.Notation
+
+  alias ReWeb.Resolvers
+
+  object :address do
+    field :id, :id
+    field :street, :string
+    field :street_number, :string
+    field :neighborhood, :string
+    field :city, :string
+    field :state, :string
+    field :postal_code, :string
+    field :lat, :float
+    field :lng, :float
+
+    field :street_slug, :string
+    field :neighborhood_slug, :string
+    field :city_slug, :string
+    field :state_slug, :string
+
+    field :neighborhood_description, :string,
+      resolve: &Resolvers.Addresses.neighborhood_description/3
+
+    field :is_covered, :boolean, resolve: &Resolvers.Addresses.is_covered/3
+  end
+
+  object :district do
+    field :state, :string
+    field :city, :string
+    field :name, :string
+    field :state_slug, :string
+    field :city_slug, :string
+    field :name_slug, :string
+    field :description, :string
+    field :status, :string
+  end
+
+  input_object :address_input do
+    field :street, non_null(:string)
+    field :street_number, non_null(:string)
+    field :neighborhood, non_null(:string)
+    field :city, non_null(:string)
+    field :state, non_null(:string)
+    field :postal_code, non_null(:string)
+    field :lat, non_null(:float)
+    field :lng, non_null(:float)
+  end
+
+  object :address_queries do
+    @desc "Get all districts"
+    field :districts, list_of(:district), resolve: &Resolvers.Addresses.districts/2
+
+    @desc "Show district"
+    field :district, :district do
+      arg :state_slug, non_null(:string)
+      arg :city_slug, non_null(:string)
+      arg :name_slug, non_null(:string)
+
+      resolve &Resolvers.Addresses.district/2
+    end
+
+    @desc "Get address coverage"
+    field :address_is_covered, :boolean do
+      arg :state, non_null(:string)
+      arg :city, non_null(:string)
+      arg :neighborhood, non_null(:string)
+
+      resolve &Resolvers.Addresses.is_covered/2
+    end
+  end
+
+  object :address_mutations do
+    @desc "Insert address"
+    field :address_insert, type: :address do
+      arg :input, non_null(:address_input)
+
+      resolve &Resolvers.Addresses.insert/2
+    end
+  end
+end

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -289,9 +289,6 @@ defmodule ReWeb.Types.Listing do
     @desc "Get favorited listings"
     field :favorited_listings, list_of(:listing), resolve: &Resolvers.Accounts.favorited/2
 
-    @desc "Get all neighborhoods"
-    field :neighborhoods, list_of(:string), resolve: &Resolvers.Listings.neighborhoods/2
-
     @desc "Featured listings"
     field :featured_listings, list_of(:listing), resolve: &Resolvers.Listings.featured/2
 

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -145,50 +145,6 @@ defmodule ReWeb.Types.Listing do
     field :deactivation_reason, :deactivation_reason
   end
 
-  object :address do
-    field :id, :id
-    field :street, :string
-    field :street_number, :string
-    field :neighborhood, :string
-    field :city, :string
-    field :state, :string
-    field :postal_code, :string
-    field :lat, :float
-    field :lng, :float
-
-    field :street_slug, :string
-    field :neighborhood_slug, :string
-    field :city_slug, :string
-    field :state_slug, :string
-
-    field :neighborhood_description, :string,
-      resolve: &Resolvers.Addresses.neighborhood_description/3
-
-    field :is_covered, :boolean, resolve: &Resolvers.Addresses.is_covered/3
-  end
-
-  object :district do
-    field :state, :string
-    field :city, :string
-    field :name, :string
-    field :state_slug, :string
-    field :city_slug, :string
-    field :name_slug, :string
-    field :description, :string
-    field :status, :string
-  end
-
-  input_object :address_input do
-    field :street, non_null(:string)
-    field :street_number, non_null(:string)
-    field :neighborhood, non_null(:string)
-    field :city, non_null(:string)
-    field :state, non_null(:string)
-    field :postal_code, non_null(:string)
-    field :lat, non_null(:float)
-    field :lng, non_null(:float)
-  end
-
   input_object :deactivation_options_input do
     field :deactivation_reason, non_null(:deactivation_reason)
     field :sold_price, :integer
@@ -336,18 +292,6 @@ defmodule ReWeb.Types.Listing do
     @desc "Get all neighborhoods"
     field :neighborhoods, list_of(:string), resolve: &Resolvers.Listings.neighborhoods/2
 
-    @desc "Get all districts"
-    field :districts, list_of(:district), resolve: &Resolvers.Addresses.districts/2
-
-    @desc "Show district"
-    field :district, :district do
-      arg :state_slug, non_null(:string)
-      arg :city_slug, non_null(:string)
-      arg :name_slug, non_null(:string)
-
-      resolve &Resolvers.Addresses.district/2
-    end
-
     @desc "Featured listings"
     field :featured_listings, list_of(:listing), resolve: &Resolvers.Listings.featured/2
 
@@ -359,25 +303,9 @@ defmodule ReWeb.Types.Listing do
 
       resolve &Resolvers.Listings.relaxed/2
     end
-
-    @desc "Get address coverage"
-    field :address_is_covered, :boolean do
-      arg :state, non_null(:string)
-      arg :city, non_null(:string)
-      arg :neighborhood, non_null(:string)
-
-      resolve &Resolvers.Addresses.is_covered/2
-    end
   end
 
   object :listing_mutations do
-    @desc "Insert address"
-    field :address_insert, type: :address do
-      arg :input, non_null(:address_input)
-
-      resolve &Resolvers.Addresses.insert/2
-    end
-
     @desc "Insert listing"
     field :insert_listing, type: :listing do
       arg :input, non_null(:listing_input)


### PR DESCRIPTION
Move address related types, queries, and mutations to own module instead keep it growing inside listing type module. Also, move neighborhood resolver from listings' module to addresses. 