### PR TITLE
refactor(listings): remove pattern match in favor of get_field

### DIFF
--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -164,27 +164,9 @@ defmodule Re.Listing do
 
   defp generate_uuid(changeset), do: Re.ChangesetHelper.generate_uuid(changeset)
 
-  defp calculate_price_per_area(
-         %Ecto.Changeset{valid?: true, changes: %{price: price, area: area}} = changeset
-       ) do
-    set_price_per_area(price, area, changeset)
-  end
-
-  defp calculate_price_per_area(
-         %Ecto.Changeset{valid?: true, changes: %{price: price}, data: %{area: area}} = changeset
-       ) do
-    set_price_per_area(price, area, changeset)
-  end
-
-  defp calculate_price_per_area(
-         %Ecto.Changeset{valid?: true, changes: %{area: area}, data: %{price: price}} = changeset
-       ) do
-    set_price_per_area(price, area, changeset)
-  end
-
-  defp calculate_price_per_area(
-         %Ecto.Changeset{valid?: true, data: %{price: price, area: area}} = changeset
-       ) do
+  defp calculate_price_per_area(%Ecto.Changeset{valid?: true} = changeset) do
+    price = get_field(changeset, :price, nil)
+    area = get_field(changeset, :area, nil)
     set_price_per_area(price, area, changeset)
   end
 


### PR DESCRIPTION
Price and area are now getting using [`get_field`](https://hexdocs.pm/ecto/Ecto.Changeset.html#get_field/3) so we don't need all permutations between `changes` and `data` to get both. It will recalc `price_per_area` each time, I think it does worth once readability is better now.  