### PR TITLE
fix(salesforce) adjust visit arrival time when idle_time is present

### DIFF
--- a/apps/re_integrations/lib/routific/payload/inbound.ex
+++ b/apps/re_integrations/lib/routific/payload/inbound.ex
@@ -51,6 +51,7 @@ defmodule ReIntegrations.Routific.Payload.Inbound do
         end: finish,
         address: Map.get(visit, "location_name"),
         break: Map.get(visit, "break", false),
+        idle_time: Map.get(visit, "idle_time", 0),
         notes: get_in(input, [location_id, "notes"]),
         custom_notes: get_in(input, [location_id, "customNotes"])
       }

--- a/apps/re_integrations/lib/salesforce/mapper/routific.ex
+++ b/apps/re_integrations/lib/salesforce/mapper/routific.ex
@@ -56,5 +56,5 @@ defmodule ReIntegrations.Salesforce.Mapper.Routific do
            if(is_nil(event.notes), do: "", else: event.notes)
 
   defp update_datetime(%Time{} = time, %DateTime{} = date),
-    do: date |> Timex.set(time: time) |> Timex.Timezone.convert(:utc)
+    do: date |> Timex.set(time: time) |> Timex.Timezone.convert(:utc) |> DateTime.to_naive()
 end

--- a/apps/re_integrations/lib/salesforce/mapper/routific.ex
+++ b/apps/re_integrations/lib/salesforce/mapper/routific.ex
@@ -27,14 +27,18 @@ defmodule ReIntegrations.Salesforce.Mapper.Routific do
          {:ok, calendar} <- Re.Calendars.get(calendar_uuid),
          {:ok, sdr} <- Salesforce.get_user(event.custom_notes["owner_id"]),
          {:ok, account} <- Salesforce.get_account(event.custom_notes["account_id"]) do
+      start_time = event.start |> update_datetime(date) |> Timex.shift(minutes: event.idle_time)
+      end_time = update_datetime(event.end, date)
+      duration = Timex.diff(end_time, start_time, :minutes)
+
       %{
         owner_id: @event_owner_id,
         what_id: event.id,
         type: :visit,
         address: event.address,
-        start: update_datetime(event.start, date),
-        end: update_datetime(event.end, date),
-        duration: @tour_visit_duration,
+        start: start_time,
+        end: end_time,
+        duration: duration,
         subject: "[#{calendar.name}] Visita para tour",
         description: build_event_description(event, %{sdr: sdr, account: account})
       }

--- a/apps/re_integrations/test/salesforce/mapper/routific_test.exs
+++ b/apps/re_integrations/test/salesforce/mapper/routific_test.exs
@@ -5,8 +5,7 @@ defmodule ReIntegrations.Salesforce.Mapper.RoutificTest do
 
   alias ReIntegrations.{
     Routific,
-    Salesforce.Mapper,
-    Salesforce.Payload
+    Salesforce.Mapper
   }
 
   @calendar_uuid Ecto.UUID.generate()
@@ -42,8 +41,8 @@ defmodule ReIntegrations.Salesforce.Mapper.RoutificTest do
       assert %{
                what_id: "0x02",
                type: :visit,
-               start: ~U[2019-08-01 12:30:00.000Z],
-               end: ~U[2019-08-01 13:00:00.000Z],
+               start: ~N[2019-08-01 12:30:00.000],
+               end: ~N[2019-08-01 13:00:00.000],
                address: "some address",
                duration: 30
              } = Mapper.Routific.build_event(@visit, @calendar_uuid, @payload)
@@ -51,8 +50,8 @@ defmodule ReIntegrations.Salesforce.Mapper.RoutificTest do
 
     test "shifts start time by idle_time" do
       assert %{
-               start: ~U[2019-08-01 12:30:00.000Z],
-               end: ~U[2019-08-01 13:00:00.000Z],
+               start: ~N[2019-08-01 12:30:00.000],
+               end: ~N[2019-08-01 13:00:00.000],
                duration: 30
              } =
                @visit

--- a/apps/re_integrations/test/salesforce/mapper/routific_test.exs
+++ b/apps/re_integrations/test/salesforce/mapper/routific_test.exs
@@ -1,0 +1,67 @@
+defmodule ReIntegrations.Salesforce.Mapper.RoutificTest do
+  use ReIntegrations.ModelCase
+
+  import Re.Factory
+
+  alias ReIntegrations.{
+    Routific,
+    Salesforce.Mapper,
+    Salesforce.Payload
+  }
+
+  @calendar_uuid Ecto.UUID.generate()
+
+  @visit %{
+    id: "0x02",
+    start: ~T[12:30:00Z],
+    end: ~T[13:00:00Z],
+    address: "some address",
+    break: false,
+    idle_time: 0,
+    notes: "",
+    custom_notes: %{"account_id" => "0x01", "owner_id" => "0x01"}
+  }
+
+  @payload %Routific.Payload.Inbound{
+    status: :finished,
+    options: %{"date" => "2019-08-01T21:00:00.000+0000"},
+    unserved: [],
+    solution: %{
+      @calendar_uuid => [@visit]
+    }
+  }
+
+  setup do
+    address = insert(:address)
+    insert(:calendar, uuid: @calendar_uuid, address: address)
+    :ok
+  end
+
+  describe "build_event/1" do
+    test "builds salesforce event from a routific solution" do
+      assert %{
+               what_id: "0x02",
+               type: :visit,
+               start: ~U[2019-08-01 12:30:00.000Z],
+               end: ~U[2019-08-01 13:00:00.000Z],
+               address: "some address",
+               duration: 30
+             } = Mapper.Routific.build_event(@visit, @calendar_uuid, @payload)
+    end
+
+    test "shifts start time by idle_time" do
+      assert %{
+               start: ~U[2019-08-01 12:30:00.000Z],
+               end: ~U[2019-08-01 13:00:00.000Z],
+               duration: 30
+             } =
+               @visit
+               |> Map.merge(%{
+                 start: ~T[12:00:00Z],
+                 end: ~T[13:00:00Z],
+                 idle_time: 30
+               })
+               |> Mapper.Routific.build_event(@calendar_uuid, @payload)
+    end
+  end
+end


### PR DESCRIPTION
Routific's result might extend an visit's duration by including an "idle time" to wait for a valid time-window, which causes the salesforce event insertion to fail with `INVALID_FIELD_FOR_INSERT_UPDATE` due to start/end time difference not matching `DurationInMinutes`.
This PR fixes this by shifting the event's start time to match the actual duration the visit.