### PR TITLE
Fix opportunity time window

### DIFF
--- a/apps/re_integrations/lib/salesforce/mapper/routific.ex
+++ b/apps/re_integrations/lib/salesforce/mapper/routific.ex
@@ -8,7 +8,7 @@ defmodule ReIntegrations.Salesforce.Mapper.Routific do
     Salesforce.Payload.Opportunity
   }
 
-  @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 60)
+  @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 40)
   @event_owner_id Application.get_env(:re_integrations, :salesforce_event_owner_id)
 
   def build_visit(%Opportunity{} = opportunity) do

--- a/apps/re_integrations/lib/salesforce/payload/opportunity.ex
+++ b/apps/re_integrations/lib/salesforce/payload/opportunity.ex
@@ -53,6 +53,8 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
   @params ~w(id account_id owner_id address neighborhood tour_strict_date tour_strict_time
              tour_period stage notes)a
 
+  @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 60)
+
   def build_all(list) do
     results = Enum.map(list, &with({:ok, value} <- build(&1), do: value))
 
@@ -85,7 +87,7 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
   defp changeset(struct, params), do: cast(struct, params, @params)
 
   def visit_start_window(%{tour_period: :strict, tour_strict_time: %Time{} = time}),
-    do: %{start: time, end: time}
+    do: %{start: time, end: Time.add(time, (@tour_visit_duration + 15) * 60, :second)}
 
   def visit_start_window(%{tour_period: :morning}),
     do: %{start: ~T[09:00:00Z], end: ~T[12:00:00Z]}

--- a/apps/re_integrations/lib/salesforce/payload/opportunity.ex
+++ b/apps/re_integrations/lib/salesforce/payload/opportunity.ex
@@ -54,6 +54,7 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
              tour_period stage notes)a
 
   @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 60)
+  @tour_visit_time_variance Application.get_env(:re_integrations, :tour_visit_time_variance, 15)
 
   def build_all(list) do
     results = Enum.map(list, &with({:ok, value} <- build(&1), do: value))
@@ -87,7 +88,10 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
   defp changeset(struct, params), do: cast(struct, params, @params)
 
   def visit_start_window(%{tour_period: :strict, tour_strict_time: %Time{} = time}),
-    do: %{start: time, end: Time.add(time, (@tour_visit_duration + 15) * 60, :second)}
+    do: %{
+      start: Time.add(time, -@tour_visit_time_variance * 60, :second),
+      end: Time.add(time, (@tour_visit_duration + @tour_visit_time_variance) * 60, :second)
+    }
 
   def visit_start_window(%{tour_period: :morning}),
     do: %{start: ~T[09:00:00Z], end: ~T[12:00:00Z]}

--- a/apps/re_integrations/lib/salesforce/payload/opportunity.ex
+++ b/apps/re_integrations/lib/salesforce/payload/opportunity.ex
@@ -53,8 +53,8 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
   @params ~w(id account_id owner_id address neighborhood tour_strict_date tour_strict_time
              tour_period stage notes)a
 
-  @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 60)
-  @tour_visit_time_variance Application.get_env(:re_integrations, :tour_visit_time_variance, 15)
+  @tour_visit_duration Application.get_env(:re_integrations, :tour_visit_duration, 40)
+  @tour_visit_max_lateness Application.get_env(:re_integrations, :tour_visit_max_lateness, 10)
 
   def build_all(list) do
     results = Enum.map(list, &with({:ok, value} <- build(&1), do: value))
@@ -89,8 +89,8 @@ defmodule ReIntegrations.Salesforce.Payload.Opportunity do
 
   def visit_start_window(%{tour_period: :strict, tour_strict_time: %Time{} = time}),
     do: %{
-      start: Time.add(time, -@tour_visit_time_variance * 60, :second),
-      end: Time.add(time, (@tour_visit_duration + @tour_visit_time_variance) * 60, :second)
+      start: Time.add(time, -@tour_visit_max_lateness * 60, :second),
+      end: Time.add(time, (@tour_visit_duration + @tour_visit_max_lateness) * 60, :second)
     }
 
   def visit_start_window(%{tour_period: :morning}),

--- a/apps/re_integrations/test/salesforce/payload/opportunity_test.exs
+++ b/apps/re_integrations/test/salesforce/payload/opportunity_test.exs
@@ -40,7 +40,7 @@ defmodule ReIntegrations.Salesforce.Payload.OpportunityTest do
 
   describe "visit_start_window/1" do
     test "returns exact time when tour period is strict" do
-      assert %{start: ~T[20:00:00Z], end: ~T[21:00:00.000000]} =
+      assert %{start: ~T[19:50:00.000000], end: ~T[21:10:00.000000]} =
                Payload.Opportunity.visit_start_window(%{
                  tour_strict_time: ~T[20:00:00Z],
                  tour_period: :strict

--- a/apps/re_integrations/test/salesforce/payload/opportunity_test.exs
+++ b/apps/re_integrations/test/salesforce/payload/opportunity_test.exs
@@ -40,7 +40,7 @@ defmodule ReIntegrations.Salesforce.Payload.OpportunityTest do
 
   describe "visit_start_window/1" do
     test "returns exact time when tour period is strict" do
-      assert %{start: ~T[20:00:00Z], end: ~T[20:00:00Z]} =
+      assert %{start: ~T[20:00:00Z], end: ~T[21:00:00.000000]} =
                Payload.Opportunity.visit_start_window(%{
                  tour_strict_time: ~T[20:00:00Z],
                  tour_period: :strict

--- a/config/test.exs
+++ b/config/test.exs
@@ -82,6 +82,7 @@ config :re_integrations,
   zapier_webhook_pass: "testpass",
   cloudinary_client: ReIntegrations.TestCloudex,
   orulo_url: "http://www.emcasa.com/orulo",
+  tour_visit_duration: 60,
   google_calendar_acl: %{
     role: "owner",
     scope: %{


### PR DESCRIPTION
This fixes the generated routific time window for salesforce opportunities with a strict time constraint. This range should be greater than the visit's duration.