### PR TITLE
Export CEP to zap

### DIFF
--- a/apps/re/lib/exporters/zap.ex
+++ b/apps/re/lib/exporters/zap.ex
@@ -7,9 +7,10 @@ defmodule Re.Exporters.Zap do
   @highlight 2
   @super_highlight 3
 
-  @exported_attributes ~w(id type subtype category address state city neighborhood street_number complement
-                          price maintenance_fee util_area area_unit rooms bathrooms suites garage_spots
-                          property_tax description images highlight tags)a
+  @exported_attributes ~w(id type subtype category address state city neighborhood street_number
+                          complement postal_code price maintenance_fee util_area area_unit rooms
+                          bathrooms suites garage_spots property_tax description images highlight
+                          tags)a
 
   @default_options %{attributes: @exported_attributes, highlight_ids: [], super_highlight_ids: []}
 
@@ -82,6 +83,10 @@ defmodule Re.Exporters.Zap do
 
   defp convert_attribute(:complement, listing, _, acc) do
     [{"Complemento", %{}, listing.complement} | acc]
+  end
+
+  defp convert_attribute(:postal_code, listing, _, acc) do
+    [{"CEP", %{}, String.replace(listing.address.postal_code, "-", "")} | acc]
   end
 
   defp convert_attribute(:price, listing, _, acc) do

--- a/apps/re/test/exporters/zap_test.exs
+++ b/apps/re/test/exporters/zap_test.exs
@@ -61,6 +61,7 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
+          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -130,6 +131,7 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
+          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -189,6 +191,7 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
+          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -257,6 +260,7 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
+          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>
@@ -330,6 +334,7 @@ defmodule Re.Exporters.ZapTest do
           "<Bairro>Copacabana</Bairro>" <>
           "<Numero>55</Numero>" <>
           "<Complemento>basement</Complemento>" <>
+          "<CEP>11111111</CEP>" <>
           "<PrecoVenda>1000000</PrecoVenda>" <>
           "<PrecoCondominio>1000</PrecoCondominio>" <>
           "<AreaUtil>50</AreaUtil>" <>


### PR DESCRIPTION
~For some reason, zap wasn't complaining that we weren't exporting the postal code, although it's required in the docs.~ Actually, it's not required.

OLX is asking for CEP and they use them same format as zap's.