### PR TITLE
Shortlist/create shortlist structure

### DIFF
--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -74,6 +74,11 @@ defmodule Re.Listing do
       join_keys: [listing_uuid: :uuid, tag_uuid: :uuid],
       on_replace: :delete
 
+    many_to_many :listings, Re.Shortlist,
+      join_through: "listings_shortlists",
+      join_keys: [shortlist_uuid: :uuid, listing_uuid: :uuid],
+      on_replace: :delete
+
     timestamps()
   end
 

--- a/apps/re/lib/shortlists/shortlist.ex
+++ b/apps/re/lib/shortlists/shortlist.ex
@@ -1,0 +1,30 @@
+defmodule Re.Shortlist do
+  @moduledoc """
+  Model for shortlists entity
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:uuid, :binary_id, autogenerate: false}
+
+  schema "shortlists" do
+    field :opportunity_id, :string
+
+    many_to_many :listings, Re.Listing,
+      join_through: "listings_shortlists",
+      join_keys: [shortlist_uuid: :uuid, listing_uuid: :uuid],
+      on_replace: :delete
+
+    timestamps()
+  end
+
+  @required ~w(opportunity_id)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required)
+    |> validate_required(@required)
+    |> Re.ChangesetHelper.generate_uuid()
+  end
+end

--- a/apps/re/lib/shortlists/shortlists.ex
+++ b/apps/re/lib/shortlists/shortlists.ex
@@ -23,28 +23,28 @@ defmodule Re.Shortlists do
   def get_or_create(opportunity_id) do
     case Repo.get_by(Shortlist, opportunity_id: opportunity_id) do
       nil ->
-        with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
-             {:ok, params} <- create_params(opportunity),
-             {:ok, listing_uuids} <- get_shortlist(params) do
-          listings = get_active_listings_by_uuid(listing_uuids)
-
-          %Shortlist{}
-          |> Shortlist.changeset(%{opportunity_id: opportunity_id})
-          |> Ecto.Changeset.put_assoc(:listings, listings)
-          |> Repo.insert()
-        else
-          _error -> {:error, :invalid_opportunity}
-        end
+        create_shortlist(opportunity_id)
 
       shortlist ->
         {:ok, shortlist}
     end
   end
 
+  defp create_shortlist(opportunity_id) do
+    with {:ok, listing_uuids} <- get_listing_uuids_from_opportunity_preferences(opportunity_id) do
+      listings = get_active_listings_by_uuid(listing_uuids)
+
+      %Shortlist{}
+      |> Shortlist.changeset(%{opportunity_id: opportunity_id})
+      |> Ecto.Changeset.put_assoc(:listings, listings)
+      |> Repo.insert()
+    else
+      _error -> {:error, :invalid_opportunity}
+    end
+  end
+
   def generate_shortlist_from_salesforce_opportunity(opportunity_id) do
-    with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
-         {:ok, params} <- create_params(opportunity),
-         {:ok, listing_uuids} <- get_shortlist(params) do
+    with {:ok, listing_uuids} <- get_listing_uuids_from_opportunity_preferences(opportunity_id) do
       get_active_listings_by_uuid(listing_uuids)
     else
       _error -> {:error, :invalid_opportunity}
@@ -57,6 +57,13 @@ defmodule Re.Shortlists do
     |> case do
       {:ok, params} -> {:ok, Map.put(%{}, :characteristcs, params)}
       error -> error
+    end
+  end
+
+  defp get_listing_uuids_from_opportunity_preferences(opportunity_id) do
+    with {:ok, opportunity} <- Salesforce.get_opportunity(opportunity_id),
+         {:ok, params} <- create_params(opportunity) do
+      get_shortlist(params)
     end
   end
 

--- a/apps/re/priv/repo/migrations/20190820170942_create_shortlists.exs
+++ b/apps/re/priv/repo/migrations/20190820170942_create_shortlists.exs
@@ -1,0 +1,20 @@
+defmodule Re.Repo.Migrations.CreateShortlists do
+  use Ecto.Migration
+
+  def change do
+    create table(:shortlists, primary_key: false) do
+      add :uuid, :uuid, primary_key: true
+      add :opportunity_id, :string, null: false
+
+      timestamps()
+    end
+
+    create table(:listings_shortlists, primary_key: false) do
+      add :listing_uuid, references(:listings, column: :uuid, type: :uuid), primary_key: true
+
+      add :shortlist_uuid,
+          references(:shortlists, column: :uuid, type: :uuid, on_delete: :delete_all),
+          primary_key: true
+    end
+  end
+end

--- a/apps/re/priv/repo/migrations/20190820170942_create_shortlists.exs
+++ b/apps/re/priv/repo/migrations/20190820170942_create_shortlists.exs
@@ -16,5 +16,7 @@ defmodule Re.Repo.Migrations.CreateShortlists do
           references(:shortlists, column: :uuid, type: :uuid, on_delete: :delete_all),
           primary_key: true
     end
+
+    create index(:listings_shortlists, [:listing_uuid, :shortlist_uuid])
   end
 end

--- a/apps/re/test/shortlists/shortlist_test.exs
+++ b/apps/re/test/shortlists/shortlist_test.exs
@@ -3,20 +3,22 @@ defmodule Re.ShortlistTest do
 
   alias Re.Shortlist
 
-  test "changeset with valid attributes" do
-    attrs = %{opportunity_id: "0x01"}
+  describe "changeset/2" do
+    test "changeset with valid attributes" do
+      attrs = %{opportunity_id: "0x01"}
 
-    changeset = Shortlist.changeset(%Shortlist{}, attrs)
+      changeset = Shortlist.changeset(%Shortlist{}, attrs)
 
-    assert changeset.valid?
-  end
+      assert changeset.valid?
+    end
 
-  test "changeset with invalid attributes" do
-    changeset = Shortlist.changeset(%Shortlist{}, %{})
+    test "changeset with invalid attributes" do
+      changeset = Shortlist.changeset(%Shortlist{}, %{})
 
-    refute changeset.valid?
+      refute changeset.valid?
 
-    assert Keyword.get(changeset.errors, :opportunity_id) ==
-             {"can't be blank", [validation: :required]}
+      assert Keyword.get(changeset.errors, :opportunity_id) ==
+               {"can't be blank", [validation: :required]}
+    end
   end
 end

--- a/apps/re/test/shortlists/shortlist_test.exs
+++ b/apps/re/test/shortlists/shortlist_test.exs
@@ -1,0 +1,22 @@
+defmodule Re.ShortlistTest do
+  use Re.ModelCase
+
+  alias Re.Shortlist
+
+  test "changeset with valid attributes" do
+    attrs = %{opportunity_id: "0x01"}
+
+    changeset = Shortlist.changeset(%Shortlist{}, attrs)
+
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Shortlist.changeset(%Shortlist{}, %{})
+
+    refute changeset.valid?
+
+    assert Keyword.get(changeset.errors, :opportunity_id) ==
+             {"can't be blank", [validation: :required]}
+  end
+end

--- a/apps/re/test/support/factory.ex
+++ b/apps/re/test/support/factory.ex
@@ -381,6 +381,13 @@ defmodule Re.Factory do
     }
   end
 
+  def shortlist_factory do
+    %Re.Shortlist{
+      uuid: UUID.uuid4(),
+      opportunity_id: "0x01"
+    }
+  end
+
   defp random_postcode do
     first =
       10_000..99_999


### PR DESCRIPTION
This feature creates a proper structure to shortlists. A shortlists can have multiple listings, we have no trigger to create a new one, so the creation is made by `get_or_create`. If it doesn't exist the `get_or_create` will get listings from shortlist service and create a new shortlist from it, if it does exists will send the old one (as the name says). 

Is a good idea take a look on the base (`shortlist/service-client`) branch before digging into this one. After I create a `GraphQL` query for use this feature, I'll remove `generate_shortlist_from_salesforce_opportunity` feature, once this only sends data API results to the client instead of persist them. 

I'll implement GraphQL call in another PR.