### PR TITLE
Add IsExportable listing filter

### DIFF
--- a/apps/re/lib/listings/exporter.ex
+++ b/apps/re/lib/listings/exporter.ex
@@ -19,7 +19,7 @@ defmodule Re.Listings.Exporter do
   ]
 
   def exportable(filters, _params) do
-    filters = Map.put(filters, :exportable, true)
+    filters = Map.put(filters, :is_exportable, true)
 
     Queries.active()
     |> Filters.apply(filters)

--- a/apps/re/lib/listings/filters/filters.ex
+++ b/apps/re/lib/listings/filters/filters.ex
@@ -35,7 +35,7 @@ defmodule Re.Listings.Filters do
     field :cities, {:array, :string}
     field :cities_slug, {:array, :string}
     field :states_slug, {:array, :string}
-    field :exportable, :boolean
+    field :is_exportable, :boolean
     field :tags_slug, {:array, :string}
     field :tags_uuid, {:array, :string}
     field :statuses, {:array, :string}
@@ -58,7 +58,7 @@ defmodule Re.Listings.Filters do
   @filters ~w(max_price min_price max_rooms min_rooms max_suites min_suites min_area max_area
               neighborhoods types max_lat min_lat max_lng min_lng neighborhoods_slugs
               max_garage_spots min_garage_spots garage_types cities cities_slug states_slug
-              exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
+              is_exportable tags_slug tags_uuid statuses min_floor_count max_floor_count
               min_unit_per_floor max_unit_per_floor orientations sun_periods min_age max_age
               min_price_per_area max_price_per_area min_maintenance_fee max_maintenance_fee
               max_bathrooms min_bathrooms is_release exclude_similar_for_primary_market)a
@@ -251,8 +251,8 @@ defmodule Re.Listings.Filters do
     )
   end
 
-  defp attr_filter({:exportable, exportable}, query) do
-    from(l in query, where: l.is_exportable == ^exportable)
+  defp attr_filter({:is_exportable, is_exportable}, query) do
+    from(l in query, where: l.is_exportable == ^is_exportable)
   end
 
   defp attr_filter({:tags_slug, []}, query), do: query

--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -221,6 +221,7 @@ defmodule ReWeb.Types.Listing do
     field :min_maintenance_fee, :float
     field :max_maintenance_fee, :float
     field :is_release, :boolean
+    field :is_exportable, :boolean
     field :exclude_similar_for_primary_market, :boolean
   end
 

--- a/apps/re_web/test/graphql/dashboard/query_test.exs
+++ b/apps/re_web/test/graphql/dashboard/query_test.exs
@@ -122,7 +122,7 @@ defmodule ReWeb.GraphQL.Dashboard.QueryTest do
       query = """
         query Dashboard {
           dashboard {
-            activeListingCount(isRelease: false, isExportable: true)
+            activeListingCount(isRelease: true, isExportable: true)
           }
         }
       """


### PR DESCRIPTION
This PR adds is_exportable to graphql's `ListingFilterInput` type and fixes a false positive assertion on `active_listing_count`'s test case. I'll change `active_listing_filter`'s graphql input to `ListingFilterInput` in another PR.