### PR TITLE
Send price suggestion salesforce

### DIFF
--- a/apps/re/lib/application.ex
+++ b/apps/re/lib/application.ex
@@ -13,7 +13,8 @@ defmodule Re.Application do
     Listings,
     Listings.History,
     PubSub,
-    Repo
+    Repo,
+    SellerLeads
   }
 
   def start(_type, _args) do

--- a/apps/re/lib/application.ex
+++ b/apps/re/lib/application.ex
@@ -36,6 +36,7 @@ defmodule Re.Application do
       worker(History.Server, []),
       {BuyerLeads.JobQueue, repo: Repo},
       {Developments.JobQueue, repo: Repo},
-      {Listings.JobQueue, repo: Repo}
+      {Listings.JobQueue, repo: Repo},
+      {SellerLeads.JobQueue, repo: Repo}
     ]
 end

--- a/apps/re/lib/interests/interests.ex
+++ b/apps/re/lib/interests/interests.ex
@@ -51,6 +51,8 @@ defmodule Re.Interests do
     |> PubSub.publish_new("contact_request")
   end
 
+  def request_price_suggestion(_params, nil), do: {:error, :bad_request}
+
   def request_price_suggestion(params, user) do
     with {:ok, address} <- Addresses.insert_or_update(params.address) do
       params

--- a/apps/re/lib/interests/interests.ex
+++ b/apps/re/lib/interests/interests.ex
@@ -2,6 +2,7 @@ defmodule Re.Interests do
   @moduledoc """
   Context to manage operation between users and listings
   """
+  @behaviour Bodyguard.Policy
 
   import Ecto.Query
 
@@ -22,6 +23,8 @@ defmodule Re.Interests do
     Repo,
     User
   }
+
+  defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def data(params), do: Dataloader.Ecto.new(Re.Repo, query: &query/2, default_params: params)
 
@@ -49,11 +52,11 @@ defmodule Re.Interests do
   end
 
   def request_price_suggestion(params, user) do
-    with {:ok, address} <- Addresses.insert_or_update(params.address),
-         {:ok, request} <- PriceSuggestions.create_request(params, address, user) do
-      request
-      |> Repo.preload(:address)
-      |> PriceSuggestions.suggest_price()
+    with {:ok, address} <- Addresses.insert_or_update(params.address) do
+      params
+      |> Map.put(:address_id, address.id)
+      |> Map.put(:user_id, user.id)
+      |> PriceSuggestions.create_request()
       |> PubSub.publish_new("new_price_suggestion_request")
     end
   end

--- a/apps/re/lib/interests/policy.ex
+++ b/apps/re/lib/interests/policy.ex
@@ -1,0 +1,14 @@
+defmodule Re.Interests.Policy do
+  @moduledoc """
+  Policy module for user permission on interests
+  """
+  alias Re.User
+
+  def authorize(_, %User{role: "admin"}, _), do: :ok
+
+  def authorize(:request_price_suggestion, %User{}, _), do: :ok
+
+  def authorize(_, nil, _), do: {:error, :unauthorized}
+
+  def authorize(_, _, _), do: {:error, :forbidden}
+end

--- a/apps/re/lib/price_suggestions/price_suggestions.ex
+++ b/apps/re/lib/price_suggestions/price_suggestions.ex
@@ -9,27 +9,18 @@ defmodule Re.PriceSuggestions do
     PriceSuggestions.Request,
     PriceTeller,
     Repo,
-    User
+    SellerLeads.JobQueue
   }
 
-  alias Ecto.Changeset
+  alias Ecto.{
+    Changeset,
+    Multi
+  }
 
   def suggest_price(%Request{} = request) do
     request
     |> preload_address()
     |> do_suggest_price()
-    |> case do
-      {:ok, suggested_price} ->
-        params =
-          Map.merge(%{suggested_price: suggested_price.listing_price_rounded}, suggested_price)
-
-        request
-        |> Request.changeset(params)
-        |> Repo.update()
-
-      error ->
-        error
-    end
   end
 
   def suggest_price(%Listing{} = listing) do
@@ -55,7 +46,6 @@ defmodule Re.PriceSuggestions do
     params
     |> map_params()
     |> PriceTeller.ask()
-    |> format_output()
   end
 
   defp map_params(params) do
@@ -82,30 +72,39 @@ defmodule Re.PriceSuggestions do
   defp round_if_not_nil(nil), do: 0
   defp round_if_not_nil(maintenance_fee), do: round(maintenance_fee)
 
-  defp format_output({:ok, suggested_price}), do: {:ok, suggested_price}
-
-  defp format_output(response) do
-    Sentry.capture_message("Error on priceteller response",
-      extra: %{response: Kernel.inspect(response)}
-    )
-
-    response
-  end
-
   defp preload_address(%Listing{} = listing), do: Repo.preload(listing, :address)
 
   defp preload_address(params), do: params
 
-  def create_request(params, %{id: address_id}, user) do
-    %Request{}
-    |> Changeset.change(address_id: address_id)
-    |> attach_user(user)
-    |> Request.changeset(params)
-    |> Repo.insert()
+  def create_request(params) do
+    with %{valid?: true} = changeset <- Request.changeset(%Request{}, params),
+         suggested_price <- do_suggest_price(params),
+         %{valid?: true} = changeset <- set_suggested_price(changeset, suggested_price) do
+      uuid = Changeset.get_field(changeset, :uuid)
+
+      Ecto.Multi.new()
+      |> Multi.insert(:insert_price_suggestion_request, changeset)
+      |> JobQueue.enqueue(:seller_lead_job, %{
+        "type" => "process_price_suggestion_request",
+        "uuid" => uuid
+      })
+      |> Repo.transaction()
+      |> return_insertion()
+    else
+      %Changeset{} = changeset -> {:error, changeset}
+      error -> error
+    end
   end
 
-  defp attach_user(changeset, %User{id: id}),
-    do: Changeset.change(changeset, user_id: id)
+  defp set_suggested_price(changeset, {:ok, suggested_price}) do
+    changeset
+    |> Request.changeset(%{suggested_price: suggested_price.listing_price_rounded})
+    |> Request.changeset(suggested_price)
+  end
 
-  defp attach_user(changeset, _), do: changeset
+  defp set_suggested_price(changeset, _), do: changeset
+
+  defp return_insertion({:ok, %{insert_price_suggestion_request: request}}), do: {:ok, request}
+
+  defp return_insertion(error), do: error
 end

--- a/apps/re/lib/price_suggestions/request.ex
+++ b/apps/re/lib/price_suggestions/request.ex
@@ -6,6 +6,8 @@ defmodule Re.PriceSuggestions.Request do
 
   import Ecto.Changeset
 
+  alias Re.SellerLead
+
   schema "price_suggestion_requests" do
     field :uuid, Ecto.UUID
     field :name, :string
@@ -50,4 +52,22 @@ defmodule Re.PriceSuggestions.Request do
   end
 
   defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
+
+  def seller_lead_changeset(lead) do
+    params = %{
+      source: "WebSite",
+      type: lead.type,
+      area: lead.area,
+      maintenance_fee: lead.maintenance_fee,
+      rooms: lead.rooms,
+      bathrooms: lead.bathrooms,
+      suites: lead.suites,
+      garage_spots: lead.garage_spots,
+      suggested_price: lead.suggested_price,
+      user_uuid: lead.user.uuid,
+      address_uuid: lead.address.uuid
+    }
+
+    SellerLead.changeset(%SellerLead{}, params)
+  end
 end

--- a/apps/re/lib/seller_leads/job_queue.ex
+++ b/apps/re/lib/seller_leads/job_queue.ex
@@ -4,5 +4,31 @@ defmodule Re.SellerLeads.JobQueue do
   """
   use EctoJob.JobQueue, table_name: "seller_lead_jobs"
 
-  def perform(_, _), do: :ok
+  require Ecto.Query
+
+  alias Re.{
+    PriceSuggestions.Request,
+    Repo
+  }
+
+  alias Ecto.Multi
+
+  def perform(%Multi{} = multi, %{"type" => "process_price_suggestion_request", "uuid" => uuid}) do
+    Request
+    |> Ecto.Query.preload([:address, :user])
+    |> Repo.get_by(uuid: uuid)
+    |> Request.seller_lead_changeset()
+    |> insert_seller_lead(multi)
+    |> Repo.transaction()
+    |> handle_error()
+  end
+
+  def perform(_multi, job), do: raise("Job type not handled. Job: #{Kernel.inspect(job)}")
+
+  defp insert_seller_lead(changeset, multi),
+    do: Multi.insert(multi, :insert_seller_lead, changeset)
+
+  defp handle_error({:ok, result}), do: {:ok, result}
+
+  defp handle_error(_error), do: raise("Error when performing SellerLeads.JobQueue")
 end

--- a/apps/re/lib/seller_leads/salesforce/client.ex
+++ b/apps/re/lib/seller_leads/salesforce/client.ex
@@ -9,7 +9,7 @@ defmodule Re.SellerLeads.Salesforce.Client do
     User
   }
 
-  @exported ~w(uuid source type complement price rooms bathrooms suites garage_spots
+  @exported ~w(uuid source type complement suggested_price rooms bathrooms suites garage_spots
                maintenance_fee area tour_option inserted_at)a
 
   def create_lead(%Re.SellerLead{} = lead) do

--- a/apps/re/lib/seller_leads/seller_lead.ex
+++ b/apps/re/lib/seller_leads/seller_lead.ex
@@ -19,6 +19,7 @@ defmodule Re.SellerLead do
     field :suites, :integer
     field :garage_spots, :integer
     field :price, :float
+    field :suggested_price, :float
     field :tour_option, :utc_datetime
 
     belongs_to :address, Re.Address,
@@ -36,7 +37,7 @@ defmodule Re.SellerLead do
 
   @required ~w(source)a
   @optional ~w(complement type area maintenance_fee rooms bathrooms suites garage_spots price
-               tour_option address_uuid user_uuid)a
+               suggested_price tour_option address_uuid user_uuid)a
   @params @required ++ @optional
 
   def changeset(struct, params \\ %{}) do

--- a/apps/re/lib/seller_leads/seller_lead.ex
+++ b/apps/re/lib/seller_leads/seller_lead.ex
@@ -34,9 +34,8 @@ defmodule Re.SellerLead do
     timestamps(type: :utc_datetime)
   end
 
-  @required ~w(origin)a
-  @optional ~w(street street_number city state neighborhood postal_code name phone email source
-               complement type area maintenance_fee rooms bathrooms suites garage_spots value
+  @required ~w(source)a
+  @optional ~w(complement type area maintenance_fee rooms bathrooms suites garage_spots price
                tour_option address_uuid user_uuid)a
   @params @required ++ @optional
 

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -2,13 +2,17 @@ defmodule Re.SellerLeads do
   @moduledoc """
   Context boundary to Seller Leads
   """
+  require Ecto.Query
 
   alias Re.{
     PubSub,
     Repo,
+    SellerLead,
     SellerLeads.Facebook,
     SellerLeads.Site
   }
+
+  alias Ecto.Query
 
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
@@ -23,5 +27,18 @@ defmodule Re.SellerLeads do
     %Facebook{}
     |> Facebook.changeset(payload)
     |> Repo.insert()
+  end
+
+  def get_preloaded(uuid, preloads) do
+    SellerLead
+    |> Query.preload(^preloads)
+    |> do_get(uuid)
+  end
+
+  defp do_get(query, uuid) do
+    case Repo.get(query, uuid) do
+      nil -> {:error, :not_found}
+      seller_lead -> {:ok, seller_lead}
+    end
   end
 end

--- a/apps/re/priv/repo/migrations/20190722193439_add_suggested_price_seller_lead.exs
+++ b/apps/re/priv/repo/migrations/20190722193439_add_suggested_price_seller_lead.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.AddSuggestedPriceSellerLead do
+  use Ecto.Migration
+
+  def change do
+    alter table(:seller_leads) do
+      add :suggested_price, :float
+    end
+  end
+end

--- a/apps/re/test/interests/interests_test.exs
+++ b/apps/re/test/interests/interests_test.exs
@@ -106,6 +106,47 @@ defmodule Re.InterestsTest do
       assert request.user_id == user.id
       assert request.suggested_price == 26_279.0
     end
+
+    test "should not store price suggestion request without user" do
+      mock(
+        HTTPoison,
+        :post,
+        {:ok,
+         %{
+           body:
+             "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
+         }}
+      )
+
+      address_params = %{
+        street: "street",
+        street_number: "street_number",
+        neighborhood: "neighborhood",
+        city: "city",
+        state: "ST",
+        postal_code: "12345-123",
+        lat: 10.10,
+        lng: 10.10
+      }
+
+      params = %{
+        address: address_params,
+        name: "name",
+        email: "email@emcasa.com",
+        rooms: 2,
+        bathrooms: 2,
+        area: 30,
+        garage_spots: 2,
+        suites: 1,
+        type: "Apartamento",
+        maintenance_fee: 100.00,
+        is_covered: true
+      }
+
+      assert {:error, :bad_request} = Interests.request_price_suggestion(params, nil)
+
+      refute Repo.one(Request)
+    end
   end
 
   describe "notify_when_covered/1" do

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -19,7 +19,7 @@ defmodule Re.SellerLeads.JobQueueTest do
       %{uuid: user_uuid} = user = insert(:user)
 
       %{uuid: uuid} =
-        lead =
+        price_suggestion_request =
         insert(:price_suggestion_request,
           address: address,
           user: user
@@ -38,15 +38,15 @@ defmodule Re.SellerLeads.JobQueueTest do
       assert seller.address_uuid == address_uuid
       assert seller.source == "WebSite"
       assert seller.complement == nil
-      assert seller.type == lead.type
-      assert seller.area == lead.area
-      assert seller.maintenance_fee == lead.maintenance_fee
-      assert seller.rooms == lead.rooms
-      assert seller.bathrooms == lead.bathrooms
-      assert seller.suites == lead.suites
-      assert seller.garage_spots == lead.garage_spots
+      assert seller.type == price_suggestion_request.type
+      assert seller.area == price_suggestion_request.area
+      assert seller.maintenance_fee == price_suggestion_request.maintenance_fee
+      assert seller.rooms == price_suggestion_request.rooms
+      assert seller.bathrooms == price_suggestion_request.bathrooms
+      assert seller.suites == price_suggestion_request.suites
+      assert seller.garage_spots == price_suggestion_request.garage_spots
       assert seller.price == nil
-      assert seller.suggested_price == lead.suggested_price
+      assert seller.suggested_price == price_suggestion_request.suggested_price
     end
   end
 

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -130,4 +130,18 @@ defmodule Re.SellerLeads.JobQueueTest do
       assert_called(HTTPoison, :post, [^uri, ^encoded_seller_lead])
     end
   end
+
+  describe "not handled jobs" do
+    test "raise if not passing a multi" do
+      assert_raise RuntimeError, fn ->
+        JobQueue.perform(:not_multi, %{})
+      end
+    end
+
+    test "raise if job type not handled" do
+      assert_raise RuntimeError, fn ->
+        JobQueue.perform(Multi.new(), %{"type" => "whatever", "uuid" => nil})
+      end
+    end
+  end
 end

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -1,0 +1,50 @@
+defmodule Re.SellerLeads.JobQueueTest do
+  use Re.ModelCase
+  use Mockery
+
+  import Re.Factory
+
+  alias Re.{
+    SellerLead,
+    SellerLeads.JobQueue,
+    Repo
+  }
+
+  alias Ecto.Multi
+
+  describe "price_suggestion_request" do
+    test "process lead" do
+      %{uuid: address_uuid} = address = insert(:address)
+      %{uuid: user_uuid} = user = insert(:user)
+
+      %{uuid: uuid} =
+        lead =
+        insert(:price_suggestion_request,
+          address: address,
+          user: user
+        )
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "process_price_suggestion_request",
+                 "uuid" => uuid
+               })
+
+      assert seller = Repo.one(SellerLead)
+      assert seller.uuid
+      assert seller.user_uuid == user_uuid
+      assert seller.address_uuid == address_uuid
+      assert seller.source == "WebSite"
+      assert seller.complement == nil
+      assert seller.type == lead.type
+      assert seller.area == lead.area
+      assert seller.maintenance_fee == lead.maintenance_fee
+      assert seller.rooms == lead.rooms
+      assert seller.bathrooms == lead.bathrooms
+      assert seller.suites == lead.suites
+      assert seller.garage_spots == lead.garage_spots
+      assert seller.price == nil
+      assert seller.suggested_price == lead.suggested_price
+    end
+  end
+end

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -86,7 +86,7 @@ defmodule Re.SellerLeads.JobQueueTest do
           rooms: seller_lead.rooms,
           suites: seller_lead.suites,
           maintenance_fee: seller_lead.maintenance_fee,
-          price: seller_lead.price,
+          suggested_price: seller_lead.suggested_price,
           source: seller_lead.source,
           tour_option: seller_lead.tour_option,
           inserted_at: seller_lead.inserted_at,

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -3,6 +3,7 @@ defmodule Re.SellerLeads.JobQueueTest do
   use Mockery
 
   import Re.Factory
+  import Re.CustomAssertion
 
   alias Re.{
     SellerLead,
@@ -31,6 +32,7 @@ defmodule Re.SellerLeads.JobQueueTest do
                })
 
       assert seller = Repo.one(SellerLead)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
       assert seller.uuid
       assert seller.user_uuid == user_uuid
       assert seller.address_uuid == address_uuid
@@ -45,6 +47,87 @@ defmodule Re.SellerLeads.JobQueueTest do
       assert seller.garage_spots == lead.garage_spots
       assert seller.price == nil
       assert seller.suggested_price == lead.suggested_price
+    end
+  end
+
+  describe "create_lead_salesforce" do
+    @uri %URI{
+      authority: "www.emcasa.com",
+      fragment: nil,
+      host: "www.emcasa.com",
+      path: "/salesforce_zapier",
+      port: 80,
+      query: nil,
+      scheme: "http",
+      userinfo: nil
+    }
+
+    setup do
+      user = insert(:user)
+      address = insert(:address)
+      seller_lead = insert(:seller_lead, user: user, address: address)
+
+      {:ok, encoded_seller_lead} =
+        Jason.encode(%{
+          name: user.name,
+          email: user.email,
+          phone: user.phone,
+          city: address.city,
+          state: address.state,
+          street: address.street,
+          street_number: address.street_number,
+          neighborhood: address.neighborhood,
+          postal_code: address.postal_code,
+          type: seller_lead.type,
+          complement: seller_lead.complement,
+          garage_spots: seller_lead.garage_spots,
+          area: seller_lead.area,
+          bathrooms: seller_lead.bathrooms,
+          rooms: seller_lead.rooms,
+          suites: seller_lead.suites,
+          maintenance_fee: seller_lead.maintenance_fee,
+          price: seller_lead.price,
+          source: seller_lead.source,
+          tour_option: seller_lead.tour_option,
+          inserted_at: seller_lead.inserted_at,
+          uuid: seller_lead.uuid
+        })
+
+      {:ok, seller_lead: seller_lead, encoded_seller_lead: encoded_seller_lead}
+    end
+
+    test "create lead", %{seller_lead: seller_lead, encoded_seller_lead: encoded_seller_lead} do
+      mock(HTTPoison, :post, {:ok, %{status_code: 200, body: ~s({"status":"success"})}})
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "create_lead_salesforce",
+                 "uuid" => seller_lead.uuid
+               })
+
+      refute Repo.one(JobQueue)
+      uri = @uri
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_seller_lead])
+    end
+
+    test "raise when there's a timeout", %{
+      seller_lead: seller_lead,
+      encoded_seller_lead: encoded_seller_lead
+    } do
+      mock(HTTPoison, :post, {:error, %{reason: :timeout}})
+
+      assert_raise RuntimeError, fn ->
+        assert {:error, _} =
+                 JobQueue.perform(Multi.new(), %{
+                   "type" => "create_lead_salesforce",
+                   "uuid" => seller_lead.uuid
+                 })
+      end
+
+      uri = @uri
+
+      assert_called(HTTPoison, :post, [^uri, ^encoded_seller_lead])
     end
   end
 end

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -6,9 +6,9 @@ defmodule Re.SellerLeads.JobQueueTest do
   import Re.CustomAssertion
 
   alias Re.{
+    Repo,
     SellerLead,
-    SellerLeads.JobQueue,
-    Repo
+    SellerLeads.JobQueue
   }
 
   alias Ecto.Multi

--- a/apps/re/test/seller_leads/salesforce/client_test.exs
+++ b/apps/re/test/seller_leads/salesforce/client_test.exs
@@ -42,7 +42,7 @@ defmodule Re.SellerLeads.Salesforce.ClientTest do
           rooms: seller_lead.rooms,
           suites: seller_lead.suites,
           maintenance_fee: seller_lead.maintenance_fee,
-          price: seller_lead.price,
+          suggested_price: seller_lead.suggested_price,
           source: seller_lead.source,
           tour_option: seller_lead.tour_option,
           inserted_at: seller_lead.inserted_at,

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -182,7 +182,8 @@ defmodule Re.Factory do
       type: random(:listing_type),
       maintenance_fee: random(:maintenance_fee_float),
       area: Enum.random(1..500),
-      is_covered: Enum.random([true, false])
+      is_covered: Enum.random([true, false]),
+      suggested_price: random(:price)
     }
   end
 

--- a/apps/re_web/lib/graphql/resolvers/interests.ex
+++ b/apps/re_web/lib/graphql/resolvers/interests.ex
@@ -14,7 +14,9 @@ defmodule ReWeb.Resolvers.Interests do
   end
 
   def request_price_suggestion(params, %{context: %{current_user: current_user}}) do
-    Interests.request_price_suggestion(params, current_user)
+    with :ok <- Bodyguard.permit(Interests, :request_price_suggestion, current_user) do
+      Interests.request_price_suggestion(params, current_user)
+    end
   end
 
   def notify_when_covered(params, _), do: Interests.notify_when_covered(params)

--- a/apps/re_web/test/graphql/interests/price_suggestions/query_test.exs
+++ b/apps/re_web/test/graphql/interests/price_suggestions/query_test.exs
@@ -65,7 +65,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
     }
   }
 
-  test "anonymous should request price suggestion", %{unauthenticated_conn: conn} do
+  test "anonymous should not request price suggestion", %{unauthenticated_conn: conn} do
     mutation = """
       mutation RequestPriceSuggestion (
         $name: String!,
@@ -104,16 +104,15 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
       {:ok,
        %{
          body:
-          "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
        }}
     )
 
     conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, @variables))
 
-    assert %{"suggestedPrice" => 26_279.0} ==
-             json_response(conn, 200)["data"]["requestPriceSuggestion"]
+    assert [%{"code" => 401, "message" => "Unauthorized"}] = json_response(conn, 200)["errors"]
 
-    assert Repo.get_by(Request, name: "Mah Name")
+    refute Repo.get_by(Request, name: "Mah Name")
   end
 
   test "user should request price suggestion", %{user_conn: conn, user_user: user} do
@@ -155,7 +154,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
       {:ok,
        %{
          body:
-          "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
+           "{\"sale_price_rounded\":24195.0,\"sale_price\":24195.791,\"listing_price_rounded\":26279.0,\"listing_price\":26279.915,\"listing_price_error_q90_min\":25200.0,\"listing_price_error_q90_max\":28544.0,\"listing_price_per_sqr_meter\":560.0,\"listing_average_price_per_sqr_meter\":610.0}"
        }}
     )
 
@@ -168,7 +167,7 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
     assert request.user_id == user.id
   end
 
-  test "nameless anonymous user should request price suggestions", %{unauthenticated_conn: conn} do
+  test "nameless anonymous should not request price suggestions", %{unauthenticated_conn: conn} do
     mutation = """
       mutation RequestPriceSuggestion (
         $email: String!,
@@ -216,14 +215,9 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
     conn =
       post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, nameless_variables))
 
-    %{"suggestedPrice" => suggested_price, "id" => id, "name" => name} =
-      json_response(conn, 200)["data"]["requestPriceSuggestion"]
+    assert [%{"code" => 401, "message" => "Unauthorized"}] = json_response(conn, 200)["errors"]
 
-    assert 26_279.0 == suggested_price
-
-    refute name
-
-    assert Repo.get_by(Request, id: id)
+    refute Repo.one(Request)
   end
 
   test "user should get nil price suggestion when parameters are not completly filled", %{
@@ -273,22 +267,20 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
     )
 
     assert capture_log(fn ->
-             conn =
-               post(
-                 conn,
-                 "/graphql_api",
-                 AbsintheHelpers.mutation_wrapper(mutation, @invalid_variables)
-               )
-
-             assert [%{"code" => 422}, %{"code" => 422}] = json_response(conn, 200)["errors"]
+             post(
+               conn,
+               "/graphql_api",
+               AbsintheHelpers.mutation_wrapper(mutation, @invalid_variables)
+             )
            end) =~ ":invalid_input in priceteller"
 
     assert request = Repo.get_by(Request, name: "Mah Name")
     assert request.user_id == user.id
+    refute request.suggested_price
   end
 
   @tag capture_log: true
-  test "handle priceteller timeout", %{unauthenticated_conn: conn} do
+  test "handle priceteller timeout", %{user_conn: conn} do
     mutation = """
       mutation RequestPriceSuggestion (
         $name: String!,
@@ -325,10 +317,9 @@ defmodule ReWeb.GraphQL.Interests.PriceSuggestions.QueryTest do
 
     conn = post(conn, "/graphql_api", AbsintheHelpers.mutation_wrapper(mutation, @variables))
 
-    refute json_response(conn, 200)["data"]["requestPriceSuggestion"]
+    assert json_response(conn, 200)["data"]["requestPriceSuggestion"]
 
-    assert [%{"message" => "Timeout", "code" => 408}] = json_response(conn, 200)["errors"]
-
-    assert Repo.get_by(Request, name: "Mah Name")
+    assert request = Repo.get_by(Request, name: "Mah Name")
+    refute request.suggested_price
   end
 end


### PR DESCRIPTION
Follow-up modification to complement #662 and #665
- Job to process `price_suggestion_request` to `seller_lead`
- Job to send `seller_lead` to salesforce through zapier

~Pending manual test to check zapier is fine~