### PR TITLE
Add optional utm fields in Interest

### DIFF
--- a/apps/re/lib/interests/interest.ex
+++ b/apps/re/lib/interests/interest.ex
@@ -17,6 +17,12 @@ defmodule Re.Interest do
     field :email, :string
     field :phone, :string
     field :message, :string
+    field :campaign, :string
+    field :medium, :string
+    field :source, :string
+    field :initial_campaign, :string
+    field :initial_medium, :string
+    field :initial_source, :string
 
     belongs_to :listing, Re.Listing
     belongs_to :interest_type, Re.InterestType
@@ -25,7 +31,8 @@ defmodule Re.Interest do
   end
 
   @required ~w(name phone listing_id)a
-  @optional ~w(email message interest_type_id uuid)a
+  @optional ~w(email message interest_type_id uuid campaign medium
+               source initial_campaign initial_medium initial_source)a
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/apps/re/priv/repo/migrations/20190716142149_add_utm_fields_to_interest.exs
+++ b/apps/re/priv/repo/migrations/20190716142149_add_utm_fields_to_interest.exs
@@ -1,0 +1,14 @@
+defmodule Re.Repo.Migrations.AddUtmFieldsToInterest do
+  use Ecto.Migration
+
+  def change do
+    alter table(:interests) do
+      add :campaign, :string
+      add :medium, :string
+      add :source, :string
+      add :initial_campaign, :string
+      add :initial_medium, :string
+      add :initial_source, :string
+    end
+  end
+end

--- a/apps/re_web/lib/graphql/types/interest.ex
+++ b/apps/re_web/lib/graphql/types/interest.ex
@@ -15,6 +15,12 @@ defmodule ReWeb.Types.Interest do
     field :email, :string
     field :phone, :string
     field :message, :string
+    field :campaign, :string
+    field :medium, :string
+    field :source, :string
+    field :initial_campaign, :string
+    field :initial_medium, :string
+    field :initial_source, :string
 
     field :listing, :listing, resolve: dataloader(Re.Listings)
     field :interest_type, :interest_type, resolve: dataloader(Re.Interests.Types)
@@ -25,6 +31,12 @@ defmodule ReWeb.Types.Interest do
     field :phone, :string
     field :email, :string
     field :message, :string
+    field :campaign, :string
+    field :medium, :string
+    field :source, :string
+    field :initial_campaign, :string
+    field :initial_medium, :string
+    field :initial_source, :string
 
     field :interest_type_id, non_null(:id)
     field :listing_id, non_null(:id)

--- a/apps/re_web/test/graphql/interests/mutation_test.exs
+++ b/apps/re_web/test/graphql/interests/mutation_test.exs
@@ -32,9 +32,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
         "campaign" => "utm campaign",
         "medium" => "utm medium",
         "source" => "utm source",
-        "initial_campaign" => "utm initial_campaign",
-        "initial_medium" => "utm initial_medium",
-        "initial_source" => "utm initial_source",
+        "initialCampaign" => "utm initial campaign",
+        "initialMedium" => "utm initial medium",
+        "initialSource" => "utm initial source",
         "interestTypeId" => interest_type_id,
         "listingId" => listing_id
       }
@@ -50,9 +50,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
           campaign
           medium
           source
-          initial_campaign
-          initial_medium
-          initial_source
+          initialCampaign
+          initialMedium
+          initialSource
           listing {
             id
           }
@@ -74,9 +74,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
              "campaign" => "utm campaign",
              "medium" => "utm medium",
              "source" => "utm source",
-             "initial_campaign" => "utm initial_campaign",
-             "initial_medium" => "utm initial_medium",
-             "initial_source" => "utm initial_source",
+             "initialCampaign" => "utm initial campaign",
+             "initialMedium" => "utm initial medium",
+             "initialSource" => "utm initial source",
              "interestType" => %{
                "id" => to_string(interest_type_id),
                "name" => interest_type_name
@@ -104,9 +104,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
         "campaign" => "utm campaign",
         "medium" => "utm medium",
         "source" => "utm source",
-        "initial_campaign" => "utm initial_campaign",
-        "initial_medium" => "utm initial_medium",
-        "initial_source" => "utm initial_source",
+        "initialCampaign" => "utm initial campaign",
+        "initialMedium" => "utm initial medium",
+        "initialSource" => "utm initial source",
         "interestTypeId" => interest_type_id,
         "listingId" => listing_id
       }
@@ -122,9 +122,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
           campaign
           medium
           source
-          initial_campaign
-          initial_medium
-          initial_source
+          initialCampaign
+          initialMedium
+          initialSource
           listing {
             id
           }
@@ -146,9 +146,9 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
              "campaign" => "utm campaign",
              "medium" => "utm medium",
              "source" => "utm source",
-             "initial_campaign" => "utm initial_campaign",
-             "initial_medium" => "utm initial_medium",
-             "initial_source" => "utm initial_source",
+             "initialCampaign" => "utm initial campaign",
+             "initialMedium" => "utm initial medium",
+             "initialSource" => "utm initial source",
              "interestType" => %{
                "id" => to_string(interest_type_id),
                "name" => interest_type_name

--- a/apps/re_web/test/graphql/interests/mutation_test.exs
+++ b/apps/re_web/test/graphql/interests/mutation_test.exs
@@ -29,6 +29,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
         "email" => "testemail@emcasa.com",
         "phone" => "123321123",
         "message" => "this website is cool",
+        "campaign" => "utm campaign",
+        "medium" => "utm medium",
+        "source" => "utm source",
+        "initial_campaign" => "utm initial_campaign",
+        "initial_medium" => "utm initial_medium",
+        "initial_source" => "utm initial_source",
         "interestTypeId" => interest_type_id,
         "listingId" => listing_id
       }
@@ -41,6 +47,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
           email
           phone
           message
+          campaign
+          medium
+          source
+          initial_campaign
+          initial_medium
+          initial_source
           listing {
             id
           }
@@ -59,6 +71,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
              "email" => "testemail@emcasa.com",
              "phone" => "123321123",
              "message" => "this website is cool",
+             "campaign" => "utm campaign",
+             "medium" => "utm medium",
+             "source" => "utm source",
+             "initial_campaign" => "utm initial_campaign",
+             "initial_medium" => "utm initial_medium",
+             "initial_source" => "utm initial_source",
              "interestType" => %{
                "id" => to_string(interest_type_id),
                "name" => interest_type_name
@@ -83,6 +101,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
         "email" => "testemail@emcasa.com",
         "phone" => "123321123",
         "message" => "this website is cool",
+        "campaign" => "utm campaign",
+        "medium" => "utm medium",
+        "source" => "utm source",
+        "initial_campaign" => "utm initial_campaign",
+        "initial_medium" => "utm initial_medium",
+        "initial_source" => "utm initial_source",
         "interestTypeId" => interest_type_id,
         "listingId" => listing_id
       }
@@ -95,6 +119,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
           email
           phone
           message
+          campaign
+          medium
+          source
+          initial_campaign
+          initial_medium
+          initial_source
           listing {
             id
           }
@@ -113,6 +143,12 @@ defmodule ReWeb.GraphQL.Interests.MutationTest do
              "email" => "testemail@emcasa.com",
              "phone" => "123321123",
              "message" => "this website is cool",
+             "campaign" => "utm campaign",
+             "medium" => "utm medium",
+             "source" => "utm source",
+             "initial_campaign" => "utm initial_campaign",
+             "initial_medium" => "utm initial_medium",
+             "initial_source" => "utm initial_source",
              "interestType" => %{
                "id" => to_string(interest_type_id),
                "name" => interest_type_name


### PR DESCRIPTION
Adds a mutation to include `campaign`, `medium`, `source` and their initial values to the `Interest` model.

Also includes these same fields in the `createInterest` mutation input (they're optional).