### PR TITLE
fix(districts): add only failed one

### DIFF
--- a/apps/re/lib/mix/tasks/addresses.add_district.ex
+++ b/apps/re/lib/mix/tasks/addresses.add_district.ex
@@ -13,16 +13,6 @@ defmodule Mix.Tasks.Re.Addresses.AddDistrict do
 
   @shortdoc "Create new district"
   @covered_districts [
-    "Água Branca",
-    "Barra Funda",
-    "Pacaembu",
-    "Santa Cecília",
-    "Vila Buarque",
-    "Higienópolis",
-    "Consolação",
-    "Bela Vista",
-    "Liberdade",
-    "Aclimação",
     "Vila Romana"
   ]
 

--- a/apps/re/test/mix/addresses/add_district_test.exs
+++ b/apps/re/test/mix/addresses/add_district_test.exs
@@ -23,16 +23,6 @@ defmodule Mix.Tasks.Re.Addresses.AddDistrictTest do
       AddDistrict.run([])
 
       covered_districts = [
-        "Água Branca",
-        "Barra Funda",
-        "Pacaembu",
-        "Santa Cecília",
-        "Vila Buarque",
-        "Higienópolis",
-        "Consolação",
-        "Bela Vista",
-        "Liberdade",
-        "Aclimação",
         "Vila Romana"
       ]
 


### PR DESCRIPTION
I tried to create `Aclimação` neighborhood, this one already exists, so it failed to insert the next value. Also, created a new task to improve some aspects of this same task. 