### PR TITLE
fix(leads): allow leads with more than 255 chars on url

### DIFF
--- a/apps/re/priv/repo/migrations/20190723134327_modify_buyer_lead_url_size.exs
+++ b/apps/re/priv/repo/migrations/20190723134327_modify_buyer_lead_url_size.exs
@@ -1,9 +1,15 @@
 defmodule Re.Repo.Migrations.ModifyBuyerLeadUrlSize do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:buyer_leads) do
       modify :url, :text
+    end
+  end
+
+  def down do
+    alter table(:buyer_leads) do
+      modify :url, :string
     end
   end
 end

--- a/apps/re/priv/repo/migrations/20190723134327_modify_buyer_lead_url_size.exs
+++ b/apps/re/priv/repo/migrations/20190723134327_modify_buyer_lead_url_size.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.ModifyBuyerLeadUrlSize do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buyer_leads) do
+      modify :url, :text
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190723164843_modify_empty_search_buyer_leads_url_size.exs
+++ b/apps/re/priv/repo/migrations/20190723164843_modify_empty_search_buyer_leads_url_size.exs
@@ -1,0 +1,15 @@
+defmodule Re.Repo.Migrations.ModifyEmptySearchBuyerLeadsUrlSize do
+  use Ecto.Migration
+
+  def up do
+    alter table(:empty_search_buyer_leads) do
+      modify :url, :text
+    end
+  end
+
+  def down do
+    alter table(:empty_search_buyer_leads) do
+      modify :url, :string
+    end
+  end
+end

--- a/apps/re/test/buyer_leads/buyer_leads_test.exs
+++ b/apps/re/test/buyer_leads/buyer_leads_test.exs
@@ -35,7 +35,6 @@ defmodule Re.BuyerLeadsTest do
       assert_enqueued_job(Repo.all(JobQueue), "process_empty_search_buyer_lead")
     end
 
-    @tag dev: true
     test "should create a buyer lead with more than 255 chars" do
       user = insert(:user)
 

--- a/apps/re/test/buyer_leads/buyer_leads_test.exs
+++ b/apps/re/test/buyer_leads/buyer_leads_test.exs
@@ -34,5 +34,21 @@ defmodule Re.BuyerLeadsTest do
       assert Repo.one(EmptySearch)
       assert_enqueued_job(Repo.all(JobQueue), "process_empty_search_buyer_lead")
     end
+
+    @tag dev: true
+    test "should create a buyer lead with more than 255 chars" do
+      user = insert(:user)
+
+      params =
+        params_for(
+          :empty_search_buyer_lead,
+          user_uuid: user.uuid,
+          url: String.duplicate("a", 256)
+        )
+
+      assert {:ok, _buyer_lead} = BuyerLeads.create_empty_search(params, user)
+
+      assert Repo.one(EmptySearch)
+    end
   end
 end

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -489,7 +489,6 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.user_url == "http://localhost:3000/usuarios/#{user_id}"
     end
 
-    @tag dev: true
     test "proecss lead with huge url" do
       %{id: user_id, uuid: user_uuid} = insert(:user, phone: "+5511999999999", name: nil)
 

--- a/apps/re/test/buyer_leads/job_queue_test.exs
+++ b/apps/re/test/buyer_leads/job_queue_test.exs
@@ -488,6 +488,35 @@ defmodule Re.BuyerLeads.JobQueueTest do
       assert buyer.url == "https://www.emcasa.com/imoveis/ny/new-york"
       assert buyer.user_url == "http://localhost:3000/usuarios/#{user_id}"
     end
+
+    @tag dev: true
+    test "proecss lead with huge url" do
+      %{id: user_id, uuid: user_uuid} = insert(:user, phone: "+5511999999999", name: nil)
+
+      %{uuid: uuid} =
+        insert(:empty_search_buyer_lead,
+          user_uuid: user_uuid,
+          city: "New York",
+          city_slug: "new-york",
+          state: "NY",
+          state_slug: "ny",
+          url: String.duplicate("/feature", 256)
+        )
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "process_empty_search_buyer_lead",
+                 "uuid" => uuid
+               })
+
+      assert buyer = Repo.one(BuyerLead)
+      assert_enqueued_job(Repo.all(JobQueue), "create_lead_salesforce")
+      assert buyer.uuid
+      assert buyer.user_uuid == user_uuid
+      assert buyer.location == "new-york|ny"
+      assert buyer.url == String.duplicate("/feature", 256)
+      assert buyer.user_url == "http://localhost:3000/usuarios/#{user_id}"
+    end
   end
 
   describe "requeue_all/1" do


### PR DESCRIPTION
Fixes [BACKEND-1P](https://sentry.io/organizations/emcasa/issues/1074544642/?project=1389074)