### PR TITLE
Zapier salesforce seller client

### DIFF
--- a/apps/re/lib/seller_leads/salesforce/client.ex
+++ b/apps/re/lib/seller_leads/salesforce/client.ex
@@ -1,0 +1,42 @@
+defmodule Re.SellerLeads.Salesforce.Client do
+  @moduledoc """
+  Module to interface with salesforce
+  """
+
+  alias Re.{
+    Address,
+    SellerLeads.Salesforce.ZapierClient,
+    User
+  }
+
+  @exported ~w(uuid source type complement price rooms bathrooms suites garage_spots
+               maintenance_fee area tour_option inserted_at)a
+
+  def create_lead(%Re.SellerLead{} = lead) do
+    lead
+    |> Map.take(@exported)
+    |> put_user_params(lead.user)
+    |> put_address_params(lead.address)
+    |> Map.update(:phone, "", fn phone -> String.replace(phone, "+", "") end)
+    |> Jason.encode!()
+    |> ZapierClient.post()
+    |> case do
+      {:ok, %{status_code: 200, body: body}} -> Jason.decode(body)
+      error -> error
+    end
+  end
+
+  def create_lead(_), do: {:error, :lead_type_not_handled}
+
+  defp put_user_params(params, %User{} = user) do
+    user
+    |> Map.take(~w(name phone email)a)
+    |> Map.merge(params)
+  end
+
+  defp put_address_params(params, %Address{} = address) do
+    address
+    |> Map.take(~w(street street_number city state neighborhood postal_code)a)
+    |> Map.merge(params)
+  end
+end

--- a/apps/re/lib/seller_leads/salesforce/zapier_client.ex
+++ b/apps/re/lib/seller_leads/salesforce/zapier_client.ex
@@ -1,0 +1,16 @@
+defmodule Re.SellerLeads.Salesforce.ZapierClient do
+  @moduledoc """
+  Module for zapier webhook trigger
+  """
+  require Mockery.Macro
+
+  @url Application.get_env(:re, :zapier_create_salesforce_seller_lead_url, "")
+
+  def post(payload) do
+    @url
+    |> URI.parse()
+    |> http_client().post(payload)
+  end
+
+  defp http_client, do: Mockery.Macro.mockable(HTTPoison)
+end

--- a/apps/re/lib/seller_leads/seller_lead.ex
+++ b/apps/re/lib/seller_leads/seller_lead.ex
@@ -37,7 +37,7 @@ defmodule Re.SellerLead do
   @required ~w(origin)a
   @optional ~w(street street_number city state neighborhood postal_code name phone email source
                complement type area maintenance_fee rooms bathrooms suites garage_spots value
-               tour_option)a
+               tour_option address_uuid user_uuid)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/seller_leads/seller_lead.ex
+++ b/apps/re/lib/seller_leads/seller_lead.ex
@@ -12,7 +12,7 @@ defmodule Re.SellerLead do
     field :source, :string
     field :complement, :string
     field :type, :string
-    field :area, :string
+    field :area, :integer
     field :maintenance_fee, :float
     field :rooms, :integer
     field :bathrooms, :integer

--- a/apps/re/priv/repo/migrations/20190717190328_fix_area_type.exs
+++ b/apps/re/priv/repo/migrations/20190717190328_fix_area_type.exs
@@ -1,0 +1,25 @@
+defmodule Re.Repo.Migrations.FixAreaType do
+  use Ecto.Migration
+
+  def up do
+    alter table(:seller_leads) do
+      remove :area
+    end
+
+    flush()
+
+    alter table(:seller_leads) do
+      add :area, :integer
+    end
+  end
+
+  def down do
+    alter table(:seller_leads) do
+      remove :area
+    end
+
+    alter table(:seller_leads) do
+      add :area, :string
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190717191541_add_fk_index_seller_lead.exs
+++ b/apps/re/priv/repo/migrations/20190717191541_add_fk_index_seller_lead.exs
@@ -1,0 +1,25 @@
+defmodule Re.Repo.Migrations.FixSellerLeadUserReference do
+  use Ecto.Migration
+
+  def up do
+    alter table(:seller_leads) do
+      remove :user_uuid
+    end
+
+    flush()
+
+    alter table(:seller_leads) do
+      add :user_uuid, references(:users, column: :uuid, type: :uuid)
+    end
+
+    create index(:seller_leads, [:address_uuid, :user_uuid])
+  end
+
+  def down do
+    alter table(:seller_leads) do
+      remove :user_uuid
+    end
+
+    drop index(:seller_leads, [:address_uuid, :user_uuid])
+  end
+end

--- a/apps/re/test/seller_leads/salesforce/client_test.exs
+++ b/apps/re/test/seller_leads/salesforce/client_test.exs
@@ -1,0 +1,88 @@
+defmodule Re.SellerLeads.Salesforce.ClientTest do
+  use Re.ModelCase
+  use Mockery
+
+  import Re.Factory
+
+  alias Re.SellerLeads.Salesforce.Client
+
+  describe "create_lead/1" do
+    @uri %URI{
+      authority: "www.emcasa.com",
+      fragment: nil,
+      host: "www.emcasa.com",
+      path: "/salesforce_zapier",
+      port: 80,
+      query: nil,
+      scheme: "http",
+      userinfo: nil
+    }
+
+    setup do
+      user = insert(:user)
+      address = insert(:address)
+      seller_lead = insert(:seller_lead, user: user, address: address)
+
+      {:ok, encoded_seller_lead} =
+        Jason.encode(%{
+          name: user.name,
+          email: user.email,
+          phone: user.phone,
+          city: address.city,
+          state: address.state,
+          street: address.street,
+          street_number: address.street_number,
+          neighborhood: address.neighborhood,
+          postal_code: address.postal_code,
+          type: seller_lead.type,
+          complement: seller_lead.complement,
+          garage_spots: seller_lead.garage_spots,
+          area: seller_lead.area,
+          bathrooms: seller_lead.bathrooms,
+          rooms: seller_lead.rooms,
+          suites: seller_lead.suites,
+          maintenance_fee: seller_lead.maintenance_fee,
+          price: seller_lead.price,
+          source: seller_lead.source,
+          tour_option: seller_lead.tour_option,
+          inserted_at: seller_lead.inserted_at,
+          uuid: seller_lead.uuid
+        })
+
+      {:ok, seller_lead: seller_lead, encoded_seller_lead: encoded_seller_lead}
+    end
+
+    test "should send a request to create a lead", %{
+      seller_lead: seller_lead,
+      encoded_seller_lead: encoded_seller_lead
+    } do
+      mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
+
+      assert {:ok, %{"status" => "success"}} = Client.create_lead(seller_lead)
+
+      uri = @uri
+      assert_called(HTTPoison, :post, [^uri, ^encoded_seller_lead])
+    end
+
+    test "should not send a request on not handled lead type" do
+      mock(HTTPoison, :post, {:ok, %{body: ~s({"status":"success"})}})
+
+      assert {:error, :lead_type_not_handled} = Client.create_lead(%{})
+
+      uri = @uri
+      refute_called(HTTPoison, :post, [^uri, "{}"])
+    end
+
+    test "should handle request error", %{
+      seller_lead: seller_lead,
+      encoded_seller_lead: encoded_seller_lead
+    } do
+      mock(HTTPoison, :post, {:error, %HTTPoison.Error{id: nil, reason: :timeout}})
+
+      assert {:error, %{reason: :timeout}} = Client.create_lead(seller_lead)
+
+      uri = @uri
+      assert_called(HTTPoison, :post, [^uri, ^encoded_seller_lead])
+    end
+  end
+end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -359,6 +359,24 @@ defmodule Re.Factory do
     }
   end
 
+  def seller_lead_factory do
+    %Re.SellerLead{
+      uuid: UUID.uuid4(),
+      type: random(:listing_type),
+      complement: Address.secondary_address(),
+      maintenance_fee: random(:maintenance_fee_float),
+      rooms: Enum.random(1..10),
+      bathrooms: Enum.random(1..10),
+      garage_spots: Enum.random(0..10),
+      suites: Enum.random(0..10),
+      price: random(:price),
+      area: Enum.random(25..500),
+      source: Enum.random(~w(Website Facebook)),
+      tour_option: ~N[2019-07-18 10:00:00.000000],
+      inserted_at: ~N[2019-07-17 10:00:00.000000]
+    }
+  end
+
   defp random_postcode do
     first =
       10_000..99_999

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -65,6 +65,7 @@ config :re,
   facebook_access_token: System.get_env("FACEBOOK_ACCESS_TOKEN"),
   garagem_url: System.get_env("GARAGEM_URL"),
   zapier_create_salesforce_lead_url: System.get_env("SALESFORCE_ZAPIER_URL"),
+  zapier_create_salesforce_seller_lead_url: System.get_env("SALESFORCE_ZAPIER_SELLER_URL"),
   priceteller_url: System.get_env("PRICETELLER_URL"),
   priceteller_token: System.get_env("PRICETELLER_TOKEN")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -66,6 +66,7 @@ config :re,
   facebook_access_token: "testsecret",
   garagem_url: "http://localhost:3000",
   zapier_create_salesforce_lead_url: "http://www.emcasa.com/salesforce_zapier",
+  zapier_create_salesforce_seller_lead_url: "http://www.emcasa.com/salesforce_zapier",
   priceteller_url: "http://www.emcasa.com/priceteller",
   priceteller_token: "mahtoken",
   retry_expiry: 100


### PR DESCRIPTION
Following up on #662 to add a client to send seller leads to salesforce via zapier
The client configuration is pretty similar to buyer leads, but for now for simplicity we'll keep it separated.
When there's a need to extract some stuff, we'll do.