### PR TITLE
feature(listings): remove is_active from listing schema

### DIFF
--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -28,7 +28,6 @@ defmodule Re.Listing do
     field :balconies, :integer
     field :has_elevator, :boolean
     field :matterport_code, :string
-    field :is_active, :boolean, default: false
     field :status, :string, default: "inactive"
     field :is_exclusive, :boolean, default: false
     field :is_release, :boolean, default: false

--- a/apps/re/priv/repo/migrations/20190812135911_remove_is_active_from_listings.exs
+++ b/apps/re/priv/repo/migrations/20190812135911_remove_is_active_from_listings.exs
@@ -1,0 +1,9 @@
+defmodule Re.Repo.Migrations.RemoveIsActiveFromListings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:listings) do
+      remove :is_active
+    end
+  end
+end


### PR DESCRIPTION
All uses are already redirected to resolve using `status` field.