### PR TITLE
Get list of duplicated entities on seller lead

### DIFF
--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -91,11 +91,14 @@ defmodule Re.SellerLeads do
   end
 
   def duplicated?(address, complement) do
-    duplicated_entities = duplicated_entities(address, complement)
+    duplicated_entities(address, complement)
+    |> duplicated?()
+  end
 
+  def duplicated?(duplicated_entities \\ %{}) do
     duplicated_entities
-    |> Map.keys()
-    |> Enum.any?(fn key ->  Kernel.length(Map.get(duplicated_entities, key)) > 0 end)
+    |> Map.values()
+    |> Enum.any?(fn value ->  Kernel.length(value) > 0 end)
   end
 
   def duplicated_entities(address, complement) do

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -96,16 +96,12 @@ defmodule Re.SellerLeads do
   end
 
   def duplicated?(duplicated_entities \\ %{}) do
-    duplicated_entities
-    |> Map.values()
-    |> Enum.any?(fn value -> Kernel.length(value) > 0 end)
+    Kernel.length(duplicated_entities) > 0
   end
 
   def duplicated_entities(address, complement) do
-    %{
-      seller_leads: check_duplicated_entity(address, complement, :seller_leads),
-      listings: check_duplicated_entity(address, complement, :listings)
-    }
+    check_duplicated_entity(address, complement, :seller_leads)
+    ++ check_duplicated_entity(address, complement, :listings)
   end
 
   defp check_duplicated_entity(address, complement, entity_name) do
@@ -117,7 +113,7 @@ defmodule Re.SellerLeads do
     |> Enum.filter(fn entity ->
       normalize_complement(entity.complement) == normalized_complement
     end)
-    |> Enum.map(fn entity -> entity.uuid end)
+    |> Enum.map(fn entity -> %{type: entity.__struct__, uuid: entity.uuid} end)
   end
 
   @number_group_regex ~r/(\d)*/

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -100,8 +100,8 @@ defmodule Re.SellerLeads do
   end
 
   def duplicated_entities(address, complement) do
-    check_duplicated_entity(address, complement, :seller_leads)
-    ++ check_duplicated_entity(address, complement, :listings)
+    check_duplicated_entity(address, complement, :seller_leads) ++
+      check_duplicated_entity(address, complement, :listings)
   end
 
   defp check_duplicated_entity(address, complement, entity_name) do

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -95,9 +95,8 @@ defmodule Re.SellerLeads do
     |> duplicated?()
   end
 
-  def duplicated?(duplicated_entities \\ %{}) do
-    Kernel.length(duplicated_entities) > 0
-  end
+  def duplicated?([]), do: false
+  def duplicated?(_), do: true
 
   def duplicated_entities(address, complement) do
     check_duplicated_entity(address, complement, :seller_leads) ++

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -91,18 +91,28 @@ defmodule Re.SellerLeads do
   end
 
   def duplicated?(address, complement) do
-    check_attribute_duplicated(address, complement, :seller_leads) ||
-      check_attribute_duplicated(address, complement, :listings)
+    duplicated_entities = duplicated_entities(address, complement)
+
+    duplicated_entities
+    |> Map.keys()
+    |> Enum.any?(fn key ->  Kernel.length(Map.get(duplicated_entities, key)) > 0 end)
   end
 
-  defp check_attribute_duplicated(address, complement, attribute_to_fetch) do
+  def duplicated_entities(address, complement) do
+    %{
+      seller_leads: check_duplicated_entity(address, complement, :seller_leads),
+      listings: check_duplicated_entity(address, complement, :listings)
+    }
+  end
+
+  defp check_duplicated_entity(address, complement, entity_name) do
     normalized_complement = normalize_complement(complement)
 
     address
-    |> Repo.preload(attribute_to_fetch)
-    |> Map.get(attribute_to_fetch)
-    |> Enum.any?(fn attribute ->
-      normalize_complement(attribute.complement) == normalized_complement
+    |> Repo.preload(entity_name)
+    |> Map.get(entity_name)
+    |> Enum.filter(fn entity ->
+      normalize_complement(entity.complement) == normalized_complement
     end)
   end
 

--- a/apps/re/lib/seller_leads/seller_leads.ex
+++ b/apps/re/lib/seller_leads/seller_leads.ex
@@ -98,7 +98,7 @@ defmodule Re.SellerLeads do
   def duplicated?(duplicated_entities \\ %{}) do
     duplicated_entities
     |> Map.values()
-    |> Enum.any?(fn value ->  Kernel.length(value) > 0 end)
+    |> Enum.any?(fn value -> Kernel.length(value) > 0 end)
   end
 
   def duplicated_entities(address, complement) do
@@ -117,6 +117,7 @@ defmodule Re.SellerLeads do
     |> Enum.filter(fn entity ->
       normalize_complement(entity.complement) == normalized_complement
     end)
+    |> Enum.map(fn entity -> entity.uuid end)
   end
 
   @number_group_regex ~r/(\d)*/

--- a/apps/re/test/seller_leads/seller_leads_test.exs
+++ b/apps/re/test/seller_leads/seller_leads_test.exs
@@ -138,24 +138,28 @@ defmodule Re.SellerLeadsTest do
   end
 
   describe "duplicated_entities" do
-    test "should return an empty list when the address doesn't exists for seller lead", %{address: address} do
+    test "should return an empty list when the address doesn't exists for seller lead", %{
+      address: address
+    } do
       insert(:seller_lead, address: address, complement: "Apto. 201")
 
       assert [] == SellerLeads.duplicated_entities(address, "Apartamento 401")
     end
 
-    test "should return a list with one seller lead when the address and the complement is nil matches with one seller lead in the base", %{address: address} do
+    test "should return a list with one seller lead when the address and the complement is nil matches with one seller lead in the base",
+         %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: nil)
 
-      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, nil)
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] ==
+               SellerLeads.duplicated_entities(address, nil)
     end
-
 
     test "should return a list with one listing uuid when the address and the complement is nil matches with one listing in the base",
          %{address: address} do
       listing = insert(:listing, address: address, complement: nil)
 
-      assert [%{type: Listing, uuid: listing.uuid}] == SellerLeads.duplicated_entities(address, nil)
+      assert [%{type: Listing, uuid: listing.uuid}] ==
+               SellerLeads.duplicated_entities(address, nil)
     end
 
     test "should return a list with one listing and one seller lead when the address and the complement is nil matches with one listing  and one seller in the base",
@@ -173,21 +177,24 @@ defmodule Re.SellerLeadsTest do
          %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: "100")
 
-      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] ==
+               SellerLeads.duplicated_entities(address, "100")
     end
 
     test "should return a list with one seller lead when the seller lead address has a complement with letters for seller lead",
          %{address: address} do
-      seller_lead =  insert(:seller_lead, address: address, complement: "apto 100")
+      seller_lead = insert(:seller_lead, address: address, complement: "apto 100")
 
-      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] ==
+               SellerLeads.duplicated_entities(address, "100")
     end
 
     test "should return a map with one seller lead when the passed address has a complement with letters for seller lead",
          %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: "100")
 
-      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "apto 100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] ==
+               SellerLeads.duplicated_entities(address, "apto 100")
     end
 
     test "should return a list with one seller lead when the address has a similar complement with letters and multiple groups for seller lead",
@@ -203,7 +210,8 @@ defmodule Re.SellerLeadsTest do
          %{address: address} do
       listing = insert(:listing, address: address, complement: "Bloco 3 - Apto 200")
 
-      assert [%{type: Listing, uuid: listing.uuid}] == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+      assert [%{type: Listing, uuid: listing.uuid}] ==
+               SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
     end
 
     test "should return an empty list when the passed address is the same address but a different complement as a publicated listing",

--- a/apps/re/test/seller_leads/seller_leads_test.exs
+++ b/apps/re/test/seller_leads/seller_leads_test.exs
@@ -6,6 +6,8 @@ defmodule Re.SellerLeadsTest do
   import Re.CustomAssertion
 
   alias Re.{
+    Listing,
+    SellerLead,
     SellerLeads,
     SellerLeads.JobQueue,
     SellerLeads.Site,
@@ -136,92 +138,79 @@ defmodule Re.SellerLeadsTest do
   end
 
   describe "duplicated_entities" do
-    test "should return an empty map when the address doesn't exists for seller lead", %{address: address} do
+    test "should return an empty list when the address doesn't exists for seller lead", %{address: address} do
       insert(:seller_lead, address: address, complement: "Apto. 201")
 
-      assert %{seller_leads: [], listings: []} == SellerLeads.duplicated_entities(address, "Apartamento 401")
+      assert [] == SellerLeads.duplicated_entities(address, "Apartamento 401")
     end
 
-    test "should return a map with one seller lead when the address and the complement is nil matches with one seller lead in the base", %{address: address} do
+    test "should return a list with one seller lead when the address and the complement is nil matches with one seller lead in the base", %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: nil)
 
-      assert assert %{seller_leads: [seller_lead.uuid], listings: []} == SellerLeads.duplicated_entities(address, nil)
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, nil)
     end
 
 
-    test "should return a map with one listing uuid when the address and the complement is nil matches with one listing in the base",
+    test "should return a list with one listing uuid when the address and the complement is nil matches with one listing in the base",
          %{address: address} do
       listing = insert(:listing, address: address, complement: nil)
 
-      assert assert %{seller_leads: [], listings: [listing.uuid]} == SellerLeads.duplicated_entities(address, nil)
+      assert [%{type: Listing, uuid: listing.uuid}] == SellerLeads.duplicated_entities(address, nil)
     end
 
-    test "should return a map with one listing and one seller lead when the address and the complement is nil matches with one listing  and one seller in the base",
+    test "should return a list with one listing and one seller lead when the address and the complement is nil matches with one listing  and one seller in the base",
          %{address: address} do
       listing = insert(:listing, address: address, complement: nil)
       seller_lead = insert(:seller_lead, address: address, complement: nil)
 
-      assert %{
-                seller_leads: [seller_lead.uuid],
-                listings: [listing.uuid]
-              } == SellerLeads.duplicated_entities(address, nil)
+      assert [
+               %{type: SellerLead, uuid: seller_lead.uuid},
+               %{type: Listing, uuid: listing.uuid}
+             ] == SellerLeads.duplicated_entities(address, nil)
     end
 
-    test "should return a map with one seller lead uuid when the address has the exactly same complement for seller lead",
+    test "should return a list with one seller lead uuid when the address has the exactly same complement for seller lead",
          %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: "100")
 
-      assert %{
-               seller_leads: [seller_lead.uuid],
-               listings: []
-             } == SellerLeads.duplicated_entities(address, "100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "100")
     end
 
-    test "should return a map with one seller lead when the seller lead address has a complement with letters for seller lead",
+    test "should return a list with one seller lead when the seller lead address has a complement with letters for seller lead",
          %{address: address} do
       seller_lead =  insert(:seller_lead, address: address, complement: "apto 100")
 
-      assert %{
-               seller_leads: [seller_lead.uuid],
-               listings: []
-             } == SellerLeads.duplicated_entities(address, "100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "100")
     end
 
     test "should return a map with one seller lead when the passed address has a complement with letters for seller lead",
          %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: "100")
 
-      assert %{
-               seller_leads: [seller_lead.uuid],
-               listings: []
-             } == SellerLeads.duplicated_entities(address, "apto 100")
+      assert [%{type: SellerLead, uuid: seller_lead.uuid}] == SellerLeads.duplicated_entities(address, "apto 100")
     end
 
-    test "should return a map with one seller lead when the address has a similar complement with letters and multiple groups for seller lead",
+    test "should return a list with one seller lead when the address has a similar complement with letters and multiple groups for seller lead",
          %{address: address} do
       seller_lead = insert(:seller_lead, address: address, complement: "Bloco 3 - Apto 200")
 
-      assert %{
-               seller_leads: [seller_lead.uuid],
-               listings: []
-             } == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+      assert [
+               %{type: SellerLead, uuid: seller_lead.uuid}
+             ] == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
     end
 
-    test "should return a map with one listing when the passed address has a similar complement for a publicated listing",
+    test "should return a list with one listing when the passed address has a similar complement for a publicated listing",
          %{address: address} do
       listing = insert(:listing, address: address, complement: "Bloco 3 - Apto 200")
 
-      assert %{
-               seller_leads: [],
-               listings: [listing.uuid]
-             } == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+      assert [%{type: Listing, uuid: listing.uuid}] == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
     end
 
-    test "should return an empty map when the passed address is the same address but a different complement as a publicated listing",
+    test "should return an empty list when the passed address is the same address but a different complement as a publicated listing",
          %{address: address} do
       insert(:listing, address: address, complement: "Bloco 3 - Apto 320")
 
-      assert assert %{seller_leads: [], listings: []} == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+      assert [] == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
     end
   end
 end

--- a/apps/re/test/seller_leads/seller_leads_test.exs
+++ b/apps/re/test/seller_leads/seller_leads_test.exs
@@ -12,6 +12,12 @@ defmodule Re.SellerLeadsTest do
     OwnerContacts
   }
 
+  setup do
+    address = address = insert(:address)
+
+    {:ok, address: address}
+  end
+
   describe "create_site" do
     test "should create a seller lead and notify by email" do
       user = insert(:user)
@@ -126,6 +132,96 @@ defmodule Re.SellerLeadsTest do
       insert(:listing, address: address, complement: "Bloco 3 - Apto 320")
 
       refute SellerLeads.duplicated?(address, "Apto. 200 - Bloco 3")
+    end
+  end
+
+  describe "duplicated_entities" do
+    test "should return an empty map when the address doesn't exists for seller lead", %{address: address} do
+      insert(:seller_lead, address: address, complement: "Apto. 201")
+
+      assert %{seller_leads: [], listings: []} == SellerLeads.duplicated_entities(address, "Apartamento 401")
+    end
+
+    test "should return a map with one seller lead when the address and the complement is nil matches with one seller lead in the base", %{address: address} do
+      seller_lead = insert(:seller_lead, address: address, complement: nil)
+
+      assert assert %{seller_leads: [seller_lead.uuid], listings: []} == SellerLeads.duplicated_entities(address, nil)
+    end
+
+
+    test "should return a map with one listing uuid when the address and the complement is nil matches with one listing in the base",
+         %{address: address} do
+      listing = insert(:listing, address: address, complement: nil)
+
+      assert assert %{seller_leads: [], listings: [listing.uuid]} == SellerLeads.duplicated_entities(address, nil)
+    end
+
+    test "should return a map with one listing and one seller lead when the address and the complement is nil matches with one listing  and one seller in the base",
+         %{address: address} do
+      listing = insert(:listing, address: address, complement: nil)
+      seller_lead = insert(:seller_lead, address: address, complement: nil)
+
+      assert %{
+                seller_leads: [seller_lead.uuid],
+                listings: [listing.uuid]
+              } == SellerLeads.duplicated_entities(address, nil)
+    end
+
+    test "should return a map with one seller lead uuid when the address has the exactly same complement for seller lead",
+         %{address: address} do
+      seller_lead = insert(:seller_lead, address: address, complement: "100")
+
+      assert %{
+               seller_leads: [seller_lead.uuid],
+               listings: []
+             } == SellerLeads.duplicated_entities(address, "100")
+    end
+
+    test "should return a map with one seller lead when the seller lead address has a complement with letters for seller lead",
+         %{address: address} do
+      seller_lead =  insert(:seller_lead, address: address, complement: "apto 100")
+
+      assert %{
+               seller_leads: [seller_lead.uuid],
+               listings: []
+             } == SellerLeads.duplicated_entities(address, "100")
+    end
+
+    test "should return a map with one seller lead when the passed address has a complement with letters for seller lead",
+         %{address: address} do
+      seller_lead = insert(:seller_lead, address: address, complement: "100")
+
+      assert %{
+               seller_leads: [seller_lead.uuid],
+               listings: []
+             } == SellerLeads.duplicated_entities(address, "apto 100")
+    end
+
+    test "should return a map with one seller lead when the address has a similar complement with letters and multiple groups for seller lead",
+         %{address: address} do
+      seller_lead = insert(:seller_lead, address: address, complement: "Bloco 3 - Apto 200")
+
+      assert %{
+               seller_leads: [seller_lead.uuid],
+               listings: []
+             } == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+    end
+
+    test "should return a map with one listing when the passed address has a similar complement for a publicated listing",
+         %{address: address} do
+      listing = insert(:listing, address: address, complement: "Bloco 3 - Apto 200")
+
+      assert %{
+               seller_leads: [],
+               listings: [listing.uuid]
+             } == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
+    end
+
+    test "should return an empty map when the passed address is the same address but a different complement as a publicated listing",
+         %{address: address} do
+      insert(:listing, address: address, complement: "Bloco 3 - Apto 320")
+
+      assert assert %{seller_leads: [], listings: []} == SellerLeads.duplicated_entities(address, "Apto. 200 - Bloco 3")
     end
   end
 end


### PR DESCRIPTION
This PR allow us to know what entities are duplicated for an seller lead address and complement. This data will be used during the integration with salesforce to make easier to track if the lead is really a duplicated one 