### PR TITLE
Salesforce/schedule visits daily

### DIFF
--- a/apps/re_integrations/lib/application.ex
+++ b/apps/re_integrations/lib/application.ex
@@ -33,6 +33,7 @@ defmodule ReIntegrations.Application do
       worker(Search.Server, []),
       {Orulo.JobQueue, repo: Repo},
       {Salesforce.JobQueue, repo: Repo, reservation_timeout: 60_000, execution_timeout: 30_000},
-      Search.Cluster
+      Search.Cluster,
+      Salesforce.Scheduler
     ]
 end

--- a/apps/re_integrations/lib/salesforce/scheduler.ex
+++ b/apps/re_integrations/lib/salesforce/scheduler.ex
@@ -7,7 +7,7 @@ defmodule ReIntegrations.Salesforce.Scheduler do
 
   @timezone Application.get_env(:re_integrations, :timezone, "Etc/UTC")
 
-  def schedule_daily_visits(), do: @timezone |> Timex.now() |> schedule_daily_visits()
+  def schedule_daily_visits, do: @timezone |> Timex.now() |> schedule_daily_visits()
 
   def schedule_daily_visits(%DateTime{} = today) do
     today

--- a/apps/re_integrations/lib/salesforce/scheduler.ex
+++ b/apps/re_integrations/lib/salesforce/scheduler.ex
@@ -7,24 +7,17 @@ defmodule ReIntegrations.Salesforce.Scheduler do
 
   @timezone Application.get_env(:re_integrations, :timezone, "Etc/UTC")
 
-  def schedule_daily_visits(nil), do: @timezone |> Timex.now() |> schedule_daily_visits()
+  def schedule_daily_visits(), do: @timezone |> Timex.now() |> schedule_daily_visits()
 
   def schedule_daily_visits(%DateTime{} = today) do
     today
     |> Timex.weekday()
-    |> case do
-      7 ->
-        []
-
-      6 ->
-        []
-
-      5 ->
-        [Timex.shift(today, days: 1), Timex.shift(today, days: 3)]
-
-      _ ->
-        [Timex.shift(today, days: 1)]
-    end
-    |> Enum.map(&Salesforce.schedule_visits(date: &1))
+    |> dates_to_schedule_on_weekday()
+    |> Enum.map(&Salesforce.schedule_visits(date: Timex.shift(today, &1)))
   end
+
+  defp dates_to_schedule_on_weekday(7), do: []
+  defp dates_to_schedule_on_weekday(6), do: []
+  defp dates_to_schedule_on_weekday(5), do: [[days: 1], [days: 3]]
+  defp dates_to_schedule_on_weekday(_), do: [[days: 1]]
 end

--- a/apps/re_integrations/lib/salesforce/scheduler.ex
+++ b/apps/re_integrations/lib/salesforce/scheduler.ex
@@ -1,5 +1,30 @@
 defmodule ReIntegrations.Salesforce.Scheduler do
   @moduledoc false
+  alias ReIntegrations.Salesforce
+
   use Quantum.Scheduler,
     otp_app: :re_integrations
+
+  @timezone Application.get_env(:re_integrations, :timezone, "Etc/UTC")
+
+  def schedule_daily_visits(nil), do: @timezone |> Timex.now() |> schedule_daily_visits()
+
+  def schedule_daily_visits(%DateTime{} = today) do
+    today
+    |> Timex.weekday()
+    |> case do
+      7 ->
+        []
+
+      6 ->
+        []
+
+      5 ->
+        [Timex.shift(today, days: 1), Timex.shift(today, days: 3)]
+
+      _ ->
+        [Timex.shift(today, days: 1)]
+    end
+    |> Enum.map(&Salesforce.schedule_visits(date: &1))
+  end
 end

--- a/apps/re_integrations/test/salesforce/scheduler_test.exs
+++ b/apps/re_integrations/test/salesforce/scheduler_test.exs
@@ -1,0 +1,78 @@
+defmodule ReIntegrations.Salesforce.SchedulerTest do
+  use ReIntegrations.ModelCase
+  use Mockery
+
+  import Re.CustomAssertion
+  import Re.Factory
+
+  alias ReIntegrations.Salesforce
+
+  @thursday ~N[2019-08-29 00:00:00] |> Timex.to_datetime()
+  @friday ~N[2019-08-30 00:00:00] |> Timex.to_datetime()
+  @saturday ~N[2019-08-31 00:00:00] |> Timex.to_datetime()
+  @sunday ~N[2019-09-01 00:00:00] |> Timex.to_datetime()
+
+  @response {:ok,
+             %{
+               status_code: 200,
+               body: """
+               {
+                 "records": [
+                   {
+                     "Id": "0x01",
+                     "AccountId": "0x01",
+                     "OwnerId": "0x01",
+                     "Cidade__c": "São Paulo",
+                     "Dados_do_Imovel_para_Venda__c": "address 123",
+                     "Periodo_Disponibilidade_Tour__c": "Manhã"
+                   },
+                   {
+                     "Id": "0x02",
+                     "AccountId": "0x01",
+                     "OwnerId": "0x01",
+                     "Cidade__c": "São Paulo",
+                     "Dados_do_Imovel_para_Venda__c": "address 123",
+                     "Data_Fixa_para_o_Tour__c": "2019-08-26",
+                     "Horario_Fixo_para_o_Tour__c": "20:25:00",
+                     "Periodo_Disponibilidade_Tour__c": "Fixo"
+                   }
+                 ]
+               }
+               """
+             }}
+
+  setup do
+    address = insert(:address)
+    insert(:calendar, address: address)
+
+    mock(HTTPoison, [post: 3], fn
+      %URI{path: "/api/v1/query"}, _, _ -> @response
+      %URI{path: "/v1/vrp-long"}, _, _ -> {:ok, %{body: ~s({"job_id": "100"})}}
+    end)
+
+    :ok
+  end
+
+  describe "schedule_daily_visits/1" do
+    test "creates a new job to monitor routific request" do
+      Salesforce.Scheduler.schedule_daily_visits(@thursday)
+
+      assert_enqueued_job(Repo.all(Salesforce.JobQueue), "monitor_routific_job")
+    end
+
+    test "creates two jobs to monitor routific requests on fridays" do
+      Salesforce.Scheduler.schedule_daily_visits(@friday)
+      assert_enqueued_job(Repo.all(Salesforce.JobQueue), "monitor_routific_job", 2)
+    end
+
+    test "doesn't run on saturdays and sundays" do
+      assert [] ==
+               Salesforce.Scheduler.schedule_daily_visits(@saturday)
+
+      assert [] ==
+               Salesforce.Scheduler.schedule_daily_visits(@sunday)
+
+      assert_enqueued_job(Repo.all(Salesforce.JobQueue), "monitor_routific_job", 0)
+    end
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -90,7 +90,7 @@ config :re, Re.AlikeTeller.Scheduler,
 config :re_integrations, ReIntegrations.Salesforce.Scheduler,
   debug_logging: false,
   jobs: [
-    {"@daily", fn -> Re.Salesforce.schedule_visits(date: Timex.now() |> Timex.shift(days: 1)) end}
+    {"1 0 * * *", {ReIntegrations.Salesforce.Scheduler, :schedule_daily_visits, []}}
   ]
 
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -89,6 +89,7 @@ config :re, Re.AlikeTeller.Scheduler,
 
 config :re_integrations, ReIntegrations.Salesforce.Scheduler,
   debug_logging: false,
+  timezone: System.get_env("TIMEZONE") || "Etc/UTC",
   jobs: [
     {"1 0 * * *", {ReIntegrations.Salesforce.Scheduler, :schedule_daily_visits, []}}
   ]


### PR DESCRIPTION
Enable quantum job to schedule tours daily in accordance to the following rules:

* `monday - thursday` - schedules visits for the next day
* `friday` - schedules visits for saturday and monday
* `saturday & sunday` - doesn't run