### PR TITLE
fix(units): using listings price range on units

### DIFF
--- a/apps/re/lib/developments/units/unit.ex
+++ b/apps/re/lib/developments/units/unit.ex
@@ -6,6 +6,7 @@ defmodule Re.Unit do
   use Ecto.Schema
 
   import Ecto.Changeset
+  alias Re.Listing
 
   @primary_key {:uuid, :binary_id, autogenerate: false}
 
@@ -54,8 +55,8 @@ defmodule Re.Unit do
     |> validate_attributes()
     |> validate_number(
       :price,
-      greater_than_or_equal_to: 250_000,
-      less_than_or_equal_to: 100_000_000
+      greater_than_or_equal_to: Listing.price_lower_limit(),
+      less_than_or_equal_to: Listing.price_upper_limit()
     )
     |> validate_inclusion(:garage_type, @garage_types)
     |> validate_inclusion(:status, @statuses)

--- a/apps/re/lib/listings/schemas/listing.ex
+++ b/apps/re/lib/listings/schemas/listing.ex
@@ -102,6 +102,9 @@ defmodule Re.Listing do
   @price_lower_limit 200_000
   @price_upper_limit 100_000_000
 
+  def price_lower_limit, do: @price_lower_limit
+  def price_upper_limit, do: @price_upper_limit
+
   def changeset(struct, params) do
     struct
     |> cast(params, @attributes)

--- a/apps/re/test/units/unit_test.exs
+++ b/apps/re/test/units/unit_test.exs
@@ -76,7 +76,7 @@ defmodule Re.UnitTest do
 
       assert Keyword.get(changeset.errors, :price) ==
                {"must be greater than or equal to %{number}",
-                [validation: :number, kind: :greater_than_or_equal_to, number: 250_000]}
+                [validation: :number, kind: :greater_than_or_equal_to, number: 200_000]}
 
       assert Keyword.get(changeset.errors, :property_tax) ==
                {"must be greater than or equal to %{number}",


### PR DESCRIPTION
Using the same values to validate both listings and units. 