### PR TITLE
feature(graphql): add new order by criterias

### DIFF
--- a/apps/re_web/lib/graphql/types/listing.ex
+++ b/apps/re_web/lib/graphql/types/listing.ex
@@ -180,7 +180,7 @@ defmodule ReWeb.Types.Listing do
       ~w(id price property_tax maintenance_fee rooms bathrooms restrooms area garage_spots suites dependencies balconies
       price_per_area inserted_at floor)a
 
-  enum :order_type, values: ~w(desc asc)a
+  enum :order_type, values: ~w(desc asc desc_nulls_last asc_nulls_last)a
 
   input_object :listing_filter_input do
     field :max_price, :integer


### PR DESCRIPTION
Allow sort fields using nulls as last on order by, so we always list
info that exists before info which is not complete.

I was talking with @gabiseabra about this problem, whenever we sort on Garagem the nulled fields will be shown before the not nulled ones. [Postgres has a `NULLS AFTER`](https://www.postgresql.org/docs/8.3/queries-order.html) feature, so [has Ecto a native way to use it](https://hexdocs.pm/ecto/Ecto.Query.html#order_by/3). 

@gabiseabra feel free to use it whatever you see it's the appropriate way to sort. 