### PR TITLE
Shortlist/service client

### DIFF
--- a/apps/re/lib/salesforce/client.ex
+++ b/apps/re/lib/salesforce/client.ex
@@ -26,7 +26,7 @@ defmodule Re.Salesforce.Client do
     do: path |> build_uri |> @http_client.patch(Jason.encode!(body), @api_headers)
 
   defp get(path),
-    do: path |> build_uri |> @http_client.get(@api_headers)
+    do: path |> build_uri |> http_client().get(@api_headers)
 
   defp http_client, do: Mockery.Macro.mockable(@http_client)
 end

--- a/apps/re/lib/salesforce/client.ex
+++ b/apps/re/lib/salesforce/client.ex
@@ -3,6 +3,8 @@ defmodule Re.Salesforce.Client do
   Client to handle requests to an emcasa/salesforce api
   """
 
+  require Mockery.Macro
+
   @api_key Application.get_env(:re_integrations, :salesforce_api_key, "")
   @api_url Application.get_env(:re_integrations, :salesforce_url, "")
   @http_client Application.get_env(:re, :http, HTTPoison)
@@ -25,4 +27,6 @@ defmodule Re.Salesforce.Client do
 
   defp get(path),
     do: path |> build_uri |> @http_client.get(@api_headers)
+
+  defp http_client, do: Mockery.Macro.mockable(@http_client)
 end

--- a/apps/re/lib/shortlists/client.ex
+++ b/apps/re/lib/shortlists/client.ex
@@ -1,0 +1,12 @@
+defmodule Re.Shortlists.Client do
+  @moduledoc """
+  Shortlists service client
+  """
+  @url Application.get_env(:re, :shortlist_service_url, "")
+
+  def get_listings(params) do
+    @url
+    |> URI.parse()
+    |> HTTPoison.get(params)
+  end
+end

--- a/apps/re/lib/shortlists/client.ex
+++ b/apps/re/lib/shortlists/client.ex
@@ -2,11 +2,15 @@ defmodule Re.Shortlists.Client do
   @moduledoc """
   Shortlists service client
   """
+  require Mockery.Macro
+
   @url Application.get_env(:re, :shortlist_service_url, "")
 
-  def get_listings(params) do
+  def get_listings_uuids(params) do
     @url
     |> URI.parse()
-    |> HTTPoison.get(params)
+    |> http_client().get(params)
   end
+
+  defp http_client, do: Mockery.Macro.mockable(HTTPoison)
 end

--- a/apps/re/lib/shortlists/shortlists.ex
+++ b/apps/re/lib/shortlists/shortlists.ex
@@ -4,6 +4,7 @@ defmodule Re.Shortlists do
   """
 
   alias __MODULE__.{
+    Client,
     Salesforce.Opportunity
   }
 
@@ -16,6 +17,8 @@ defmodule Re.Shortlists do
   def generate_shortlist_from_salesforce_opportunity(opportunity_id) do
     with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
          {:ok, service_params} <- Opportunity.build(opportunity) do
+      IO.inspect(opportunity)
+      IO.inspect(service_params)
       {:ok, service_params}
     else
       _error -> {:error, :invalid_opportunity}

--- a/apps/re/lib/shortlists/shortlists.ex
+++ b/apps/re/lib/shortlists/shortlists.ex
@@ -8,7 +8,12 @@ defmodule Re.Shortlists do
     Salesforce.Opportunity
   }
 
-  alias Re.Salesforce
+  alias Re.{
+    Listing,
+    Listings.Queries,
+    Repo,
+    Salesforce
+  }
 
   @behaviour Bodyguard.Policy
 
@@ -16,12 +21,19 @@ defmodule Re.Shortlists do
 
   def generate_shortlist_from_salesforce_opportunity(opportunity_id) do
     with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
-         {:ok, service_params} <- Opportunity.build(opportunity) do
-      IO.inspect(opportunity)
-      IO.inspect(service_params)
-      {:ok, service_params}
+         {:ok, service_params} <- Opportunity.build(opportunity),
+         {:ok, %{body: body}} <- Client.get_listings_uuids(service_params),
+         {:ok, listing_uuids} <- Jason.decode(body) do
+      get_active_listings_by_uuid(listing_uuids)
     else
       _error -> {:error, :invalid_opportunity}
     end
+  end
+
+  defp get_active_listings_by_uuid(uuids) do
+    Listing
+    |> Queries.with_uuids(uuids)
+    |> Queries.active()
+    |> Repo.all()
   end
 end

--- a/apps/re/lib/shortlists/shortlists.ex
+++ b/apps/re/lib/shortlists/shortlists.ex
@@ -21,12 +21,17 @@ defmodule Re.Shortlists do
 
   def generate_shortlist_from_salesforce_opportunity(opportunity_id) do
     with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
-         {:ok, service_params} <- Opportunity.build(opportunity),
-         {:ok, %{body: body}} <- Client.get_listings_uuids(service_params),
-         {:ok, listing_uuids} <- Jason.decode(body) do
+         {:ok, params} <- Opportunity.build(opportunity),
+         {:ok, listing_uuids} <- get_shortlist(params) do
       get_active_listings_by_uuid(listing_uuids)
     else
       _error -> {:error, :invalid_opportunity}
+    end
+  end
+
+  defp get_shortlist(params) do
+    with {:ok, %{body: body}} <- Client.get_listings_uuids(params) do
+      Jason.decode(body)
     end
   end
 

--- a/apps/re_web/lib/graphql/resolvers/shortlists.ex
+++ b/apps/re_web/lib/graphql/resolvers/shortlists.ex
@@ -7,7 +7,6 @@ defmodule ReWeb.Resolvers.Shortlists do
   def index(%{opportunity_id: opportunity_id}, %{context: %{current_user: current_user}}) do
     case Bodyguard.permit(Shortlists, :related_listings, current_user, %{}) do
       :ok -> {:ok, Shortlists.generate_shortlist_from_salesforce_opportunity(opportunity_id)}
-      :ok -> {:ok, []}
       error -> error
     end
   end

--- a/apps/re_web/lib/graphql/resolvers/shortlists.ex
+++ b/apps/re_web/lib/graphql/resolvers/shortlists.ex
@@ -1,0 +1,14 @@
+defmodule ReWeb.Resolvers.Shortlists do
+  @moduledoc """
+  Resolver module for shortlists queries and mutations
+  """
+  alias Re.Shortlists
+
+  def index(%{opportunity_id: opportunity_id}, %{context: %{current_user: current_user}}) do
+    case Bodyguard.permit(Shortlists, :related_listings, current_user, %{}) do
+      :ok -> {:ok, Shortlists.generate_shortlist_from_salesforce_opportunity(opportunity_id)}
+      :ok -> {:ok, []}
+      error -> error
+    end
+  end
+end

--- a/apps/re_web/lib/graphql/schema.ex
+++ b/apps/re_web/lib/graphql/schema.ex
@@ -20,6 +20,7 @@ defmodule ReWeb.Schema do
   import_types ReWeb.Types.Typology
   import_types ReWeb.Types.Custom.UUID
   import_types ReWeb.Types.Utm
+  import_types ReWeb.Types.Shortlist
   import_types Absinthe.Type.Custom
 
   alias ReWeb.GraphQL.Middlewares
@@ -46,6 +47,7 @@ defmodule ReWeb.Schema do
     import_fields(:calendar_queries)
     import_fields(:development_queries)
     import_fields(:tag_queries)
+    import_fields(:shortlist_queries)
   end
 
   mutation do

--- a/apps/re_web/lib/graphql/types/shortlist.ex
+++ b/apps/re_web/lib/graphql/types/shortlist.ex
@@ -1,0 +1,17 @@
+defmodule ReWeb.Types.Shortlist do
+  @moduledoc """
+  Graphql type for shortlists.
+  """
+  use Absinthe.Schema.Notation
+
+  alias ReWeb.Resolvers
+
+  object :shortlist_queries do
+    @desc "Shortlist index"
+    field :shortlist_listings, list_of(:listing) do
+      arg :opportunity_id, non_null(:string)
+
+      resolve &Resolvers.Shortlists.index/2
+    end
+  end
+end

--- a/apps/re_web/test/graphql/shortlists/query_test.exs
+++ b/apps/re_web/test/graphql/shortlists/query_test.exs
@@ -1,0 +1,55 @@
+defmodule ReWeb.GraphQL.Shortlists.QueryTest do
+  use ReWeb.ConnCase
+
+  import Mockery
+  import Re.Factory
+
+  alias ReWeb.AbsintheHelpers
+
+  setup %{conn: conn} do
+    conn = put_req_header(conn, "accept", "application/json")
+    admin_user = insert(:user, email: "admin@email.com", role: "admin")
+    user_user = insert(:user, email: "user@email.com", role: "user")
+
+    {:ok,
+     unauthenticated_conn: conn,
+     admin_user: admin_user,
+     user_user: user_user,
+     admin_conn: login_as(conn, admin_user),
+     user_conn: login_as(conn, user_user)}
+  end
+
+  @tag dev: true
+  test "should return listings with relaxed filters for admin", %{admin_conn: conn} do
+    mock(
+      HTTPoison,
+      :get,
+      {:ok,
+       %{
+         body:
+           "{\"Infraestrutura__c\":\"Indiferente;Sacada;Churrasqueira\",\"Tipo_do_Imovel__c\":\"Apartamento\",\"Quantidade_Minima_de_Quartos__c\":\"1\",\"Quantidade_MInima_de_SuItes__c\":\"1\",\"Quantidade_Minima_de_Banheiros__c\":\"1\",\"Numero_Minimo_de_Vagas__c\":\"1\",\"Area_Desejada__c\":\"A partir de 60m²\",\"Andar_de_Preferencia__c\":\"Alto\",\"Necessita_Elevador__c\":\"Indiferente\",\"Proximidade_de_Metr__c\":\"Sim\",\"Bairros_de_Interesse__c\":\"Botafogo;Urca\",\"Valor_M_ximo_para_Compra_2__c\":\"De R$750.000 a R$1.000.000\",\"Valor_M_ximo_de_Condom_nio__c\":\"R$800 a R$1.000\",\"Portaria_2__c\":\"Indiferente\"}"
+       }}
+    )
+
+    %{id: listing_id} = insert(:listing, rooms: 3)
+
+    variables = %{
+      "opportunityId" => "0x01"
+    }
+
+    query = """
+      query ShortlistListings ($opportunityId: String) {
+        shortlistListings (opportunityId: $opportunityId) {
+          id
+        }
+      }
+    """
+
+    conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+    IO.inspect(json_response(conn, 200))
+
+    assert [%{"id" => to_string(listing_id)}] ==
+             json_response(conn, 200)["data"]["shortlistListings"]
+  end
+end

--- a/apps/re_web/test/graphql/shortlists/query_test.exs
+++ b/apps/re_web/test/graphql/shortlists/query_test.exs
@@ -1,5 +1,8 @@
 defmodule ReWeb.GraphQL.Shortlists.QueryTest do
-  use ReWeb.ConnCase
+  use ReWeb.{
+    AbsintheAssertions,
+    ConnCase
+  }
 
   import Mockery
   import Re.Factory
@@ -8,21 +11,18 @@ defmodule ReWeb.GraphQL.Shortlists.QueryTest do
 
   setup %{conn: conn} do
     conn = put_req_header(conn, "accept", "application/json")
-    admin_user = insert(:user, email: "admin@email.com", role: "admin")
-    user_user = insert(:user, email: "user@email.com", role: "user")
+    admin_user = insert(:user, role: "admin")
+    user_user = insert(:user, role: "user")
 
     {:ok,
      unauthenticated_conn: conn,
-     admin_user: admin_user,
-     user_user: user_user,
      admin_conn: login_as(conn, admin_user),
      user_conn: login_as(conn, user_user)}
   end
 
   @http_client Application.get_env(:re, :http)
 
-  @tag dev: true
-  test "should return listings with relaxed filters for admin", %{admin_conn: conn} do
+  test "should return listings from shortlist for admin", %{admin_conn: conn} do
     mock(
       @http_client,
       :get,
@@ -60,6 +60,48 @@ defmodule ReWeb.GraphQL.Shortlists.QueryTest do
     conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
 
     assert [%{"id" => to_string(listing_id)}] ==
+             json_response(conn, 200)["data"]["shortlistListings"]
+  end
+
+  test "should return a forbidden for commom user", %{user_conn: conn} do
+    variables = %{
+      "opportunityId" => "0x01"
+    }
+
+    query = """
+      query ShortlistListings ($opportunityId: String) {
+        shortlistListings (opportunityId: $opportunityId) {
+          id
+        }
+      }
+    """
+
+    conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+    assert_forbidden_response(json_response(conn, 200))
+
+    assert nil ==
+             json_response(conn, 200)["data"]["shortlistListings"]
+  end
+
+  test "should return a unauthorize for unauthenticated user", %{conn: conn} do
+    variables = %{
+      "opportunityId" => "0x01"
+    }
+
+    query = """
+      query ShortlistListings ($opportunityId: String) {
+        shortlistListings (opportunityId: $opportunityId) {
+          id
+        }
+      }
+    """
+
+    conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
+
+    assert_unauthorized_response(json_response(conn, 200))
+
+    assert nil ==
              json_response(conn, 200)["data"]["shortlistListings"]
   end
 end

--- a/apps/re_web/test/graphql/shortlists/query_test.exs
+++ b/apps/re_web/test/graphql/shortlists/query_test.exs
@@ -19,19 +19,31 @@ defmodule ReWeb.GraphQL.Shortlists.QueryTest do
      user_conn: login_as(conn, user_user)}
   end
 
+  @http_client Application.get_env(:re, :http)
+
   @tag dev: true
   test "should return listings with relaxed filters for admin", %{admin_conn: conn} do
+    mock(
+      @http_client,
+      :get,
+      {:ok,
+       %{
+         status_code: 200,
+         body: "{}"
+       }}
+    )
+
+    %{id: listing_id, uuid: listing_uuid} = insert(:listing)
+
     mock(
       HTTPoison,
       :get,
       {:ok,
        %{
-         body:
-           "{\"Infraestrutura__c\":\"Indiferente;Sacada;Churrasqueira\",\"Tipo_do_Imovel__c\":\"Apartamento\",\"Quantidade_Minima_de_Quartos__c\":\"1\",\"Quantidade_MInima_de_SuItes__c\":\"1\",\"Quantidade_Minima_de_Banheiros__c\":\"1\",\"Numero_Minimo_de_Vagas__c\":\"1\",\"Area_Desejada__c\":\"A partir de 60m²\",\"Andar_de_Preferencia__c\":\"Alto\",\"Necessita_Elevador__c\":\"Indiferente\",\"Proximidade_de_Metr__c\":\"Sim\",\"Bairros_de_Interesse__c\":\"Botafogo;Urca\",\"Valor_M_ximo_para_Compra_2__c\":\"De R$750.000 a R$1.000.000\",\"Valor_M_ximo_de_Condom_nio__c\":\"R$800 a R$1.000\",\"Portaria_2__c\":\"Indiferente\"}"
+         status_code: 200,
+         body: "[\"#{listing_uuid}\"]"
        }}
     )
-
-    %{id: listing_id} = insert(:listing, rooms: 3)
 
     variables = %{
       "opportunityId" => "0x01"
@@ -46,8 +58,6 @@ defmodule ReWeb.GraphQL.Shortlists.QueryTest do
     """
 
     conn = post(conn, "/graphql_api", AbsintheHelpers.query_wrapper(query, variables))
-
-    IO.inspect(json_response(conn, 200))
 
     assert [%{"id" => to_string(listing_id)}] ==
              json_response(conn, 200)["data"]["shortlistListings"]


### PR DESCRIPTION
Allow a client request non-persistent shortlists through GraphQL. 

Right now we're not persisting any shortlists, the backend receives an id from the client, request an opportunity to salesforce, parse it to shortlist expected params, and return some listings to the user.

The client is not done yet, so I'm awaiting it to mark the PR as ready to review.  

The next steps are to structure shortlist, liked and disliked listings as well find a trigger to create shortlists automatically. Probably I'll involve more people in both discussions...