### PR TITLE
Edit seller leads

### DIFF
--- a/apps/re/lib/salesforce/client.ex
+++ b/apps/re/lib/salesforce/client.ex
@@ -11,8 +11,13 @@ defmodule Re.Salesforce.Client do
 
   def insert_lead(payload), do: post(payload, "/api/v1/Lead")
 
+  def update_lead(payload, id), do: patch(payload, "/api/v1/Lead/" <> id)
+
   defp build_uri(path), do: URI.parse(@api_url <> path)
 
   defp post(body, path),
     do: path |> build_uri |> @http_client.post(Jason.encode!(body), @api_headers)
+
+  defp patch(body, path),
+    do: path |> build_uri |> @http_client.patch(Jason.encode!(body), @api_headers)
 end

--- a/apps/re/lib/seller_leads/job_queue.ex
+++ b/apps/re/lib/seller_leads/job_queue.ex
@@ -12,6 +12,7 @@ defmodule Re.SellerLeads.JobQueue do
     SellerLead,
     SellerLeads,
     SellerLeads.Salesforce,
+    SellerLeads.Site,
     User
   }
 
@@ -31,6 +32,19 @@ defmodule Re.SellerLeads.JobQueue do
     |> insert_seller_lead(multi, request)
     |> update_name(request)
     |> update_email(request)
+    |> Repo.transaction()
+    |> handle_error()
+  end
+
+  def perform(%Multi{} = multi, %{"type" => "process_site_seller_lead", "uuid" => uuid}) do
+    site_seller_lead =
+      Site
+      |> Ecto.Query.preload(price_request: [seller_lead: [:address, :user]])
+      |> Repo.get(uuid)
+
+    site_seller_lead
+    |> Site.seller_lead_changeset(site_seller_lead.price_request.seller_lead)
+    |> update_seller_lead(multi)
     |> Repo.transaction()
     |> handle_error()
   end
@@ -61,6 +75,14 @@ defmodule Re.SellerLeads.JobQueue do
     |> Multi.insert(:insert_seller_lead, changeset)
     |> Multi.update(:update_request, request_changeset)
     |> __MODULE__.enqueue(:salesforce_job, %{"type" => "create_lead_salesforce", "uuid" => uuid})
+  end
+
+  defp update_seller_lead(changeset, multi) do
+    uuid = Changeset.get_field(changeset, :uuid)
+
+    multi
+    |> Multi.update(:update_seller_lead, changeset)
+    |> __MODULE__.enqueue(:salesforce_job, %{"type" => "update_lead_salesforce", "uuid" => uuid})
   end
 
   defp update_name(multi, %{name: name, user: %{name: nil} = user}),

--- a/apps/re/lib/seller_leads/salesforce/client.ex
+++ b/apps/re/lib/seller_leads/salesforce/client.ex
@@ -13,7 +13,7 @@ defmodule Re.SellerLeads.Salesforce do
   @record_type_id Application.get_env(:re_integrations, :salesforce_seller_lead_record_id, "")
 
   def create_lead(%Re.SellerLead{} = lead) do
-    with {:ok, lead} <- map_params(lead),
+    with {:ok, lead} <- map_params(lead, true),
          {:ok, %{body: body}} <- Client.insert_lead(lead) do
       Jason.decode(body)
     end
@@ -21,10 +21,19 @@ defmodule Re.SellerLeads.Salesforce do
 
   def create_lead(_), do: {:error, :lead_type_not_handled}
 
-  defp map_params(lead) do
+  def update_lead(%Re.SellerLead{} = lead) do
+    with {:ok, salesforce_lead} <- map_params(lead, false),
+         {:ok, %{body: body}} <- Client.update_lead(salesforce_lead, lead.salesforce_id) do
+      Jason.decode(body)
+    end
+  end
+
+  def update_lead(_), do: {:error, :lead_type_not_handled}
+
+  defp map_params(lead, evaluation) do
     %{
       uuid: lead.uuid,
-      evaluation: false,
+      evaluation: evaluation,
       record_type_id: @record_type_id,
       type: :seller,
       realty_type: lead.type,

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -5,28 +5,37 @@ defmodule Re.SellerLeads do
   require Ecto.Query
 
   alias Re.{
-    PubSub,
     Repo,
     OwnerContacts,
     OwnerContact,
     SellerLead,
     SellerLeads.Facebook,
+    SellerLeads.JobQueue,
     SellerLeads.Site,
     SellerLeads.Broker
   }
 
   alias Ecto.{
     Changeset,
+    Multi,
     Query
   }
 
   defdelegate authorize(action, user, params), to: __MODULE__.Policy
 
   def create_site(params) do
-    %Site{}
-    |> Site.changeset(params)
-    |> Repo.insert()
-    |> PubSub.publish_new("new_site_seller_lead")
+    changeset = Site.changeset(%Site{}, params)
+
+    uuid = Changeset.get_field(changeset, :uuid)
+
+    Ecto.Multi.new()
+    |> Multi.insert(:insert_site_seller_lead, changeset)
+    |> JobQueue.enqueue(:seller_lead_job, %{
+      "type" => "process_site_seller_lead",
+      "uuid" => uuid
+    })
+    |> Repo.transaction()
+    |> return_insertion()
   end
 
   def create_broker(params) do
@@ -102,4 +111,8 @@ defmodule Re.SellerLeads do
     |> Enum.sort()
     |> Enum.join("")
   end
+
+  defp return_insertion({:ok, %{insert_site_seller_lead: request}}), do: {:ok, request}
+
+  defp return_insertion(error), do: error
 end

--- a/apps/re/lib/seller_leads/site.ex
+++ b/apps/re/lib/seller_leads/site.ex
@@ -6,6 +6,8 @@ defmodule Re.SellerLeads.Site do
 
   import Ecto.Changeset
 
+  alias Re.SellerLead
+
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
   schema "site_seller_leads" do
@@ -33,6 +35,18 @@ defmodule Re.SellerLeads.Site do
     |> validate_inclusion(:type, @types)
     |> generate_uuid()
     |> validate_attributes()
+  end
+
+  def seller_lead_changeset(site_seller_lead, seller_lead) do
+    params = %{
+      complement: site_seller_lead.complement,
+      type: site_seller_lead.type,
+      maintenance_fee: site_seller_lead.maintenance_fee,
+      suites: site_seller_lead.suites,
+      price: site_seller_lead.price
+    }
+
+    SellerLead.changeset(seller_lead, params)
   end
 
   @more_than_zero_attributes ~w(maintenance_fee suites price)a

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -6,6 +6,7 @@ defmodule Re.SellerLeads.JobQueueTest do
   import Re.CustomAssertion
 
   alias Re.{
+    PriceSuggestions.Request,
     Repo,
     SellerLead,
     SellerLeads.JobQueue,
@@ -48,6 +49,9 @@ defmodule Re.SellerLeads.JobQueueTest do
       assert seller.garage_spots == price_suggestion_request.garage_spots
       assert seller.price == nil
       assert seller.suggested_price == price_suggestion_request.suggested_price
+
+      assert request = Repo.get_by(Request, uuid: uuid)
+      assert request.seller_lead_uuid == seller.uuid
     end
 
     test "save name in user when nil" do

--- a/apps/re/test/seller_leads/job_queue_test.exs
+++ b/apps/re/test/seller_leads/job_queue_test.exs
@@ -148,6 +148,20 @@ defmodule Re.SellerLeads.JobQueueTest do
     end
   end
 
+  describe "update_lead_salesforce" do
+    test "update lead" do
+      seller_lead = insert(:seller_lead, user: build(:user), address: build(:address))
+
+      assert {:ok, _} =
+               JobQueue.perform(Multi.new(), %{
+                 "type" => "update_lead_salesforce",
+                 "uuid" => seller_lead.uuid
+               })
+
+      refute Repo.one(JobQueue)
+    end
+  end
+
   describe "not handled jobs" do
     test "raise if not passing a multi" do
       assert_raise RuntimeError, fn ->

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -12,7 +12,7 @@ defmodule Re.Factory do
       uuid: UUID.uuid4(),
       name: Name.name(),
       email: Internet.email(),
-      phone: "+55#{Enum.random(10000000000..99999999999)}",
+      phone: "+55#{Enum.random(10_000_000_000..99_999_999_999)}",
       role: "user",
       notification_preferences: %{
         email: true,
@@ -376,7 +376,8 @@ defmodule Re.Factory do
       area: Enum.random(25..500),
       source: Enum.random(~w(Website Facebook)),
       tour_option: ~N[2019-07-18 10:00:00.000000],
-      inserted_at: ~N[2019-07-17 10:00:00.000000]
+      inserted_at: ~N[2019-07-17 10:00:00.000000],
+      salesforce_id: "0x01"
     }
   end
 

--- a/apps/re_integrations/test/support/test_http.ex
+++ b/apps/re_integrations/test/support/test_http.ex
@@ -196,6 +196,20 @@ defmodule ReIntegrations.TestHTTP do
          """
        }}
 
+  def patch(%URI{path: "/api/v1/Lead/0x01"}, _body, _opts),
+    do:
+      {:ok,
+       %{
+         status_code: 200,
+         body: """
+         {
+           "id": "0x01",
+           "success": true,
+           "errors": []
+         }
+         """
+       }}
+
   def patch(%URI{path: "/api/v1/Opportunity/0x01"}, _body, _opts),
     do:
       {:ok,


### PR DESCRIPTION
When a `site_seller_lead` comes in, it's the same lead as the `price_suggestion_request` that comes before.
To be able to unify that lead, we're saving some references and retrieving it to, instead of creating a new `seller_lead`, editing an existing one.
Then, when sending to salesforce, we're making an update instead of creating a new one and changing the `evaluation` parameter to be able to specify that this lead has "evolved".