### PR TITLE
fix(orulo): parse to expected type

### DIFF
--- a/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
+++ b/apps/re_integrations/lib/orulo/payload_processor/buildings.ex
@@ -56,7 +56,7 @@ defmodule ReIntegrations.Orulo.PayloadProcessor.Buildings do
   defp enqueue_typology_job(multi, building) do
     JobQueue.enqueue(multi, :fetch_typologies, %{
       "type" => "fetch_typologies",
-      "building_id" => building.external_id
+      "building_id" => building.external_id |> Integer.to_string()
     })
   end
 end


### PR DESCRIPTION
This is the problem cause import failures, I refactor the used module to use string instead of an integer but didn't change the provider. 

The PR #734 allow run failed jobs again. 